### PR TITLE
fix: semgrep installation + runtime arguments now work

### DIFF
--- a/configs/embed_sast.c4m
+++ b/configs/embed_sast.c4m
@@ -1,0 +1,9 @@
+run_sast_tools: true
+
+# Embed sast reports in chalk marks.
+
+# `chalk insert` uses the mark_default template.
+mark_template.mark_default.key.SAST.use: true
+
+# `chalk docker build` uses the `minimal` template.
+mark_template.minimal.key.SAST.use: true

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -16,7 +16,7 @@ tool semgrep {
                                                    dict[string, string])
   semgrep_config_profile: "auto"
   semgrep_format:         "sarif"
-  semgrep_metrics:        "off"
+  semgrep_metrics:        "on"
   semgrep_other_flags:    ""
   doc: """
 This runs the semgrep static analyizer.  If it doesn't exist in the
@@ -26,33 +26,38 @@ You can configure the following fields in the tool.semgrep object:
 
 semgrep_config_profile: The semgrep profile to use.  Defaults to 'auto'
 semgrep_format:         The output format flag to pass. Defaults to 'sarif'
-semgrep_metrics:        Whether to ping semgrep. 'on' or 'off'. Defaults to 'off'
+semgrep_metrics:        Whether to ping semgrep. 'on' or 'off'. Defaults to 'on' to be compatible with config=auto
 """
 }
 
+
+
 func find_semgrep(ignore) {
-  result := find_exe("semgrep", [])
+  semgrep_path := "/tmp/semgrep.env/bin/semgrep"
+  result := find_exe(semgrep_path, [])
 
   if result == "" {
-    trace("find_semgrep: Unable to find semgrep in $PATH")
+    trace("find_semgrep: Unable to find semgrep at" + result)
   } else {
     trace("found semgrep at: " + result)
   }
 }
 
 func install_semgrep(ignore) {
-  error("!!! install semgrep!!")
-  output, code := system("python3 -m pip install semgrep")
-  if code != 0 {
-    error("python3 install failed")
-    output, code := system("python -m pip install semgrep")
+  trace("attempting to install semgrep to python3 venv")
+
+  # venv is only compatible with python3
+  output, code := system("python3 -m venv /tmp/semgrep.env")
+  if code == 0 {
+    output, code := system("/tmp/semgrep.env/bin/python3 -m pip install 'semgrep>=1.48'")
+    if code == 0 {
+      trace("semgrep successfully installed")
+      return true
+    }
   }
-  if code != 0 {
-    error("normal python install failed")
-    return false
-  }
-  error("install worked")
-  return true
+
+  trace("semgrep could not be installed")
+  return false
 }
 
 func get_semgrep_args(artifact) {
@@ -76,6 +81,7 @@ func load_semgrep_results(out: string, code) {
     info("semgrep didn't find any components; ignoring.")
   }
   else {
-     return { "SAST" : out }
+    trace("semgrep ran with results: " + out)
+    return { "SAST" : out }
   }
 }

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -41,13 +41,17 @@ func find_semgrep(ignore) {
 }
 
 func install_semgrep(ignore) {
+  error("!!! install semgrep!!")
   output, code := system("python3 -m pip install semgrep")
   if code != 0 {
+    error("python3 install failed")
     output, code := system("python -m pip install semgrep")
   }
   if code != 0 {
+    error("normal python install failed")
     return false
   }
+  error("install worked")
   return true
 }
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue
closes https://github.com/crashappsec/chalk/issues/92

## Description
- semgrep download is now managed by python3 venv instead of pip installing to user installtion
- install location is directly passed to `find_semgrep` so semgrep can be found even if it's not in $PATH
- semgrep default run arguments conflicted with each other, metrics is now default `on` to work with `config=auto`

## Testing

tests need to be added to ensure that semgrep run returns correct sast json
