### PR TITLE
fix(heartbeat): fixing flaky heartbeat test due to invalid probe build tag

### DIFF
--- a/src/commands/cmd_docker.nim
+++ b/src/commands/cmd_docker.nim
@@ -202,26 +202,12 @@ proc getDefaultPlatformInfo(ctx: DockerInvocation): string =
     return ctx.foundPlatform
 
   let
-    probeFile    = """
+    probeFile      = """
 FROM alpine
 ARG TARGETPLATFORM
 RUN echo "CHALK_TARGET_PLATFORM=$TARGETPLATFORM"
 """
-    randomBinary = secureRand[array[16, char]]()
-  var
-    binStr       = newStringOfCap(16)
-
-  for ch in randomBinary:
-    binStr.add(ch)
-
-  # Base64 gives a mix of upper and lower, but docker only accepts
-  # lower in tags. So we lose some entropy, which is why we use a
-  # pretty long tag to make sure we're way above an accidental
-  # collision boundary.
-
-  let
-    preTag         = binStr.encode(safe=true).replace("-", ".").replace("=","")
-    tmpTag         = "chalk_" & preTag.toLowerAscii() & "_probe"
+    tmpTag         = chooseNewTag()
     buildKitKey    = "DOCKER_BUILDKIT"
     buildKitKeySet = existsEnv(buildKitKey)
   var buildKitValue: string

--- a/src/commands/cmd_docker.nim
+++ b/src/commands/cmd_docker.nim
@@ -221,7 +221,7 @@ RUN echo "CHALK_TARGET_PLATFORM=$TARGETPLATFORM"
 
   let
     preTag         = binStr.encode(safe=true).replace("-", ".").replace("=","")
-    tmpTag         = preTag.toLowerAscii()
+    tmpTag         = "chalk_" & preTag.toLowerAscii() & "_probe"
     buildKitKey    = "DOCKER_BUILDKIT"
     buildKitKeySet = existsEnv(buildKitKey)
   var buildKitValue: string
@@ -233,6 +233,8 @@ RUN echo "CHALK_TARGET_PLATFORM=$TARGETPLATFORM"
                                           "-", "."], probeFile)
     stdErr = allOut.getStderr()
     parts  = stdErr.split("CHALK_TARGET_PLATFORM=")
+
+  trace("Probing for current docker build platform:\n" & stdErr)
 
   if buildKitKeySet:
     # key was set before us, so restore whatever the value was

--- a/src/docs/core-release-notes.md
+++ b/src/docs/core-release-notes.md
@@ -14,6 +14,8 @@
 - Segfault when running chalk operation (e.g. `insert`) in empty
   git repo without any commits.
   [39](https://github.com/crashappsec/chalk/pull/39)
+- Sometimes Docker build would not wrap entrypoint.
+  [45](https://github.com/crashappsec/chalk/pull/45)
 
 ## Known Issues
 
@@ -61,7 +63,7 @@ At release time, here are known issues:
 - Chalk does not yet handle Docker HEREDOCs (which we've found aren't
   yet getting heavy use).
 
-- Chalk currently will refuse to automaticlly wrap or sign
+- Chalk currently will refuse to automatically wrap or sign
   multi-architecture builds. It still will produce the desired
   container with a chalk mark, however.
 
@@ -84,7 +86,7 @@ At release time, here are known issues:
 
 ### Other
 
-- The bash autocomplete script installson a Mac, but because it's not
+- The bash autocomplete script installation a Mac, but because it's not
   a zsh script, it will not autocomplete file arguments, etc.
 
 - The signing functionality does download the `cosign` binary if not
@@ -144,10 +146,10 @@ At release time, here are known issues:
 
 We are actively developing Chalk, and listening closely to the people
 already using it. Below are a number of key items in our backlog that
-we're considering. However, we have made no descisions on the order
+we're considering. However, we have made no decisions on the order
 we'll work on these things, and may add or drop items from the
 list. For a more up-to-date view, please check our issues list in
-Github.
+GitHub.
 
 All of the below are targets for our Open Source; we also will soon be
 releasing services around Chalk (with a free tier).

--- a/tests/chalk/runner.py
+++ b/tests/chalk/runner.py
@@ -352,6 +352,7 @@ class Chalk:
         push: bool = False,
         config: Optional[Path] = None,
         buildkit: bool = True,
+        log_level: ChalkLogLevel = "none",
     ) -> tuple[str, ChalkProgram]:
         cwd = cwd or Path(os.getcwd())
         context = context or getattr(dockerfile, "parent", cwd)
@@ -372,7 +373,7 @@ class Chalk:
             self.run(
                 # TODO remove log level but there are error bugs due to --debug
                 # which fail the command validation
-                log_level="none",
+                log_level=log_level,
                 debug=True,
                 virtual=virtual,
                 config=config,

--- a/tests/data/configs/docker_heartbeat.conf
+++ b/tests/data/configs/docker_heartbeat.conf
@@ -1,3 +1,4 @@
+log_level: "trace"
 unsubscribe("report", "json_console_out")
 custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false

--- a/tests/data/dockerfiles/valid/sleep/Dockerfile
+++ b/tests/data/dockerfiles/valid/sleep/Dockerfile
@@ -1,2 +1,3 @@
 FROM ubuntu
-ENTRYPOINT ["/usr/bin/sleep", "5"]
+COPY sleep.sh /sleep.sh
+ENTRYPOINT ["/bin/sh", "/sleep.sh"]

--- a/tests/data/dockerfiles/valid/sleep/sleep.sh
+++ b/tests/data/dockerfiles/valid/sleep/sleep.sh
@@ -1,0 +1,3 @@
+echo before sleep
+sleep 5
+echo after sleep

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -284,6 +284,7 @@ def test_docker_heartbeat(chalk_copy: Chalk, random_hex: str):
     chalk_copy.docker_build(
         dockerfile=DOCKERFILES / "valid" / "sleep" / "Dockerfile",
         tag=tag,
+        log_level="trace",
     )
 
     _, result = Docker.run(

--- a/tests/utils/docker.py
+++ b/tests/utils/docker.py
@@ -83,9 +83,14 @@ class Docker:
                     "writing image",
                     text=build.logs,
                     words=1,  # there is "done" after hash
+                    reverse=True,
                 ).split(":")[1]
             except ValueError:
-                image_id = build.find("Successfully built", words=1)
+                image_id = build.find(
+                    "Successfully built",
+                    words=1,
+                    reverse=True,
+                )
                 # legacy builder returns short id so we figure out longer id
                 image_id = run(
                     ["docker", "inspect", image_id, "--format", "{{ .ID }}"],

--- a/tests/utils/os.py
+++ b/tests/utils/os.py
@@ -103,8 +103,17 @@ class Program:
             self.exit_code, self.cmd, output=self.stdout, stderr=self.stderr
         )
 
-    def find(self, needle: str, text: Optional[str] = None, words: int = 0) -> str:
-        for line in (text or self.text).splitlines():
+    def find(
+        self,
+        needle: str,
+        text: Optional[str] = None,
+        words: int = 0,
+        reverse: bool = False,
+    ) -> str:
+        lines = (text or self.text).splitlines()
+        if reverse:
+            lines = lines[::-1]
+        for line in lines:
             if needle in line:
                 i = line.find(needle)
                 result = line[i:].replace(needle, "", 1).strip()
@@ -149,7 +158,7 @@ class Program:
         text = self.after(match=after, text=text)
         try:
             return json.loads(text), len(text)
-        except Exception as e:
+        except json.JSONDecodeError as e:
             # if there is extra data we grab valid json until the
             # invalid character
             e_str = str(e)


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

heartbeat test is flaky

## Description

The root cause was that probe build to get current build platform, docker tag name was random which sometimes resulted in invalid tag names:

```
ERROR: invalid tag ".mpiljfkim.ahsfgpf3f4g": invalid reference format
```

docker tag names need to start/end with alphanumeric character so to solve it adding `chalk_` and `_probe` prefix/suffix. This ensures the build tag is correct and docker can build it.

## Testing

```sh
until not 'make tests args="test_docker.py::test_docker_heartbeat --slow --pdb"'
```
