### PR TITLE
misc fixes for the OSS repo

### DIFF
--- a/.github/copyright.tmpl
+++ b/.github/copyright.tmpl
@@ -1,0 +1,4 @@
+Copyright (c) ${years}, Crash Override, Inc.
+
+This file is part of ${projectname}
+(see ${projecturl})

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,3 @@
-#% INTERNAL
-
-The below license is the license for the open source repository, ONLY.
-Copyright to all source code in this repo is held by Crash Override,
-Inc. (2022-2023), unless otherwise noted at the top of the source
-file, and all rights are reserved.  The code in this repo include
-things not in the open source repo, and for such code, it is only
-available under a commercial license, and is not copyleft.
-
-Chalk itself does not link against any external GPL'd code; we retain
-the copyright for the code that is here, and along with it, the right
-to dual license it.
-
-It is our policy as company not to link to GPLd code in the software
-we write in all cases where we do not own the copyright!
-
-#% END
 GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -636,3 +619,4 @@ Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
 
                      END OF TERMS AND CONDITIONS
+

--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,4 @@ tests_parallel: tests
 .PHONY: sqlite
 sqlite: server/sqlite
 
-include .github/Makefile.dist
+include $(wildcard .github/Makefile.*)

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -76,6 +76,9 @@ task debug, "Get a debug build":
   # additional flags are configured in config.nims
   exec "nimble build --define:debug"
 
+task release, "Package the release build":
+  exec "nimble build"
+
 let completion_script_version = version
 
 task mark_completion, "Replace the chalk mark in a completion script, including the articact version":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,15 @@
+networks:
+  chalk:
+  imds:
+    ipam:
+      driver: default
+      config:
+        - subnet: 169.254.169.254/24
+
 services:
+  # --------------------------------------------------------------------------
+  # CHALK
+
   chalk:
     build:
       context: .
@@ -7,3 +18,146 @@ services:
     working_dir: /chalk
     volumes:
       - .:/chalk/
+      - ../nimutils:/nimutils
+      - ../con4m:/con4m
+    # environment:
+    # CON4M_DEV is conditionally set in Makefile
+      
+
+  # --------------------------------------------------------------------------
+  # SERVER
+
+  server: &server
+    build:
+      context: ./server
+      target: deps
+    networks:
+      chalk:
+        aliases:
+          - chalk.local
+    ports:
+      - 8585:8585
+    working_dir: /chalk/server
+    volumes:
+      - .:/chalk
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - sh -c "curl -f http://localhost:8585/health"
+      start_period: 30s
+      interval: 1s
+
+  server-tls:
+    <<: *server
+    command: run -r -p 5858 --domain=tls.chalk.local --keyfile=cert.key --certfile=cert.pem --use-existing-cert
+    ports:
+      - 5858:5858
+    networks:
+      chalk:
+        aliases:
+          - tls.chalk.local
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - sh -c "curl -f https://localhost:5858/health --insecure"
+      start_period: 30s
+      interval: 1s
+
+
+  # --------------------------------------------------------------------------
+  # TESTS
+
+  # there is no official imds test container so we have very simple wrapper
+  imds:
+    build:
+      context: ./tests
+    entrypoint: uvicorn
+    command: app:app --host=0.0.0.0 --port=80 --reload
+    working_dir: /imds
+    volumes:
+      - ./tests/imds:/imds
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - sh -c "curl -f http://localhost/health"
+      start_period: 10s
+      interval: 1s
+    networks:
+      imds:
+        ipv4_address: 169.254.169.254
+
+  # simple server for serving static files
+  static:
+    build:
+      context: ./tests
+    entrypoint: python
+    command: -m http.server 8000
+    working_dir: /chalk/tests
+    volumes:
+      - .:/chalk
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - sh -c "curl -f http://localhost:8000/conftest.py"
+      start_period: 10s
+      interval: 1s
+    networks:
+      chalk:
+
+  tests:
+    build:
+      context: ./tests
+    volumes:
+      - .:/chalk
+      - /var/run/docker.sock:/var/run/docker.sock
+    working_dir: /chalk/tests
+    networks:
+      - chalk
+      - imds
+    depends_on:
+      registry:
+        condition: service_healthy
+      server:
+        condition: service_healthy
+      server-tls:
+        condition: service_healthy
+      imds:
+        condition: service_healthy
+      static:
+        condition: service_healthy
+    environment:
+      GITHUB_ACTIONS: ${GITHUB_ACTIONS:-}
+
+  # --------------------------------------------------------------------------
+  # MISC DEPS
+
+  registry:
+    image: registry:2
+    ports:
+      - "5044:5044"
+    environment:
+      - REGISTRY_HTTP_ADDR=0.0.0.0:5044
+    networks:
+      - chalk
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - sh -c "echo 'GET / HTTP/1.1' | nc -v localhost 5044"
+      start_period: 30s
+      interval: 1s
+
+  sqlite:
+    image: coleifer/sqlite-web
+    volumes:
+      - ./server:/server
+    environment:
+      SQLITE_DATABASE: /server/chalkdb.sqlite
+    ports:
+      - 18080:8080
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - sh -c "echo 'GET / HTTP/1.1' | nc -v localhost 8080"
+      start_period: 30s
+      interval: 1s
+

