### PR TITLE
fix: added _ACTION_ID in push template and moved to the top of all report template configs

### DIFF
--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -1667,6 +1667,9 @@ report_template push_default {
   You can certainly collect a lot more data here, but we expect it
   should usually be redundant w/ the info you collected during a build.
 """
+  key._ACTION_ID.use                          = true
+  key._TIMESTAMP.use                          = true
+  key._DATETIME.use                           = true
   key._OPERATION.use                          = true
   ~key._CURRENT_HASH.use                      = true
   key._STORE_URI.use                          = true


### PR DESCRIPTION
## Issue

Fixes #115

## Description

This PR adds `_ACTION_ID` to the default `push` template
## Testing

Issue a `push` command and see that `_ACTION_ID` is properly set