### PR TITLE
test(gdb): adding gdb tests for elf encoding (on behalf of Liming)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-*config-tool*
 .dockerignore
 .github
 Dockerfile*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .TODO
-.config-tool-bin/
-config-tool-outdir
 /bin/chalk
 /chalk
 /src/getlibpath

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ chalk-docs: $(BINARY)
 # ----------------------------------------------------------------------------
 # TOOL MAKEFILES
 
-TOOLS=config-tool server
+TOOLS=server
 
 .PHONY: $(TOOLS)
 $(TOOLS):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - ../con4m:/con4m
     # environment:
     # CON4M_DEV is conditionally set in Makefile
-      
 
   # --------------------------------------------------------------------------
   # SERVER
@@ -62,7 +61,6 @@ services:
         - sh -c "curl -f https://localhost:5858/health --insecure"
       start_period: 30s
       interval: 1s
-
 
   # --------------------------------------------------------------------------
   # TESTS
@@ -107,6 +105,12 @@ services:
   tests:
     build:
       context: ./tests
+      args:
+        BASE: ${BASE:-ubuntu}
+    cap_add:
+      - SYS_PTRACE # for gdb
+    security_opt:
+      - seccomp=unconfined # for gdb
     volumes:
       - .:/chalk
       - /var/run/docker.sock:/var/run/docker.sock
@@ -160,4 +164,3 @@ services:
         - sh -c "echo 'GET / HTTP/1.1' | nc -v localhost 8080"
       start_period: 30s
       interval: 1s
-

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,19 +1,42 @@
-FROM gcr.io/projectsigstore/cosign as cosign
+# this needs to be before any FROM clauses
+ARG BASE=ubuntu
+ARG PYTHON_VERSION=3.11.3
 
-FROM python:3.11.3-alpine3.17
+# ----------------------------------------------------------------------------
 
-ARG POETRY_VERSION=1.5.1
+FROM python:$PYTHON_VERSION-alpine3.17 as alpine
 
 # install chalk runtime deps
 RUN apk add --no-cache curl git
 
-# M1-only deps to compile wheels on ARM
 RUN if uname -m | grep -Ei "arm|aarch"; then \
     apk add --no-cache \
         gcc \
         libffi-dev \
         musl-dev \
     ; fi
+
+# ----------------------------------------------------------------------------
+
+FROM python:$PYTHON_VERSION-slim as ubuntu
+
+RUN apt-get update -y && \
+    apt-get install -y \
+        curl \
+        git \
+        gdb \
+        && \
+    apt-get clean -y
+
+# ----------------------------------------------------------------------------
+
+FROM gcr.io/projectsigstore/cosign as cosign
+
+# ----------------------------------------------------------------------------
+
+FROM $BASE
+
+ARG POETRY_VERSION=1.5.1
 
 COPY --from=cosign /ko-app/cosign /usr/local/bin/cosign
 

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -10,6 +10,7 @@ import os
 
 ROOT = Path(__file__).parent
 DATA = ROOT / "data"
+GDB = ROOT / "gdb"
 
 CODEOWNERS = DATA / "codeowners"
 CONFIGS = DATA / "configs"
@@ -47,3 +48,4 @@ DATE_PATH = shutil.which("date")
 LS_PATH = shutil.which("ls")
 UNAME_PATH = shutil.which("uname")
 SLEEP_PATH = shutil.which("sleep")
