### PR TITLE
fix: remove broken links to removed how-tos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,6 @@ Many companies and the US Government are now mandating suppliers providing suppl
 
 From a code base, easily understand the environments where code and even particular branches are running. Gather code owners for the applications and code repos. Follow this how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-create-a-real-time-application-inventory).
 
-#### Create network services visibility reports from containers
-
-Understanding which services run in containers can help you build a service map. Use Chalk to automatically create periodic reports on container network tables, or visibility into service availability. Follow this how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-create-network-services-visibility-reports-from-containers).
-
-#### Create and maintain an SBOM registry
-
-Automatically create SBOMs for every build of every code repo, including auto-deploying and using built-in SBOM generation and collection tools. Send these SBOMs to a central location for further analysis, and to maintain a record across your environment. Follow this how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-create-and-maintain-an-sbom-registry).
-
 #### How-to deploy Chalk globally using Docker
 
 You can deploy Chalk by setting a global alias for Docker and having it call Chalk, so that every build that runs through your build server using Docker, will automatically be 'chalked'. It's a technique that can be combined with chalks ability to deploy tools and configure monitoring, to automatically add security controls and collect information for every application. Follow this how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-deploy-chalk-globally-using-docker)]


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ ] Filled out the template to a useful degree

## Description

Removes how-to links to missing pages that are 404ing