### PR TITLE
[enhancement] Make --help behavior more intuitive

### DIFF
--- a/src/chalk.nim
+++ b/src/chalk.nim
@@ -21,7 +21,7 @@ when isMainModule:
     warn("No working codec is available for the native executable type")
 
   if passedHelpFlag:
-    runChalkHelp("help") # no return; in cmd_help.nim
+    runChalkHelp(getCommandName()) # no return; in cmd_help.nim
 
   setupDefaultLogConfigs() # src/sinks.nim
   checkSetupStatus()       # attestation.nim

--- a/src/commands/cmd_help.nim
+++ b/src/commands/cmd_help.nim
@@ -462,8 +462,16 @@ proc runChalkHelp*(cmdName = "help") {.noreturn.} =
     con4mRuntime = getChalkRuntime()
 
   if cmdName != "help":
-    toOut = con4mRuntime.getCommandDocs(cmdName)
-  elif len(args) == 0:
+    # In this branch, the --help flag got passed, and we will check to
+    # see if the command was explicitly passed, or if it was implicit.
+    # If it was implicit, give the help overview instead of the command
+    # overview.
+    let defaultCmd = chalkConfig.getDefaultCommand().getOrElse("")
+    if defaultCmd != "" and defaultCmd notin commandLineParams():
+      toOut = con4mRuntime.getHelpOverview()
+    else:
+      toOut = con4mRuntime.getCommandDocs(cmdName)
+  elif len(args) == 0 or "--help" in args:
     toOut = con4mRuntime.getHelpOverview()
   elif args[0] in ["metadata", "keys", "key"]:
       toOut = con4mRuntime.keyHelp(args)

--- a/src/commands/cmd_help.nim
+++ b/src/commands/cmd_help.nim
@@ -455,6 +455,17 @@ proc getOutputHelp(state: ConfigState, kind = CDocConsole): string =
 
   result &= state.getSinkHelp(kind)
 
+proc hasHelpFlag(args: seq[string]): bool =
+  for item in args:
+    if not item.startswith("-"):
+      continue
+    var s = item[1 .. ^1]
+    while s.startswith("-"):
+      s = s[1 .. ^1]
+
+    if s in ["help", "h"]:
+      return true
+
 proc runChalkHelp*(cmdName = "help") {.noreturn.} =
   var
     args         = getArgs()
@@ -471,7 +482,7 @@ proc runChalkHelp*(cmdName = "help") {.noreturn.} =
       toOut = con4mRuntime.getHelpOverview()
     else:
       toOut = con4mRuntime.getCommandDocs(cmdName)
-  elif len(args) == 0 or "--help" in args:
+  elif len(args) == 0 or args.hasHelpFlag():
     toOut = con4mRuntime.getHelpOverview()
   elif args[0] in ["metadata", "keys", "key"]:
       toOut = con4mRuntime.keyHelp(args)


### PR DESCRIPTION
I am now special casing when the --help flag is passed, so that it never gets passed as a search argument to the 'help' command; it always triggers command help.

I also tweaked the behavior of how the flag works in the presence of a default command-- it now gives the global help if the command was NOT explicitly provided, instead of the help for the implicit command-- this seems like much more expected behavior for novices.

Closes #11 