+GDB_PATH = shutil.which("gdb")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from filelock import FileLock
 
 from .chalk.runner import Chalk
 from .conf import (
+    GDB_PATH,
     SERVER_CERT,
     SERVER_DB,
     SERVER_HTTP,
@@ -63,6 +64,12 @@ def be_exclusive(request, worker_id):
         else:
             with lock(f"worker-{worker_id}.lck"):
                 yield
+
+
+@pytest.fixture(autouse=True)
+def requires_gdb(request):
+    if request.node.get_closest_marker("requires_gdb") and not GDB_PATH:
+        pytest.skip(f"gdb is not installed. skipping test")
 
 
 @pytest.fixture()

--- a/tests/gdb/__init__.py
+++ b/tests/gdb/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2023, Crash Override, Inc.
+#
+# This file is part of Chalk
+# (see https://crashoverride.com/docs/chalk)

--- a/tests/gdb/callback.py
+++ b/tests/gdb/callback.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2023, Crash Override, Inc.
+#
+# This file is part of Chalk
+# (see https://crashoverride.com/docs/chalk)
+import json
+import struct
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+class MMap(NamedTuple):
+    start: int
+    end: int
+    mode: str
+    offset: int
+    ids: str
+    inode: int
+    name: str
+
+
+class BasicCallbackBreakpoint(gdb.Breakpoint):
+    def __init__(self, location: str, callback):
+        self.callback = callback
+        print(f"setting breakpoint @ {location}")
+        super().__init__(location)
+
+    def stop(self):
+        return self.callback()
+
+
+def get_bin_name() -> Path:
+    """
+    Get executable name from gdb
+    """
+    return Path(gdb.current_progspace().filename)
+
+
+def get_program():
+    return gdb.inferiors()[-1]
+
+
+def get_pid() -> int:
+    """
+    Get pid of the running process
+    """
+    return get_program().pid
+
+
+def get_entrypoint() -> int:
+    """
+    Get entrypoint offset from /proc
+    """
+    with open(f"/proc/{get_pid()}/exe", "rb") as fid:
+        data = fid.read(32)
+        value = struct.unpack("<Q", data[0x18:])
+        return value[0]
+
+
+def get_maps() -> list[MMap]:
+    maps = []
+    with open(f"/proc/{get_pid()}/maps", "rb") as fid:
+        for line in fid.read().decode().splitlines():
+            try:
+                address_range, mode, offset, ids, inode, name = line.split()
+            except ValueError:
+                continue
+            else:
+                start, end = address_range.split("-")
+                maps.append(
+                    MMap(
+                        int(start, 16),
+                        int(end, 16),
+                        mode,
+                        int(offset, 16),
+                        ids,
+                        int(inode),
+                        name,
+                    )
+                )
+    return maps
+
+
+def read_memory(address: int, length: int) -> bytes:
+    """
+    Read given length of bytes at address of memory
+    """
+    return bytes(get_program().read_memory(address, length))
+
+
+def get_register(name: str) -> int:
+    """
+    Get value of register by its name
+    """
+    frame = gdb.selected_frame()
+    value = int(frame.read_register(name))
+    if value < 0:
+        return value & 0xFFFFFFFFFFFFFFFF
+    return value
+
+
+# callback on _start that sets a second callback
+def start_callback():
+    """
+    callback for _start
+
+    then then sets breakpoint for entrypoint during which we can inspect
+    the state of the program memory
+    """
+    print("callback on _start initiated")
+
+    bin_path = get_bin_name()
+    entrypoint_offset = get_entrypoint()
+    mapping = next(i for i in get_maps() if i.name == str(bin_path) and "x" in i.mode)
+    start = mapping.start
+    offset = mapping.offset
+    entrypoint = start + entrypoint_offset - offset
+
+    print(f"binary = {bin_path}")
+    print(f"entrypoint_offset = {hex(entrypoint_offset)}")
+    print(f"start = {hex(start)}")
+    print(f"offset = {hex(offset)}")
+    print(f"entrypoint = {hex(entrypoint)}")
+
+    try:
+        # set NEW breakpoint with new callback
+        BasicCallbackBreakpoint(f"*{hex(entrypoint)}", entry_callback)
+    except Exception as e:
+        print(e)
+
+    return True
+
+
+# callback on actual entrypoint that grabs memory and writes it to tmp file for checking
+def entry_callback():
+    print("callback on entrypoint initiated")
+
+    pc = get_register("pc")
+    memory = read_memory(pc, 0x20)
+
+    print(f"pc = {pc:02x}")
+    print(
+        json.dumps(
+            {
+                "pc_memory": memory.hex(),
+            },
+            indent=2,
+        )
+    )
+
+
+def setbp():
+    # set breakpoint at _start to ensure callback is called
+    BasicCallbackBreakpoint("_start", start_callback)

--- a/tests/gdb/commands.gdb
+++ b/tests/gdb/commands.gdb
@@ -1,0 +1,8 @@
+set pagination off
+set disassembly-flavor intel
+starti
+source ./callback.py
+python setbp()
+run
+continue
+quit

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
-addopts = -v --doctest-modules --ignore=data --strict-markers
+addopts = -v --doctest-modules --ignore=gdb --ignore=data --strict-markers
 markers =
     slow: marks tests as slow
     exclusive
     docker_cleanup
+    requires_gdb

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,11 +94,6 @@ def test_invalid_load(chalk_copy: Chalk, test_config_file: str, use_embedded: bo
     "test_config_file, expected_error",
     [
         ("validation/valid_1.conf", VALIDATION_ERROR),
-        # TODO: re-enable these once config-tool is updated
-        # ("config-tool/CI_CD_Docker.c4m", ""),
-        # ("config-tool/CI_CD_Standalone.c4m", ""),
-        # ("config-tool/default-USING-API.c4m", ""),
-        # ("config-tool/default.c4m", ""),
     ],
 )
 @pytest.mark.parametrize(
@@ -155,11 +150,6 @@ def test_load_url(
     [
         ("validation/valid_1.conf", True, VALIDATION_ERROR),
         ("validation/invalid_1.conf", False, ""),
-        # TODO: re-enable these once config-tool is updated
-        # ("config-tool/CI_CD_Docker.c4m", True, ""),
-        # ("config-tool/CI_CD_Standalone.c4m", True, ""),
-        # ("config-tool/default-USING-API.c4m", True, ""),
-        # ("config-tool/default.c4m", True, ""),
     ],
 )
 def test_external_configs(

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from .chalk.runner import Chalk, ChalkReport
+from .chalk.runner import Chalk
 from .conf import CONFIGS, SLEEP_PATH, UNAME_PATH
 from .utils.bin import sha256
 from .utils.log import get_logger

--- a/tests/utils/dict.py
+++ b/tests/utils/dict.py
@@ -2,11 +2,59 @@
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
+import operator
 import re
-from typing import Any
+from typing import Any, Callable
+
+
+ANY = object()
+MISSING = object()
+
+
+class Length:
+    pretty = {
+        "eq": "==",
+        "gt": ">",
+        "ge": ">=",
+        "lt": "<",
+        "le": "<=",
+    }
+
+    def __init__(self, size: int, op: Callable[[Any, Any], bool] = operator.eq):
+        self.size = size
+        self.op = op
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.pretty.get(self.op.__name__, '')}{self.size})"
+
+    def __eq__(self, other: Any):
+        return self.op(len(other), self.size)
+
+
+class Contains:
+    def __init__(self, items: set[Any]):
+        self.items = items
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.items!r})"
+
+    def __eq__(self, other: Any):
+        return all(i in other for i in self.items)
+
+
+class IfExists:
+    def __init__(self, value: Any):
+        self.value = value
 
 
 class ContainsMixin(dict):
