### PR TITLE
fix: pushing all docker tags on build --push

### DIFF
--- a/tests/chalk/runner.py
+++ b/tests/chalk/runner.py
@@ -386,6 +386,7 @@ class Chalk:
         *,
         dockerfile: Optional[Path | str] = None,
         tag: Optional[str] = None,
+        tags: Optional[list[str]] = None,
         context: Optional[Path | str] = None,
         expected_success: bool = True,
         expecting_report: bool = True,
@@ -400,24 +401,27 @@ class Chalk:
         secrets: Optional[dict[str, Path]] = None,
         log_level: ChalkLogLevel = "none",
         env: Optional[dict[str, str]] = None,
+        run_docker: bool = True,
     ) -> tuple[str, ChalkProgram]:
         cwd = cwd or Path(os.getcwd())
         context = context or getattr(dockerfile, "parent", cwd)
 
         # run vanilla docker build to ensure it works without chalk
-        Docker.build(
-            tag=tag,
-            context=context,
-            dockerfile=dockerfile,
-            args=args,
-            cwd=cwd,
-            push=push,
-            platforms=platforms,
-            expected_success=expected_success,
-            buildkit=buildkit,
-            buildx=buildx,
-            secrets=secrets,
-        )
+        if run_docker:
+            Docker.build(
+                tag=tag,
+                tags=tags,
+                context=context,
+                dockerfile=dockerfile,
+                args=args,
+                cwd=cwd,
+                push=push,
+                platforms=platforms,
+                expected_success=expected_success,
+                buildkit=buildkit,
+                buildx=buildx,
+                secrets=secrets,
+            )
 
         image_hash, result = Docker.with_image_id(
             self.run(
@@ -429,6 +433,7 @@ class Chalk:
                 config=config,
                 params=Docker.build_cmd(
                     tag=tag,
+                    tags=tags,
                     context=context,
                     dockerfile=dockerfile,
                     args=args,

--- a/tests/utils/docker.py
+++ b/tests/utils/docker.py
@@ -19,6 +19,7 @@ class Docker:
     def build_cmd(
         *,
         tag: Optional[str],
+        tags: Optional[list[str]] = None,
         context: Optional[Path | str] = None,
         dockerfile: Optional[Path | str] = None,
         args: Optional[dict[str, str]] = None,
@@ -28,12 +29,15 @@ class Docker:
         secrets: Optional[dict[str, Path]] = None,
         buildkit: bool = True,
     ):
+        tags = tags or []
+        if tag:
+            tags = [tag] + tags
         cmd = ["docker"]
         if platforms or buildx:
             cmd += ["buildx"]
         cmd += ["build"]
-        if tag:
-            cmd += ["-t", tag]
+        for t in tags:
+            cmd += ["-t", t]
         if dockerfile:
             cmd += ["-f", str(dockerfile)]
         for name, value in (args or {}).items():
@@ -51,6 +55,7 @@ class Docker:
     def build(
         *,
         tag: Optional[str] = None,
+        tags: Optional[list[str]] = None,
         context: Optional[Path | str] = None,
         dockerfile: Optional[Path | str] = None,
         args: Optional[dict[str, str]] = None,
@@ -69,6 +74,7 @@ class Docker:
             run(
                 Docker.build_cmd(
                     tag=tag,
+                    tags=tags,
                     context=context,
                     dockerfile=dockerfile,
                     args=args,
@@ -169,6 +175,14 @@ class Docker:
             expected_exit_code=int(not expected_success),
             timeout=timeout,
         )
+
+    @staticmethod
+    def pull(tag: str) -> Program:
+        return run(["docker", "pull", tag])
+
+    @staticmethod
+    def imagetools_inspect(tag: str) -> Program:
+        return run(["docker", "buildx", "imagetools", "inspect", tag])
 
     @staticmethod
     def inspect(name: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

```
chalk docker build -t foo -t bar --push .
```

this would only push `foo` tag and not push `bar` tag

## Description

When specifying multiple tags during `docker build`, all tags are pushed to the registry when `--push` flag is used.

## Testing

```
➜ make tests args="test_docker.py::test_multiple_tags --logs"
```