### PR TITLE
refactor(no-api-login)!: remove the --no-api-login switch + assoc. tests

### DIFF
--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2755,15 +2755,6 @@ Chalk will also embed the keypairs internally, for future operations.
 """
 }
 
-  field api_login {
-    type:     bool
-    default:  true
-    shortdoc: "Use CrashOverride API"
-    doc: """
-Enable the use of the Crash Override API.
-"""
-  }
-
   field ignore_patterns {
     type:     list[string]
     default:  [".*/\\..*", ".*\\.txt", ".*\\.json"]

--- a/src/configs/getopts.c4m
+++ b/src/configs/getopts.c4m
@@ -661,11 +661,6 @@ with `.pub` as the file extension.
 """
   }
 
-  flag_yn api_login {
-    field_to_set: "api_login"
-    doc: """Enable/disable the use of the Crash Override API for secret management."""
-  }
-
   command gen {
     shortdoc: "Force generation of new signing key"
     doc: """

--- a/tests/chalk/runner.py
+++ b/tests/chalk/runner.py
@@ -219,7 +219,6 @@ class Chalk:
         exec_command: Optional[str | Path] = None,
         as_parent: Optional[bool] = None,
         no_color: bool = False,
-        no_api_login: bool = False,
         params: Optional[list[str]] = None,
         expected_success: bool = True,
         expecting_report: bool = True,
@@ -256,8 +255,6 @@ class Chalk:
             cmd += ["--debug"]
         if no_color:
             cmd += ["--no-color"]
-        if no_api_login:
-            cmd += ["--no-api-login"]
         if params:
             cmd += params
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -181,7 +181,6 @@ def test_setup(chalk_copy: Chalk):
     """
     needs to display password, and public and private key info in chalk
     """
-    # API login requires interactive session to login via UI
     result = chalk_copy.run(
         command="setup",
         log_level="error",

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -184,7 +184,6 @@ def test_setup(chalk_copy: Chalk):
     # API login requires interactive session to login via UI
     result = chalk_copy.run(
         command="setup",
-        no_api_login=True,
         log_level="error",
         config=CONFIGS / "nosigningkeybackup.c4m",
     )


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [X] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [X] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [X] Filled out the template to a useful degree

## Issue

No issue

## Description

Remove the `--no-api-login` switch as it longer has relevance since the `chalk setup` flow changed and no longer requires an interactive OIDC authentication. 

Tests that included the switch have also been refactored. 

