### PR TITLE
tests: fixing exclusive plugin tests

### DIFF
--- a/tests/chalk/runner.py
+++ b/tests/chalk/runner.py
@@ -6,6 +6,7 @@ import re
 import datetime
 import json
 import os
+import itertools
 from pathlib import Path
 from typing import Any, Literal, Optional, cast
 
@@ -127,18 +128,18 @@ class ChalkProgram(Program):
 
     @property
     def errors(self):
-        errors = [i for i in self.logs.splitlines() if i.startswith("error:")]
-        return errors
+        errors = itertools.takewhile(
+            lambda i: "--debug" not in i,
+            [i for i in self.logs.splitlines() if i.startswith("error:")],
+        )
+        return list(errors)
 
     @property
     def reports(self):
-        # strip chalk logs from stdout so we can find just json reports
-        # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
-        text = re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", self.text)
         text = "\n".join(
             [
                 i
-                for i in text.splitlines()
+                for i in self.text.splitlines()
                 if not any(i.startswith(j) for j in {"info:", "trace:", "error:"})
             ]
         )

--- a/tests/utils/os.py
+++ b/tests/utils/os.py
@@ -90,13 +90,18 @@ class Program:
         if not self:
             raise self.error
 
+    def _strip_ansi(self, text: str):
+        # strip chalk logs from stdout so we can find just json reports
+        # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+        return re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", text)
+
     @property
     def text(self) -> str:
-        return self.stdout.decode().strip()
+        return self._strip_ansi(self.stdout.decode().strip())
 
     @property
     def logs(self) -> str:
-        return self.stderr.decode().strip()
+        return self._strip_ansi(self.stderr.decode().strip())
 
     @property
     def error(self) -> CalledProcessError:


### PR DESCRIPTION
as tests touch common vendor file, they cannot run in parallel and need to be marked as exclusive. the fact that it passes in CI is probably just an indicator that it has much fewer cores and they dont overlap with each other but otherwise they are found to fail

also ignoring docker debug error logs from docker build helper

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

tests are failing on main

## Testing

```
make tests_parallel args="test_plugin.py"
```
