### PR TITLE
incorrect header byte fixed

### DIFF
--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -27,7 +27,7 @@ const
   gitCommitter = "committer "
   gitIdxAll    = "*.idx"
   gitIdxExt    = ".idx"
-  gitIdxHeader = "\xff\x7f\x4f\x63\x00\x00\x00\x02"
+  gitIdxHeader = "\xff\x74\x4f\x63\x00\x00\x00\x02"
   gitObjects   = "objects" & DirSep
   gitPack      = gitObjects.joinPath("pack")
   gitPackExt   = ".pack"


### PR DESCRIPTION
I do not know how this slipped past and that I didn't see sooner, but I had one byte off in my header constant which meant it always failed on .idx files, it must have been a typo? I will write tests for this. 