--- a/src/configs/README.md
+++ b/src/configs/README.md
@@ -1,14 +1,14 @@
 This directory contains con4m code that Chalk uses for various purposes:
 
-| File | Purpose |
-| ---- | ------- |
-| chalk.c42spec | This is a specification for what makes a valid chalk file. It is used to validate other files in this directory, and user configuration files, when provided. It contains definitions for the sections and fields allowed, and does extensive input validation. |
-| baseconfig.c4m | This is where the default chalk metadata keys are set up, along with other defaults. |
-| getopts.c4m | This specifies what is allowed at the command line, validates inputs and provides documentation for all the options.  It's loaded together with baseconfig.c4m (as if #include'd in C). |
-| ioconfig.c4m | Sets up defaults for output and reporting. Run after the previous two, so that it can be influenced by command-line arguments. |
-| signconfig.c4m | Sets up running external signing tools (currently only GPG). Whether this runs unless --no-load-sign-tools is passed at the command line.  It too is run together with ioconfig.c4m. |
-| sbomconfig.c4m | Sets up external sbom collection tools, if --load-sbom-tools is passed.  Also run with ioconfig.c4m |
-| sastconfig.c4m | Sets up external static analysis collection tools, if --load-sast-tools is passed, in which case it runs with ioconfig.c4m |
-| defaultconfig.c4m | This is a 'default' user config file that runs, if no other user configuration file is embedded in the binary.  It runs after the above, but before any on-filesystem config, if provided. |
-| dockercmd.c4m | This config file is used in parsing the *docker* command line, or our container chalking and wrapping. It accepts a superset of valid docker command lines.|
-| entrypoint.c4m | This isn't a valid con4m file; it's a template for a valid con4m file.  When wrapping docker entrypoints, this will be used to generate the configuration file we inject into the chalk binary to properly handle entry point execution. |
+| File              | Purpose                                                                                                                                                                                                                                                         |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| chalk.c42spec     | This is a specification for what makes a valid chalk file. It is used to validate other files in this directory, and user configuration files, when provided. It contains definitions for the sections and fields allowed, and does extensive input validation. |
+| baseconfig.c4m    | This is where the default chalk metadata keys are set up, along with other defaults.                                                                                                                                                                            |
+| getopts.c4m       | This specifies what is allowed at the command line, validates inputs and provides documentation for all the options. It's loaded together with baseconfig.c4m (as if #include'd in C).                                                                          |
+| ioconfig.c4m      | Sets up defaults for output and reporting. Run after the previous two, so that it can be influenced by command-line arguments.                                                                                                                                  |
+| signconfig.c4m    | Sets up running external signing tools (currently only GPG). Whether this runs unless --no-load-sign-tools is passed at the command line. It too is run together with ioconfig.c4m.                                                                             |
+| sbomconfig.c4m    | Sets up external sbom collection tools, if --load-sbom-tools is passed. Also run with ioconfig.c4m                                                                                                                                                              |
+| sastconfig.c4m    | Sets up external static analysis collection tools, if --load-sast-tools is passed, in which case it runs with ioconfig.c4m                                                                                                                                      |
+| defaultconfig.c4m | This is a 'default' user config file that runs, if no other user configuration file is embedded in the binary. It runs after the above, but before any on-filesystem config, if provided.                                                                       |
+| dockercmd.c4m     | This config file is used in parsing the _docker_ command line, or our container chalking and wrapping. It accepts a superset of valid docker command lines.                                                                                                     |
+| entrypoint.c4m    | This isn't a valid con4m file; it's a template for a valid con4m file. When wrapping docker entrypoints, this will be used to generate the configuration file we inject into the chalk binary to properly handle entry point execution.                         |

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -9,6 +9,7 @@ dump + load tested in test_config.py
 docker commands are not tested here but as part of the docker codec tests in test_docker.py
 exec commands are tested in test_exec.py as they are more involved
 """
+import glob
 from pathlib import Path
 
 import pytest
@@ -153,14 +154,13 @@ def test_insert_extract_delete(copy_files: list[Path], chalk: Chalk):
 
 def test_version(chalk: Chalk):
     result = chalk.run(command="version", no_color=True)
-    printed_version = result.find("Chalk version").strip("┋ ")
+    printed_version = result.find("Chalk version", words=2).split()[-1]
 
+    nimble = Path(glob.glob(f"{Path(__file__).parent.parent / '*.nimble'}")[0])
     # version output should match the version in chalk_internal.nimble
     internal_version = next(
         i.split("=")[1].strip().strip('"')
-        for i in (Path(__file__).parent.parent / "chalk_internal.nimble")
-        .read_text()
-        .splitlines()
+        for i in nimble.read_text().splitlines()
         if i.startswith("version")
     )
 


### PR DESCRIPTION
after the initial OSS release, a few nuances were missed which this pr fixes:

* removes hard dependency on `.github/Makefile.dist` in `Makefile`
* removes internal license from `LICENSE`
* adds `nimble release` task to `chalk.nimble`
* adds necessary docker-compose services to run tests
* fixes version check test to support `chalk.nimble`
* sync in md files
* adds the copyright check pre-commit template file so pre-commit works