### PR TITLE
feat(auth): adding basic/jwt auth configurations

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -8,7 +8,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#8244f2ba34c564ecf9a0a529bcc9558cc2ade4f8"
+requires "https://github.com/crashappsec/con4m#a067d04cd7c5e11b633c8d1a284c42076939637c"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/aruZeta/QRgen == 3.0.0" # MIT
 

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -339,6 +339,7 @@ const
                         staticRead("configs/base_keyspecs.c4m") &
                         staticRead("configs/base_plugins.c4m") &
                         staticRead("configs/base_sinks.c4m") &
+                        staticRead("configs/base_auths.c4m") &
                         staticRead("configs/base_chalk_templates.c4m") &
                         staticRead("configs/base_report_templates.c4m") &
                         staticRead("configs/base_outconf.c4m") &

--- a/src/configs/base_auths.c4m
+++ b/src/configs/base_auths.c4m
@@ -1,0 +1,65 @@
+##
+## Copyright (c) 2023, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+auth basic {
+  ~auth:          true
+  ~username:      true
+  ~password:      true
+  shortdoc:       "HTTP Basic Auth"
+  doc:            """
+| Parameter  | Type     | Required | Description             |
+|------------|----------|----------|-------------------------|
+| `username` | `string` | yes      | Username for basic auth |
+| `password` | `string` | yes      | Password for basic auth |
+
+This auth method allows to define basic auth which can be used by sinks.
+
+For example:
+
+```
+auth_config my_api {
+  auth:     "basic"
+  username: env("USERNAME")
+  password: env("PASSWORD")
+}
+sink_config my_https_config {
+  enabled: true
+  sink:    "post"
+  uri:     env("CHALK_POST_URL")
+  auth:    "my_api"
+}
+```
+"""
+}
+
+auth jwt {
+  ~auth:          true
+  ~token:         true
+  shortdoc:       "JWT Bearer Auth"
+  doc:            """
+| Parameter | Type     | Required | Description                                                    |
+|-----------|----------|----------|----------------------------------------------------------------|
+| `token`   | `string` | yes      | JWT Token to be sent as Bearer token. Token cannot be expired. |
+
+This auth method allows to define JWT auth which can be used by sinks.
+
+For example:
+
+```
+auth_config my_api {
+  auth:  "jwt"
+  token: env("TOKEN")
+}
+sink_config my_https_config {
+  enabled: true
+  sink:    "post"
+  uri:     env("CHALK_POST_URL")
+  auth:    "my_api"
+}
+```
+"""
+}

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -18,6 +18,7 @@
 ## - base_keyspecs.c4m
 ## - base_plugins.c4m
 ## - base_sinks.c4m
+## - base_auths.c4m
 ## - base_chalk_templates.c4m
 ## - base_report_templates.c4m
 ## - base_outconf.c4m

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -130,6 +130,7 @@ sink post {
   ~timeout:          false
   ~pinned_cert_file: false
   ~on_write_msg:     false
+  ~auth:             false
   shortdoc:          "HTTP/HTTPS POST"
   doc:       """
 
@@ -141,6 +142,7 @@ sink post {
 | `disallow_http` | false | Do not allow HTTP connections, only HTTPS |
 | `timeout` | false | Connection timeout in ms |
 | `pinned_cert_file` | false | TLS certificate file |
+| `auth` | false | Auth configuration for the API |
 
 The post will always be a single JSON object, and the default
 content-type field will be `application/json`. Changing this value
@@ -190,6 +192,7 @@ sink presign {
   ~timeout:          false
   ~pinned_cert_file: false
   ~on_write_msg:     false
+  ~auth:             false
   shortdoc:          "HTTP/HTTPS Presign PUT"
   doc:               """
 Sink which allows to upload reports to pre-signed URL.

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -924,6 +924,74 @@ field.
   }
 }
 
