### PR TITLE
[fix] Version number in con4m should match the Nimble version.

### DIFF
--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -51,7 +51,7 @@
 ##     the more basic per-op stuff such as "_CHALKS" and "ACTION_ID" I did not.
 
 ## CHALK SCHEMA
-chalk_version :=   "0.1.1"
+chalk_version :=   "0.1.2"
 ascii_magic   :=   "dadfedabbadabbed"
 
 # Field starting with an underscore (_) are "system" metadata fields, that


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [X] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ X] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ X] Filled out the template to a useful degree

## Issue

Closes #28 

## Description

Bumps the version number to the current version in the con4m sources... manually. @miki725 I think the most expedient thing to do to prevent regressions as we release is to add a pre-commit test to make sure the two are the same.


## Testing

The CHALK_VERSION field should be equal to INJECTOR_VERSION in any output.