### PR TITLE
refactor: subprocess IO

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#4a36648c7c3553961b154ce74b4f7d76b90b826a"
+requires "https://github.com/crashappsec/con4m#4a82217ce08c9cd711ce9e442a7ec4ad68199ba2"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#27a36bf4a88d75431fd1119a6eb0c5f478efe64f"
+requires "https://github.com/crashappsec/con4m#e1e68114e1302b7ba51e6576bb9480820257d12d"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#63def517abc5f4d4efb876d34b7287c9361352cd"
+requires "https://github.com/crashappsec/con4m#4a36648c7c3553961b154ce74b4f7d76b90b826a"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#e1e68114e1302b7ba51e6576bb9480820257d12d"
+requires "https://github.com/crashappsec/con4m#facf7d63439e252d71ec1d492b0af898bab027c0"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#facf7d63439e252d71ec1d492b0af898bab027c0"
+requires "https://github.com/crashappsec/con4m#49182816bd17ffa2560d3df81d2fcaed2960114c"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#4a82217ce08c9cd711ce9e442a7ec4ad68199ba2"
+requires "https://github.com/crashappsec/con4m#27a36bf4a88d75431fd1119a6eb0c5f478efe64f"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#79f958891e787d391612cab2210bc1552a61b890"
+requires "https://github.com/crashappsec/con4m#fad5f9719f6123d0c587c5424a8876eca410be64"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#49182816bd17ffa2560d3df81d2fcaed2960114c"
+requires "https://github.com/crashappsec/con4m#79f958891e787d391612cab2210bc1552a61b890"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

Closes #63 

## Description

Nothing is  this PR is directly implemented in Chalk; the implementation was in Nimutils, and this picks up the nimutils version via picking up the newest Con4m.

There's now one incredibly flexible subprocess API, with both a one-shot interface and a builder-style interface. It can do PTYs, capture, callbacks, socket listeners, etc.

The existing subprocess stuff has been all re-written on top of it (we didn't use Nim's built-in stuff because it didn't provide even basic niceties we needed, like being able to capture all of, stdin, stdout and the return code for one process). And it certainly didn't have pty support.

The old API remained for compatibility with chalk though.

The reason for this refactor wasn't the existing subprocess support, it was for future capabilities:

1. The file locking is going to get a major upgrade with any parallel chalk processes coordinating via unix sockets.
2. We wanted to be able to support capture-replay of Chalk and its use cases (which is now done in: https://github.com/crashappsec/cap10)
3. We wanted to be able to SCRIPT sessions too, or partially script, while supporting interaction and capture-replay. Basically a better `expect`. That's also done in first draft in `cap10`.

## Testing
Currently, from Chalk's perspective, this involved no code changes. So if the existing tests pass, all is good in the cosmos.