+    def has(self, **kwargs: Any):
+        """
+        >>> ContainsMixin({"foo": "bar"}).has(foo="bar")
+        True
+        """
+        return self.contains(kwargs)
+
     def contains(self, other: dict[Any, Any]):
         """
         >>> ContainsMixin({"foo": "bar"}).contains({"foo": "bar"})
@@ -34,18 +82,69 @@ class ContainsMixin(dict):
         Traceback (most recent call last):
         ...
         AssertionError: {'foo': [2, 1]} != {'foo': {1, 2, 3}}
+
+        >>> ContainsMixin({"foo": "bar"}).contains({"foo": ANY})
+        True
+        >>> ContainsMixin({"foo": "bar"}).contains({"bar": MISSING})
+        True
+
+        >>> ContainsMixin({"foo": ["bar"]}).contains({"foo": Length(1)})
+        True
+        >>> ContainsMixin({"foo": ["bar"]}).contains({"foo": Length(1, operator.gt)})
+        Traceback (most recent call last):
+        ...
+        AssertionError: {'foo': ['bar']} != {'foo': Length(>1)}
+
+        >>> ContainsMixin({"foo": "bar"}).contains({"bar": IfExists("bar")})
+        True
+        >>> ContainsMixin({"foo": "bar"}).contains({"foo": IfExists("bar")})
+        True
+        >>> ContainsMixin({"foo": "bar"}).contains({"foo": IfExists("baz")})
+        Traceback (most recent call last):
+        ...
+        AssertionError: {'foo': 'bar'} != {'foo': 'baz'}
+
+        >>> ContainsMixin({"foo": ["bar", "baz"]}).contains({"foo": Contains({"bar"})})
+        True
+        >>> ContainsMixin({"foo": ["bar", "baz"]}).contains({"foo": Contains({"foobar"})})
+        Traceback (most recent call last):
+        ...
+        AssertionError: {'foo': ['bar', 'baz']} != {'foo': Contains({'foobar'})}
         """
         for key, expected in sorted(other.items()):
-            assert key in self, f"self[{key!r}] is missing"
+            value = self.get(key)
+            if expected is MISSING:
+                assert key not in self, f"{{{key!r}: {value!r}}} should be missing"
+                continue
+            elif isinstance(expected, IfExists):
+                if key not in self:
+                    continue
+                expected = expected.value
+
+            assert key in self, f"[{key!r}] is missing"
             value = self[key]
             message = f"{{{key!r}: {value!r}}} != {{{key!r}: {expected!r}}}"
-            if isinstance(expected, dict):
+            if expected is ANY:
+                pass  # dont assert anything about the value
+            elif isinstance(expected, dict):
                 assert isinstance(value, dict), message
                 assert self.__class__(value).contains(expected)
             elif isinstance(expected, set):
                 assert set(value) == expected, message
             elif isinstance(expected, re.Pattern):
                 assert expected.search(value), message
+            elif isinstance(expected, (Length, Contains)):
+                assert expected == value, message
             else:
                 assert value == expected, message
+        return True
+
+    def contains_if(self, condition: bool, other: dict[Any, Any]):
+        if condition:
+            return self.contains(other)
+        return True
+
+    def has_if(self, condition: bool, **kwargs: Any):
+        if condition:
+            return self.has(**kwargs)
         return True


### PR DESCRIPTION
@indecisivedragon  did most of the work for the gdb stuff so she deserves the credit! (Im just syncing between repos here for the most part)

gdb tests check some basic things about elf encoding by:

* running binary before chalking it and reporting:
  * couple of dozen bytes after the program entrypoint as seen in the gdb breakpoint
* chalking the binary
* running same gdb script on the chalked binary and comparing the report before chalk and after. If all goes well, there should not be any difference in the instructions of the entrypoint comparing chalked and non-chalked binary.

In the future we can add more checks here as whatever json gdb script outputs to stdout test will automatically compare.

Speaking of json, some of the bits for looking for valid json in the os.py/runner.py needed to be changed so that the json extraction logic can work for both chalk reports as well as other commands like gdb in this case.

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Description

ELF encoding was not directly tested before so it could of been producing non-runnable binaries without tests picking that up. With gdb tests, it ensures encoded ELF binary is runnable after being chalked.
