### PR TITLE
fix: chalk should push reports to report endpoint

### DIFF
--- a/configs/reporting_server.c4m
+++ b/configs/reporting_server.c4m
@@ -7,7 +7,7 @@ func validate_url(url) {
 }
 
 func get_local_url() {
-  return "http://" + external_ip() + ":8585"
+  return "http://" + external_ip() + ":8585/report"
 }
 
 parameter sink_config.output_to_http.uri {

--- a/tests/data/configs/composable/valid/compliance_docker/reporting_server.c4m
+++ b/tests/data/configs/composable/valid/compliance_docker/reporting_server.c4m
@@ -7,7 +7,7 @@ func validate_url(url) {
 }
 
 func get_local_url() {
-  return "http://" + external_ip() + ":8585"
+  return "http://" + external_ip() + ":8585/report"
 }
 
 parameter sink_config.output_to_http.uri {


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

related to https://github.com/crashappsec/chalk/issues/75

## Description

default url needs to end in `/report` to hit the correct endpoint in the api server
