### PR TITLE
Incorporate minor upstream fixes

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#e74ca798804b0505e628298788b756c8252ab92d"
+requires "https://github.com/crashappsec/con4m#e35009814fd6f712072e6c0066bc45082d4bcc66"
 
 requires "https://github.com/viega/zippy == 0.10.7"
 requires "https://github.com/aruZeta/QRgen == 3.0.0"


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

Closes #96 
## Description

Pulls in a new nimutils, which fixes two issues:
1. A file descriptor leak in subprocesses due to forgetting a destructor. Limited us to about 100 docker calls.
2. If ANSI was turned off, AND output was going to a pipe, no newlines were getting written, which made for weird log files.
3. I don't know what version of nimutils had #96, but it was an intermediate version from long ago that apparently got incorporated. So I don't know when this disappeared, but it's been a while, and it's not there now. 
## Testing
- Run docker on a command line w/ 1000 containers that don't exist (which will spawn a couple thousand processes).
- Check log output for `version` command and ensure a newline is in there.
