### PR TITLE
test(heartbeat): fixing reports utility matching logs

### DIFF
--- a/tests/chalk/runner.py
+++ b/tests/chalk/runner.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
+import re
 import datetime
 import json
 import os
@@ -132,15 +133,13 @@ class ChalkProgram(Program):
     @property
     def reports(self):
         # strip chalk logs from stdout so we can find just json reports
+        # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+        text = re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", self.text)
         text = "\n".join(
             [
                 i
-                for i in self.text.splitlines()
-                if not any(
-                    # color ansi is 11 or 13 chars
-                    i.startswith(j) or i[11:].startswith(j) or i[13:].startswith(j)
-                    for j in {"info:", "trace:", "error:"}
-                )
+                for i in text.splitlines()
+                if not any(i.startswith(j) for j in {"info:", "trace:", "error:"})
             ]
         )
         reports = []

--- a/tests/data/dockerfiles/valid/sleep/sleep.sh
+++ b/tests/data/dockerfiles/valid/sleep/sleep.sh
@@ -1,3 +1,4 @@
 echo before sleep
-sleep 5
+# heartbeat is every second so 2 seconds is enough to get at least one heartbeat
+sleep 2
 echo after sleep

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -274,9 +274,10 @@ def test_nonvirtual_invalid(chalk: Chalk, test_file: str, random_hex: str):
     )
 
 
-# exec heartbeat from inside docker
-@pytest.mark.slow()
 def test_docker_heartbeat(chalk_copy: Chalk, random_hex: str):
+    """
+    exec heartbeat from inside docker
+    """
     tag = f"test_image_{random_hex}"
     chalk_copy.load(CONFIGS / "docker_heartbeat.c4m", use_embedded=False)
 


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

Fixing heartbeat test which is failing on `main`

## Description

it excludes all log lines so that it can extract only json reports without any json blobs which might of been logged in regular log messages

## Testing

```sh
➜ make tests args="test_docker.py::test_docker_heartbeat --slow --logs --pdb"
```


tests:--slow