### PR TITLE
fix: minor testing fixes for composable config testing

### DIFF
--- a/tests/data/configs/composable/valid/valid_1.c4m
+++ b/tests/data/configs/composable/valid/valid_1.c4m
@@ -1,0 +1,6 @@
+# this config is included to test for bug that was causing a crash
+# fixed in pr https://github.com/crashappsec/chalk/pull/72
+use reporting_server from "https://chalkdust.io"
+use wrap_entrypoints from "https://chalkdust.io"
+use impersonate_docker from "https://chalkdust.io"
+use use_heartbeats from "https://chalkdust.io"

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -22,9 +22,7 @@ def get_current_config(tmp_data_dir: Path, chalk: Chalk) -> str:
     if output.is_file():
         os.remove(output)
     chalk.dump(output)
-    with open(output) as f:
-        lines = f.read()
-        return lines
+    return output.read_text()
 
 
 @pytest.mark.parametrize(
@@ -61,9 +59,7 @@ def test_composable_valid(
     # check chalk dump to validate that loaded config matches
     current_config_path = tmp_data_dir / "output.c4m"
     chalk_copy.dump(current_config_path)
-    current_config = ""
-    with open(current_config_path) as f:
-        current_config = f.read()
+    current_config = current_config_path.read_text()
 
     if replace:
         # replaces current config with content of incoming
@@ -116,9 +112,7 @@ def test_composable_multiple(
     # check chalk dump to validate that loaded config matches
     current_config_path = tmp_data_dir / "output.c4m"
     chalk_copy.dump(current_config_path)
-    current_config = ""
-    with open(current_config_path) as f:
-        current_config = f.read()
+    current_config = current_config_path.read_text()
 
     # expecting output config has `use xxx from yyy`
     # for each config in sample configs

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -74,7 +74,7 @@ def test_composable_valid(
         # adds incoming as component
         # expecting output config has `use xxx from yyy`
         config_name = test_config_file.stem
-        config_path = "/".join((CONFIGS / test_config_file).__str__().split("/")[:-1])
+        config_path = str((CONFIGS / test_config_file).parent)
         use_output = f'use {config_name} from "{config_path}"'
         assert use_output in current_config
 

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -67,9 +67,8 @@ def test_composable_valid(
 
     if replace:
         # replaces current config with content of incoming
-        with open(CONFIGS / test_config_file) as f:
-            original_config = f.read()
-            assert current_config == original_config
+        original_config = (CONFIGS / test_config_file).read_text()
+        assert current_config == original_config
     else:
         # adds incoming as component
         # expecting output config has `use xxx from yyy`

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -2,7 +2,6 @@
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
-import os
 import pytest
 
 from pathlib import Path
@@ -19,8 +18,7 @@ logger = get_logger()
 
 def get_current_config(tmp_data_dir: Path, chalk: Chalk) -> str:
     output = tmp_data_dir / "output.c4m"
-    if output.is_file():
-        os.remove(output)
+    output.unlink(missing_ok=True)
     chalk.dump(output)
     return output.read_text()
 
@@ -68,7 +66,7 @@ def test_composable_valid(
     else:
         # adds incoming as component
         # expecting output config has `use xxx from yyy`
-        config_name = test_config_file.stem
+        config_name = (CONFIGS / test_config_file).stem
         config_path = str((CONFIGS / test_config_file).parent)
         use_output = f'use {config_name} from "{config_path}"'
         assert use_output in current_config

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -73,7 +73,7 @@ def test_composable_valid(
     else:
         # adds incoming as component
         # expecting output config has `use xxx from yyy`
-        config_name = test_config_file.split("/")[-1].removesuffix(".c4m")
+        config_name = test_config_file.stem
         config_path = "/".join((CONFIGS / test_config_file).__str__().split("/")[:-1])
         use_output = f'use {config_name} from "{config_path}"'
         assert use_output in current_config


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

followup on https://github.com/crashappsec/chalk-internal/issues/851

## Description

This pr enables some tests that were disabled due to chalk bugs

