### PR TITLE
fix: reporting server config fix

### DIFF
--- a/configs/reporting_server.c4m
+++ b/configs/reporting_server.c4m
@@ -7,7 +7,7 @@ func validate_url(url) {
 }
 
 func get_local_url() {
-  return "https://" + external_ip() + ":7890"
+  return "http://" + external_ip() + ":8585"
 }
 
 parameter sink_config.output_to_http.uri {
@@ -19,7 +19,7 @@ reporting server.
 Run the server via:
 
 ```
-docker run --rm - -w /db -v $HOME/.local/c0/:/db -p 8585:8585  ghcr.io/crashappsec/chalk-test-server
+docker run -w /db -v $HOME/.local/c0/:/db -p 8585:8585 --restart=unless-stopped ghcr.io/crashappsec/chalk-test-server
 ```
 """
   validator: func validate_url(string) -> string
@@ -32,3 +32,5 @@ sink_config output_to_http {
 
   # The URI should get filled in automatically.
 }
+
+subscribe("report", "output_to_http")

--- a/tests/data/configs/composable/valid/compliance_docker/reporting_server.c4m
+++ b/tests/data/configs/composable/valid/compliance_docker/reporting_server.c4m
@@ -7,7 +7,7 @@ func validate_url(url) {
 }
 
 func get_local_url() {
-  return "https://" + external_ip() + ":7890"
+  return "http://" + external_ip() + ":8585"
 }
 
 parameter sink_config.output_to_http.uri {
@@ -19,7 +19,7 @@ reporting server.
 Run the server via:
 
 ```
-docker run --rm - -w /db -v $HOME/.local/c0/:/db -p 8585:8585  ghcr.io/crashappsec/chalk-test-server
+docker run -w /db -v $HOME/.local/c0/:/db -p 8585:8585 --restart=unless-stopped ghcr.io/crashappsec/chalk-test-server
 ```
 """
   validator: func validate_url(string) -> string
@@ -32,3 +32,5 @@ sink_config output_to_http {
 
   # The URI should get filled in automatically.
 }
+
+subscribe("report", "output_to_http")


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

related to https://github.com/crashappsec/chalk/issues/75 -- fixes the config so that we can be sure which part is failing

## Description

reporting server output sink was not actually subscribed to

## Testing

see ticket
