### PR TITLE
test(lint): adding pre-commit hook for checking chalk version across files

### DIFF
--- a/.github/check_version.sh
+++ b/.github/check_version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eEu
+set -o pipefail
+
+FILEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$FILEDIR" 1> /dev/null 2>&1
+
+# cd to root of the repo
+cd ..
+
+KEYSPEC=src/configs/base_keyspecs.c4m
+current_version=$(make version)
+keyspec_version=$(
+    grep -E "chalk_version\s:=" $KEYSPEC \
+        | cut -d'"' -f2
+)
+
+if [ "$current_version" != "$keyspec_version" ]; then
+    echo $KEYSPEC chalk_version does not match nimble chalk version
+    echo "$keyspec_version != $current_version"
+    exit 1
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,16 @@ repos:
             data/.*
           )$
 
+  - repo: local
+    hooks:
+      - id: chalkversion
+        name: chalkversion
+        description: verify chalk version matches across all chalk files
+        entry: ./.github/check_version.sh
+        language: system
+        always_run: true
+        pass_filenames: false
+
   - repo: https://github.com/tcort/markdown-link-check
     rev: v3.11.2
     hooks:


### PR DESCRIPTION
this will check chalk version matches across various files. currently we only check:

* nimble file
* base_keyspecs.c4m

If the chalk version is updated in nimble file, all other files need to match it.

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

Adds automatic check for ensuring all version numbers match

## Description

Follow up to https://github.com/crashappsec/chalk/pull/29

## Testing

```
pre-commit run --all-files
```
