### PR TITLE
Fix syft with a single component

### DIFF
--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -87,7 +87,7 @@ func extract_syft_sbom(out: string, code) {
     echo(out)
   }
 
-  validIndicator := "\"components\": "
+  validIndicator := "\"component"
   emptyIndicator := "\"components\": []"
 
   if not contains(out, validIndicator) {


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [X] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [X] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [X] Filled out the template to a useful degree

## Issue

When syft has one component (as opposed to 0 or 2), it changes the key name to "component", which was bungling detection.

## Description

It's 'validity' check just now looks for: "component
Not the whole key.

## Testing

<!-- What are the steps needed to test this PR? -->
