### PR TITLE
adding tests badge to the repository README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - src/**
+      - tests/**
+      - config.nims
+      - "*.nimble"
+      # ignore docs not to waste CI minutes
+      - "!src/docs/**"
   pull_request:
     types:
       - opened

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Chalk Logo](https://crashoverride.com/images/logos/chalk-logo.png)
 
+[![tests](https://github.com/crashappsec/chalk/actions/workflows/tests.yml/badge.svg?branch=main&event=push)](https://github.com/crashappsec/chalk/actions/workflows/tests.yml?query=branch%3Amain)
+
 # Total visibility of your software engineering lifecycle.
 
 ## About Chalk


### PR DESCRIPTION
This change adds a badge (svg image) to the repo README which shows the status of the tests CI pipeline.
Hopefully it will show just that tests are passing all the time :wink:
The badge also links to the github action page which shows the history of the tests running on main branch. Speaking of the main branch, the badge only shows
tests status for the main branch so that if any tests fail on any PRs, they will not impact the badge status.

Finally this change only runs tests on merges to main only when any of the source code changes so that we dont run tests for things like documentation changes.