### PR TITLE
fix(tools): Load tool configs for docker

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#63def517abc5f4d4efb876d34b7287c9361352cd"
+requires "https://github.com/crashappsec/con4m#420d215701f7d460d3fb47f6e68740f5e0584b55"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#420d215701f7d460d3fb47f6e68740f5e0584b55"
+requires "https://github.com/crashappsec/con4m#ac20be514a8b716b4a5a36d43cdc5b60d57cceb2"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#ac20be514a8b716b4a5a36d43cdc5b60d57cceb2"
+requires "https://github.com/crashappsec/con4m#7587d134b8025a32a9ed524babb53462df49bd00"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/src/commands/cmd_dump.nim
+++ b/src/commands/cmd_dump.nim
@@ -22,7 +22,7 @@ template baseDump(code: untyped) {.dirty.} =
 
   code
 
-  publish("confdump", toDump)
+  echo toDump
   quit(0)
 
 proc dumpToFile*() =

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -367,13 +367,6 @@ tools that ship with chalk (see `chalk config`) currently respect it
      doc:        "Specifies which kind of tool this is."
    }
 
-   field runs_once {
-     type:       bool
-     default:    true
-     write_lock: true
-     doc:        "Does the tool implementation get invoked per-artifact or per-run?"
-   }
-
    field priority {
      type:     int
      default:  50

--- a/src/confload.nim
+++ b/src/confload.nim
@@ -187,11 +187,8 @@ proc loadAllConfigs*() =
   stack.addConfLoad(ioConfName, toStream(ioConfig), notEvenDefaults).
         addConfLoad(attestConfName, toStream(attestConfig), checkNone)
 
-  let chalkOps = chalkConfig.getValidChalkCommandNames()
-  if commandName in chalkOps or (commandName == "not_supplied" and
-    chalkConfig.defaultCommand.getOrElse("") in chalkOps):
-    stack.addConfLoad(sbomConfName,   toStream(sbomConfig),   checkNone)
-    stack.addConfLoad(sastConfName,   toStream(sastConfig),   checkNone)
+  stack.addConfLoad(sbomConfName,   toStream(sbomConfig),   checkNone)
+  stack.addConfLoad(sastConfName,   toStream(sastConfig),   checkNone)
 
   stack.addCallback(loadLocalStructs)
   doRun()


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [X] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [X] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [X] Filled out the template to a useful degree

## Issue

Closes #82
Closes #63 

## Description

Internal tool configs now always load (they were not loading for all commands). But this is the right choice since the entire startup config is going to end up cached soon anyway.

Additionally, picked up the new nimutils (since this was the version I tested against), which implements the new IO handling from #63.

I also removed the `runs_once` notion. In the case of Docker, tools in the host bass will see '.'; the second time it will see the container name. Might want to provide access to context info in the future.

## Testing

Check at the end of a docker build run to see that the tools loaded.