+object auth {
+  gen_fieldname: "auths"
+  gen_typename:  "AuthSpec"
+  gen_setters:   false
+  user_def_ok:   true
+  validator:     func auth_object_check
+  doc:           """
+This object type is needed to add new auth methods to chalk.
+Various sinks can use that auth method for interacting with
+protected external APIs as well as any other components
+needing external auth functionality.
+
+The `auth` object defines which fields should be required
+for that auth configuration.
+
+For example:
+
+```
+auth my_auth {
+  ~foo: true
+}
+```
+
+This will require any auth configurations to set `foo` parameter:
+
+```
+auth_config my_auth_config {
+  auth: "my_auth"
+  foo:  "bar"
+}
+```
+"""
+
+  field doc {
+    type:    string
+    require: false
+    hidden:  true
+  }
+
+  field shortdoc {
+    type:    string
+    require: false
+    hidden:  true
+  }
+}
+
+object auth_config {
+  gen_fieldname: "authConfs"
+  gen_typename:  "AuthConfigObj"
+  gen_setters:   false
+  user_def_ok:   true
+  validator:     func auth_config_check
+  doc:           """
+This object type allows chalk configuration to define auth configurations.
+Each auth configuration must define its auth type as defined by `auth`
+objects elsewhere. In addition each auth config must set all required
+fields as defined by that auth type. For example for basic auth:
+
+```
+auth_config my_auth_config {
+  auth:     "basic"
+  username: env("USERNAME")
+  password: env("USERNAME")
+}
+```
+"""
+}
+
 object outconf {
   gen_fieldname: "outputConfigs"
   gen_typename:  "OutputConfig"
@@ -2059,6 +2127,8 @@ root {
   allow plugin
   allow sink
   allow sink_config
+  allow auth
+  allow auth_config
   allow mark_template
   allow report_template
   allow outconf
@@ -2874,7 +2944,7 @@ func key_callback_check(keyname, callback: func (string) -> `x) {
   if not typecmp(expected, actual) {
     return ("In: '" + keyname + "' callback is of type '" + $(actual) +
             "', but the key specification requires the type: '" +
-  	    $(expected) + "'")
+            $(expected) + "'")
   }
 
   return ""
@@ -2922,8 +2992,8 @@ func plugin_keyspec_check(keyname, val: list[string], context) {
       elif kind == ChalkTimeArtifact {
         never_early_field := base + "never_early"
         if attr_get(never_early_field, bool) == false {
-  	  continue
-	}
+          continue
+        }
       }
       return (keyname + ": specified key '" + item + "' cannot appear in " +
              "the 'Pre-Run' collection context")
@@ -2931,11 +3001,11 @@ func plugin_keyspec_check(keyname, val: list[string], context) {
     elif context == CCArtifact or context == CCPostChalk {
       if kind == RunTimeHost or (kind == ChalkTimeHost and context == CCPostChalk) {
         return (keyname + ": specified key '" + item + "' is a host-level " +
-	        "key that cannot appear at artifact collection time")
+                "key that cannot appear at artifact collection time")
       }
       if context == CCPostChalk and kind == ChalkTimeArtifact {
         return (keyname + ": specified key '" + item + "' must be available " +
-	       "during artifact collection")
+                "during artifact collection")
       }
     }
     else {  # context == CCPostRun
@@ -3169,9 +3239,9 @@ func use_when_check(name, value: list[string]) {
     }
     return ("'use_when' must be a valid chalk report type, or a '*' " +
            " to indicate all of them. '" + value[i] +
-	   "' isn't a chalk command.  Valid report types are: " +
-	   valid_chalk_cmds.join(", ") + ", " + other_report_ops.join(", ")
-	   )
+           "' isn't a chalk command.  Valid report types are: " +
+           valid_chalk_cmds.join(", ") + ", " + other_report_ops.join(", ")
+           )
   }
 }
 
@@ -3243,7 +3313,7 @@ func default_command_check(keyname, value) {
   }
   return ("The attribute 'default_command' is set to '" + value +
           "', which is not a valid chalk command. Must be one of: " +
-	  join(valid_chalk_cmds, ", "))
+          join(valid_chalk_cmds, ", "))
 }
 
 # Run any checks across fields that we haven't yet done...
@@ -3287,7 +3357,7 @@ func sink_object_check(path) {
     }
     return ("All sink fields must be a bool indicating whether a field is " +
             "required, or a string specifying a default value " +
-	    "(offending field: '" + f[i] + "' has type: " + $(fieldtype))
+            "(offending field: '" + f[i] + "' has type: " + $(fieldtype))
   }
 }
 
@@ -3315,7 +3385,7 @@ func sink_config_check(path) {
     if not sinkfields.contains(conffield) {
       return ("sink config provides field '" + conffield +
               "', but the specified sink '" + sinkname +
-	      "' does not use that field.")
+              "' does not use that field.")
     }
 
     if contains(["timeout", "truncation_amount", "max"], conffield) {
@@ -3366,6 +3436,62 @@ func sink_config_check(path) {
      if not conffields.contains(sinkfields[i]) {
        return "sink config is missing required field: '" + sinkfields[i] + "'"
      }
+  }
+}
+
+func auth_object_check(path) {
+  result := ""
+  f := fields(path)
+  for i from 0 to len(f) {
+    fieldname := path + "." + f[i]
+    fieldtype := attr_type(fieldname)
+    if typecmp(fieldtype, bool) or typecmp(fieldtype, string) {
+      continue
+    }
+    return ("All auth fields must be a bool indicating whether a field is " +
+            "required, or a string specifying a default value " +
+            "(offending field: '" + f[i] + "' has type: " + $(fieldtype))
+  }
+}
+
+func auth_config_check(path) {
+  result   := ""
+  authname := attr_get(path + ".auth", string)
+  if authname == "" {
+    return # Unconfigured.
+  }
+  if not attr_exists("auth." + authname) {
+    return "No such auth configured: '" + authname + "'"
+  }
+  authfields := fields("auth." + authname)
+  conffields := fields(path)
+
+  # ensure config has all required fields are present as defined in auth
+  for i from 0 to len(authfields) {
+    fullname := "auth." + authname + "." + authfields[i]
+    t := attr_type(fullname)
+    if not typecmp(t, bool) {   # TODO-- short circuit didn't work??
+      continue
+    }
+    if not attr_get(fullname, bool) {
+      continue
+    }
+    if not conffields.contains(authfields[i]) {
+      return "auth config is missing required field: '" + authfields[i] + "'"
+    }
+  }
+
+  # check config field fields
+  for i from 0 to len(conffields) {
+    conffield := conffields[i]
+    if not authfields.contains(conffield) {
+      return ("auth config provides field '" + conffield +
+              "', but the specified auth '" + authname +
+              "' does not use that field.")
+    }
+    if not typecmp(attr_type(path + "." + conffield), string) {
+      return "This field must be a string."
+    }
   }
 }
 

--- a/tests/data/sink_configs/post_http_local.c4m
+++ b/tests/data/sink_configs/post_http_local.c4m
@@ -1,10 +1,20 @@
 crashoverride_usage_reporting_url = "http://chalk.crashoverride.local:8585/ping"
 log_level = "trace"
 
+auth_config my_basic_config {
+  auth:     "basic"
+  username: "foo"
+  password: "bar"
+}
+
 sink_config my_http_config {
   enabled: true
   sink:    "post"
   uri:     env("CHALK_POST_URL")
+
+  # nothing actually checks the header but it does
+  # exercise auth implementations
+  auth:    "my_basic_config"
 
   if env_exists("CHALK_POST_HEADERS") {
     headers: mime_to_dict(env("CHALK_POST_HEADERS"))

--- a/tests/data/sink_configs/post_https_local.c4m
+++ b/tests/data/sink_configs/post_https_local.c4m
@@ -1,10 +1,19 @@
 crashoverride_usage_reporting_url = "https://chalk.crashoverride.local:8585/ping"
 log_level = "trace"
 
+auth_config my_jwt_config {
+  auth:     "jwt"
+  token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+}
+
 sink_config my_https_config {
   enabled: true
   sink:    "post"
   uri:     env("CHALK_POST_URL")
+
+  # nothing actually checks the header but it does
+  # exercise auth implementations
+  auth:    "my_jwt_config"
 
   if env_exists("TLS_CERT_FILE") {
     pinned_cert_file: env("TLS_CERT_FILE")


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Description

This will allow to easily add reusable auth configurations to sinks:

```
auth_config myauth {
    auth:     "basic"
    username: env("USERNAME")
    password: env("PASSWORD")
}
sink_config mysink {
    sink: "post"
    uri:  "http://example.com/report"
    auth: "myauth"
}
```

## Testing

```
make tests args="test_sink.py"
```
