### PR TITLE
adding github actions for lint/tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.body, format('skip:{0}', github.workflow))
+
+    concurrency:
+      # only allow one job per PR running
+      # older pending jobs will be cancelled not to waste CI minutes
+      # cannot use github.job here https://github.com/community/community/discussions/13496
+      group: ${{ github.workflow }}-pre-commit-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,89 @@
+name: tests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - src/**
+      - tests/**
+      - config.nims
+      - "*.nimble"
+      # ignore docs not to waste CI minutes
+      - "!src/docs/**"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    if: |
+      github.event_name != 'pull_request' || (
+        !github.event.pull_request.draft &&
+        !contains(github.event.pull_request.body, format('skip:{0}', github.workflow))
+      )
+
+    concurrency:
+      # only allow one job per PR running
+      # older pending jobs will be cancelled not to waste CI minutes
+      # cannot use github.job here https://github.com/community/community/discussions/13496
+      group: ${{ github.workflow }}-pytest-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Bake Images
+        run: |
+          docker buildx bake chalk server tests --load
+
+      - name: Compile Chalk
+        if: inputs.chalk_url == ''
+        run: |
+          make
+
+      - name: Download Chalk
+        if: inputs.chalk_url != ''
+        run: |
+          curl -L "${{ inputs.chalk_url }}" > chalk
+          chmod +x chalk
+          ./chalk version
+
+      - name: Run tests (Fast)
+        # run fast tests by default on PRs when
+        # "tests:--slow" is missing in PR description
+        if: |
+          github.event_name == 'pull_request' && (
+            !contains(github.event.pull_request.body, 'tests:--slow')
+          )
+        run: |
+          make tests_parallel
+
+      - name: Run tests (Slow)
+        # run slow tests on non-PR builds and when
+        # PR description has "tests:--slow"
+        if: |
+          github.event_name != 'pull_request' || (
+            contains(github.event.pull_request.body, 'tests:--slow')
+          )
+        run: |
+          make tests_parallel args="--slow"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened
@@ -24,9 +27,17 @@ jobs:
     runs-on: ubuntu-latest
 
     if: |
-      github.event_name != 'pull_request' || (
+      (
+        github.event_name == 'pull_request' &&
         !github.event.pull_request.draft &&
         !contains(github.event.pull_request.body, format('skip:{0}', github.workflow))
+      ) || (
+        github.event_name == 'push' &&
+        endsWith(github.repository, 'chalk')
+      ) || (
+        github.event_name == 'workflow_dispatch'
+      ) || (
+        github.event_name == 'schedule'
       )
 
     concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ server/app/server-static
 nimble.develop
 nimble.paths
 /chalk-docs
+oss

--- a/LICENSE
+++ b/LICENSE
@@ -619,4 +619,3 @@ Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
 
                      END OF TERMS AND CONDITIONS
-

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ clean:
 
 .PHONY: chalk-docs
 chalk-docs: $(BINARY)
-	./$(BINARY) docgen
+	rm -rf $@
+	$(DOCKER) ./$(BINARY) docgen
 
 # ----------------------------------------------------------------------------
 # TOOL MAKEFILES

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,11 @@
+target "chalk" {
+  cache-from = ["type=registry,ref=ghcr.io/crashappsec/chalk_compile:cache"]
+}
+
+target "server" {
+  cache-from = ["type=registry,ref=ghcr.io/crashappsec/chalk_local_api_server:cache"]
+}
+
+target "tests" {
+  cache-from = ["type=registry,ref=ghcr.io/crashappsec/chalk_tests:cache"]
+}


### PR DESCRIPTION
this adds automatic github actions for running linting/test checks on open PRs.

linting checks are validated by https://pre-commit.com/

other tests are using https://github.com/pytest-dev/pytest

---

tests only run when there are any source code changes (e.g. changes to `.nim` files). to test PR tests I temporarily enabled running them even without any source code changes (as this PR doesnt change any source files). that test run can be seen on:

https://github.com/crashappsec/chalk/actions/runs/6342089679/job/17227124600?pr=8

tests pass 🎉 