### PR TITLE
fix(docker): prepending docker_exe to PATH

### DIFF
--- a/src/docker_base.nim
+++ b/src/docker_base.nim
@@ -36,7 +36,9 @@ proc setDockerExeLocation*() =
       exeOpt   = chalkConfig.getDockerExe()
 
     if exeOpt.isSome():
-      userPath.add(exeOpt.get())
+      # prepend on purpose so that docker_exe config
+      # takes precedence over rest of dirs in PATH
+      userPath = @[exeOpt.get()] & userPath
 
     dockerPathOpt     = findExePath("docker", userPath, ignoreChalkExes = true)
     dockerExeLocation = dockerPathOpt.get("")


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

Currently `docker_exe` was being appended to PATH which meant that given `docker_exe` configuration didnt take any precedence in case there are multiple `docker` instances on `PATH` (which seems to be case, at least in Ubuntu).

By prepending provided path, if exists, takes precedence over other dirs in PATH.
