### PR TITLE
fix: capture heisenbug

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#63def517abc5f4d4efb876d34b7287c9361352cd"
+requires "https://github.com/crashappsec/con4m#2550d50ecb47aff62e17e379a1481194c74a6533"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#2550d50ecb47aff62e17e379a1481194c74a6533"
+requires "https://github.com/crashappsec/con4m#69919dce02d333894689e262373c58ff344c73bf"
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"
 

--- a/config.nims
+++ b/config.nims
@@ -86,3 +86,7 @@ for item in libs:
 
   switch("passL", libDir & "/" & libFile)
   switch("dynlibOverride", item)
+# begin Nimble config (version 2)
+when withDir(thisDir(), system.fileExists("nimble.paths")):
+  include "nimble.paths"
+# end Nimble config

--- a/config.nims
+++ b/config.nims
@@ -86,7 +86,3 @@ for item in libs:
 
   switch("passL", libDir & "/" & libFile)
   switch("dynlibOverride", item)
-# begin Nimble config (version 2)
-when withDir(thisDir(), system.fileExists("nimble.paths")):
-  include "nimble.paths"
-# end Nimble config


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

The fact that the C and Nim APIs disagreed on sign for an integer led to process output capture not getting presented... but only in very rare (but reproducible cases). I haven't even figured out why this mattered or why it didn't work yet. But this seems to fix it?

## Description

Pull in a new nimutils that just changes a 'cint' to a 'csize_t'.  Seriously.
## Testing

<!-- What are the steps needed to test this PR? -->

If all tests pass, the broken case we found seems to be working on multiple boxes.
