### PR TITLE
Minimize use of tmpfiles when storing Dockerfiles

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m == 0.1.5"
+requires "https://github.com/crashappsec/con4m#0040a5c15f7f98ef96046e8b998041760c849bcb"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -270,6 +270,7 @@ type
     dfCommands*:        seq[InfoBase]
     dfSections*:        seq[DockerFileSection]
     dfSectionAliases*:  OrderedTable[string, DockerFileSection]
+    dfPassOnStdin*:     bool
     addedInstructions*: seq[string]
 
   ValidateResult* = enum

--- a/src/collect.nim
+++ b/src/collect.nim
@@ -409,6 +409,8 @@ iterator artifacts*(argv: seq[string], notTmp=true): ChalkObj =
         yield item
         clearErrorObject()
 
+proc dockerFailsafe(info: DockerInvocation) {.importc.}
+
 proc getPushChalkObj*(info: DockerInvocation): ChalkObj =
     let chalkOpt = scanOne(getPluginByName("docker"), info.prefTag)
 

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2251,6 +2251,38 @@ Set the default path to search for artifacts, unless overriden by command-line a
 """
   }
 
+  field default_tmp_dir {
+    type:    string
+    require: false
+    shortdoc: "Specify a default place for /tmp files if needed"
+    doc: """
+
+Generally, systems use `/tmp` for temporary files, and most modern API
+interfaces to using `/tmp` take mitigation against file-based race
+condtions, for instance, by leveraging per-app directories and
+randomness in selecting file names.
+
+However, there are times when the system default isn't a good option
+for Chalk when it needs temporary space. Specifically, we've learned
+that, for those running Docker via Snap on Ubuntu systems, Snap's
+isolation of temporary files means that users will get an error if we
+try to use /tmp to, for instance, write out a temporary docker file
+that we want to use with a container.
+
+Specifying a directory outside of `/tmp` addresses that problem, which
+can easily be done with the quite standard `TMPDIR` environment
+variable.
+
+However, Chalk philosophically doesn't want to leave opportunity for
+people to "forget" to do things when deploying us. So this field
+allows you to pick a place for temporary files to use IF no value for
+`TMPDIR` is provided.
+
+If neither is provided, you may very well end up with `/tmp` or
+`/var/tmp`, which should be great in most cases.
+"""    
+  }
+
   field always_try_to_sign {
     type:     bool
     default:  true

--- a/src/docker_cmdline.nim
+++ b/src/docker_cmdline.nim
@@ -90,7 +90,10 @@ proc getDockerFileLoc*(state: DockerInvocation): string =
   if state.inDockerFile != "":
     return state.dockerFileLoc
   else:
-    state.dockerFileLoc = resolvePath(state.foundContext).joinPath("Dockerfile")
+    if state.foundContext == "-":
+      state.dockerFileLoc = resolvePath(".").joinPath("Dockerfile")
+    else:
+      state.dockerFileLoc = resolvePath(state.foundContext).joinPath("Dockerfile")
     return state.dockerFileLoc
 
 proc extractDockerFileFlag(state: DockerInvocation) =

--- a/src/plugins/codecDocker.nim
+++ b/src/plugins/codecDocker.nim
@@ -4,8 +4,8 @@
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
 ##
-import osproc, ../config, ../docker_base, ../chalkjson, ../util,
-       ../attestation, ../plugin_api
+import osproc, ../config, ../docker_base, ../chalkjson, ../attestation,
+       ../plugin_api
 
 const
   markFile     = "chalk.json"
@@ -35,7 +35,9 @@ proc extractImageMark(chalk: ChalkObj): ChalkDict =
   try:
     setCurrentDir(dir)
 
-    if runDocker(@["save", imageId, "-o", "image.tar"]) != 0:
+    let procInfo = runDockerGetEverything(@["save", imageId, "-o", "image.tar"])
+
+    if procInfo.getExit() != 0:
       error("Image " & imageId & ": error extracting chalk mark")
       extractFinish()
     if execCmd("tar -xf image.tar manifest.json") != 0:


### PR DESCRIPTION
Generally, systems use /tmp for temporary files, and most modern API interfaces to using /tmp take mitigation against file-based race conditions, for instance, by leveraging per-app directories and randomness in selecting file names.

However, there are times when the system default isn't a good option for Chalk when it needs temporary space. Specifically, we've learned that, for those running Docker via Snap on Ubuntu systems, Snap's isolation of temporary files means that users will get an error if we try to use /tmp to, for instance, write out a temporary docker file that we want to use with a container.

To mitigate that problem, the primary use of tmp directories in the docker path is for writing out a temporary docker file whenever additions are requested. With this PR, when we need to extend the docker file, we pass it over stdin if it's at all possible.

The only case where that's NOT possible is if the docker invocation is already using stdin to pass a context. That doesn't seem to be common, but in those cases, we still use a temporary file.

However, it's possible to address the problem externally to chalk by setting the TMPDIR environment variable; the underlying tmp file interface respects it, and it's a standard variable.

However, Chalk philosophically doesn't want to leave opportunity for people to "forget" to do things when deploying us. So we also added the `default_tmp_dir` field for the configuration, which allows you to pick a place for temporary files to use IF no value for TMPDIR is provided.

We assume if the user provides one, since it's so standard, they know what they're doing. For that reason, we didn't add a command-line flag; there's already a paradigm for this.

If a user does not use this variable and `TMPDIR` is not set, they will probably end up with `/tmp` or `/var/tmp`, which should be great in most cases now that dockerfiles aren't generally going to a tmp file.