### PR TITLE
test: ensure sboms tools actually run and embed

### DIFF
--- a/tests/data/configs/composable/valid/sboms/enable_sboms.c4m
+++ b/tests/data/configs/composable/valid/sboms/enable_sboms.c4m
@@ -1,0 +1,9 @@
+run_sbom_tools: true
+
+# Embed sboms in chalk marks.
+
+# `chalk insert` uses the mark_default template.
+mark_template.mark_default.key.SBOM.use: true
+
+# `chalk docker build` uses the `minimal` template.
+mark_template.minimal.key.SBOM.use: true


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue
testing update for https://github.com/crashappsec/chalk/issues/82

## Description
adds tests to check that sboms have been embedded into docker + binaries if `embed_sboms` is enabled
