### PR TITLE
fix(docker): inspecting base images to find entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 
 ### Fixes
 
+- Docker build correctly wraps `ENTRYPOINT` when base
+  image has it defined.
+  [#147](https://github.com/crashappsec/chalk/pull/147)
 - Fixes a segfault when using secrets backup service
   during `chalk setup`
   [#220](https://github.com/crashappsec/chalk/pull/220)
@@ -91,9 +94,6 @@
 
 ### Fixes
 
-- Docker build correctly wraps `ENTRYPOINT` when base
-  image has it defined.
-  [#147](https://github.com/crashappsec/chalk/pull/147)
 - Fixes possible exception when signing backup service
   would return non-json response
   [#189](https://github.com/crashappsec/chalk/pull/189)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@
 
 ### Fixes
 
+- Docker build correctly wraps `ENTRYPOINT` when base
+  image has it defined.
+  [#147](https://github.com/crashappsec/chalk/pull/147)
 - Fixes possible exception when signing backup service
   would return non-json response
   [#189](https://github.com/crashappsec/chalk/pull/189)
@@ -137,7 +140,7 @@
 ### Breaking Changes
 
 - Remove the `--no-api-login` option.
-  [137](https://github.com/crashappsec/chalk/pull/137)
+  [#137](https://github.com/crashappsec/chalk/pull/137)
 
 ### New Features
 
@@ -169,7 +172,7 @@
   containing JSON data. In addition cloud metadata is now
   nested to allow to include more metadata about running
   cloud instances.
-  [112](https://github.com/crashappsec/chalk/pull/112)
+  [#112](https://github.com/crashappsec/chalk/pull/112)
 
 - The signing key backup service has been completely overhauled and
   no longer uses the OIDC Device Code Flow to authenticate to the API.
@@ -191,63 +194,63 @@
 ### New Features
 
 - Adding support for git context for docker build commands.
-  [86](https://github.com/crashappsec/chalk/pull/86)
+  [#86](https://github.com/crashappsec/chalk/pull/86)
 - Adding new git metadata fields about:
 
   - authored commit
   - committer
   - tag
 
-  [86](https://github.com/crashappsec/chalk/pull/86)
-  [89](https://github.com/crashappsec/chalk/pull/89)
+  [#86](https://github.com/crashappsec/chalk/pull/86)
+  [#89](https://github.com/crashappsec/chalk/pull/89)
 
 - Improved pretty printing for various commands
-  [99](https://github.com/crashappsec/chalk/pull/99)
+  [#99](https://github.com/crashappsec/chalk/pull/99)
 - Added `github_json_group` for printing chalk marks
   in GitHub Actions.
-  [86](https://github.com/crashappsec/chalk/pull/86)
+  [#86](https://github.com/crashappsec/chalk/pull/86)
 - Adding `presign` sink to allow uploads to S3 without
   hard-coded credentials in the chalk configuration.
-  [103](https://github.com/crashappsec/chalk/pull/103)
+  [#103](https://github.com/crashappsec/chalk/pull/103)
 - Adding JWT/Basic auth authentication options to sinks.
-  [111](https://github.com/crashappsec/chalk/pull/111)
+  [#111](https://github.com/crashappsec/chalk/pull/111)
 - Adding `docker.wrap_cmd` to allow to customize whether
   `CMD` should be wrapped when `ENTRYPOINT` is missing
   in `Dockerfile`.
-  [112](https://github.com/crashappsec/chalk/pull/112)
+  [#112](https://github.com/crashappsec/chalk/pull/112)
 - Adding minimal AWS lambda metadata collection.
   It includes only basic information about lambda function
   such as its ARN and its runtime environment.
-  [112](https://github.com/crashappsec/chalk/pull/112)
+  [#112](https://github.com/crashappsec/chalk/pull/112)
 - Adding experimental support for detection of technologies used at chalk and
   runtime (programming languages, databases, servers, etc.)
-  [128](https://github.com/crashappsec/chalk/pull/128)
+  [#128](https://github.com/crashappsec/chalk/pull/128)
 
 ### Fixes
 
 - Fixes docker version comparison checks.
   As a result buildx is correctly detected now for >=0.10.
-  [86](https://github.com/crashappsec/chalk/pull/86)
+  [#86](https://github.com/crashappsec/chalk/pull/86)
 - Subprocess command output was not reliable being captured.
-  [93](https://github.com/crashappsec/chalk/pull/93)
+  [#93](https://github.com/crashappsec/chalk/pull/93)
 - Fixes automatic installation of `semgrep` when SAST is enabled.
-  [94](https://github.com/crashappsec/chalk/pull/94)
+  [#94](https://github.com/crashappsec/chalk/pull/94)
 - Ensuring chalk executable has correct permissions.
   Otherwise reading embedded configuration would fail in some cases.
-  [104](https://github.com/crashappsec/chalk/pull/104)
+  [#104](https://github.com/crashappsec/chalk/pull/104)
 - Pushing all tags during `docker build --push -t one -t two ...`.
-  [110](https://github.com/crashappsec/chalk/pull/110)
+  [#110](https://github.com/crashappsec/chalk/pull/110)
 - Sending `_ACTION_ID` during `push` command.
-  [116](https://github.com/crashappsec/chalk/pull/116)
+  [#116](https://github.com/crashappsec/chalk/pull/116)
 - All component parameters are saved in the chalk mark.
-  [126](https://github.com/crashappsec/chalk/pull/126)
+  [#126](https://github.com/crashappsec/chalk/pull/126)
 - Gracefully handling permission issues when chalk is running
   as non-existing user. This is most common in lambda
   which runs as user `993`.
-  [112](https://github.com/crashappsec/chalk/pull/112)
+  [#112](https://github.com/crashappsec/chalk/pull/112)
 - `CMD` wrapping supports wrapping shell scripts
   (e.g. `CMD set -x && echo hello`).
-  [132](https://github.com/crashappsec/chalk/pull/132)
+  [#132](https://github.com/crashappsec/chalk/pull/132)
 
 ### Known Issues
 
@@ -269,12 +272,12 @@
 ### New Features
 
 - Adding support for docker multi-platform builds.
-  [54](https://github.com/crashappsec/chalk/pull/54)
+  [#54](https://github.com/crashappsec/chalk/pull/54)
 
 ### Fixes
 
 - Honoring Syft/SBOM configs during docker builds.
-  [84](https://github.com/crashappsec/chalk/pull/84)
+  [#84](https://github.com/crashappsec/chalk/pull/84)
 
 ## 0.2.1
 
@@ -283,7 +286,7 @@
 ### Fixes
 
 - Component parameters can set config attributes.
-  [75](https://github.com/crashappsec/chalk/issues/75)
+  [#75](https://github.com/crashappsec/chalk/issues/75)
 
 ## 0.2.0
 
@@ -305,28 +308,28 @@
   incompatible will not run (and generally won't even load).
 
   We will eventually do an in-app UI to browse and install modules.
-  [47](https://github.com/crashappsec/chalk/pull/47)
-  [67](https://github.com/crashappsec/chalk/pull/67)
+  [#47](https://github.com/crashappsec/chalk/pull/47)
+  [#67](https://github.com/crashappsec/chalk/pull/67)
 
 - Added initial metadata collection for GCP and Azure, along with a
   metadata key to provide the current cloud provider, and a key that
   distinguishes the cloud provider's environments. Currently, this
   only does AWS (eks, ecs, ec2).
-  [59](https://github.com/crashappsec/chalk/pull/59)
-  [65](https://github.com/crashappsec/chalk/pull/65)
+  [#59](https://github.com/crashappsec/chalk/pull/59)
+  [#65](https://github.com/crashappsec/chalk/pull/65)
 
 - Added OIDC token refreshing, along with `chalk login` and
   `chalk logout` commands to log out of auth for the secret manager.
-  [51](https://github.com/crashappsec/chalk/pull/51)
-  [55](https://github.com/crashappsec/chalk/pull/55)
-  [60](https://github.com/crashappsec/chalk/pull/60)
+  [#51](https://github.com/crashappsec/chalk/pull/51)
+  [#55](https://github.com/crashappsec/chalk/pull/55)
+  [#60](https://github.com/crashappsec/chalk/pull/60)
 
 - The initial rendering engine work was completed. This means
   `chalk help`, `chalk help metadata` are fully functional. This engine is
   effectively most of the way to a web browser, and will enable us to
   offload a lot of the documentation, and do a little storefront (once
   we integrate in notcurses).
-  [58](https://github.com/crashappsec/chalk/pull/58)
+  [#58](https://github.com/crashappsec/chalk/pull/58)
 
 - If you're doing multi-arch binary support, Chalk can now pass your
   native binary's configuration to other arches, though it does
@@ -336,25 +339,25 @@
 ### Fixes
 
 - Docker support when installed via `Snap`.
-  [9](https://github.com/crashappsec/chalk/pull/9)
+  [#9](https://github.com/crashappsec/chalk/pull/9)
 - Removes error log when using chalk on ARM Linux as chalk fully
   runs on ARM Linux now.
-  [7](https://github.com/crashappsec/chalk/pull/7)
+  [#7](https://github.com/crashappsec/chalk/pull/7)
 - When a `Dockerfile` uses `USER` directive, chalk can now wrap
   entrypoint in that image
   (`docker.wrap_entrypoint = true` in chalk config).
-  [34](https://github.com/crashappsec/chalk/pull/34)
+  [#34](https://github.com/crashappsec/chalk/pull/34)
 - Segfault when running chalk operation (e.g. `insert`) in empty
   git repo without any commits.
-  [39](https://github.com/crashappsec/chalk/pull/39)
+  [#39](https://github.com/crashappsec/chalk/pull/39)
 - Sometimes Docker build would not wrap entrypoint.
-  [45](https://github.com/crashappsec/chalk/pull/45)
+  [#45](https://github.com/crashappsec/chalk/pull/45)
 - Cosign now only gets installed if needed.
-  [49](https://github.com/crashappsec/chalk/pull/49)
+  [#49](https://github.com/crashappsec/chalk/pull/49)
 - Docker `ENTRYPOINT`/`COMMAND` wrapping now preserves all named
   arguments from original `ENTRYPOINT`/`COMMAND`.
   (e.g. `ENTRYPOINT ["ls", "-la"]`)
-  [70](https://github.com/crashappsec/chalk/issues/70)
+  [#70](https://github.com/crashappsec/chalk/issues/70)
 
 ### Known Issues
 

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -213,7 +213,6 @@ type
 
   InfoBase* = ref object of RootRef
     error*:     string
-    stopHere*:  bool
     startLine*: int
     endLine*:   int
 
@@ -311,6 +310,7 @@ type
     foundFileArg*:      string
     dockerfileLoc*:     string
     inDockerFile*:      string
+    defaultPlatforms*:  Table[string, string]
     foundPlatform*:     string
     foundContext*:      string
     otherContexts*:     OrderedTableRef[string, string]

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -133,16 +133,18 @@ type
     chalks*:          seq[ChalkObj]
     recurse*:         bool
 
-  DockerDirective* = ref object
+  DockerStatement* = ref object of RootRef
+    startLine*:  int
+    endLine*:    int
     name*:       string
     rawArg*:     string
+
+  DockerDirective* = ref object of DockerStatement
     escapeChar*: Option[Rune]
 
-  DockerCommand* = ref object
-    name*:   string
-    rawArg*: string
+  DockerCommand* = ref object of DockerStatement
     continuationLines*: seq[int]  # line 's we continue onto.
-    errors*: seq[string]
+    errors*:            seq[string]
 
   VarSub* = ref object
     brace*:   bool
@@ -153,6 +155,7 @@ type
     error*:   string
     plus*:    bool
     minus*:   bool  #
+
   LineTokenType* = enum ltOther, ltWord, ltQuoted, ltSpace
 
   LineToken* = ref object
@@ -165,6 +168,7 @@ type
     #
     # The individual pieces in the 'contents' field will be de-quoted
     # already, with escapes processed.
+    line*:       int
     startix*:    int
     endix*:      int
     kind*:       LineTokenType
@@ -208,8 +212,10 @@ type
     inArgs*:             Table[string, string]
 
   InfoBase* = ref object of RootRef
-    error*:    string
-    stopHere*: bool
+    error*:     string
+    stopHere*:  bool
+    startLine*: int
+    endLine*:   int
 
   FromInfo* = ref object of InfoBase
     flags*:  seq[DfFlag]
@@ -232,7 +238,7 @@ type
     str*:          string
 
   OnBuildInfo* = ref object of InfoBase
-    rawContents*:  string
+    raw*:  string
 
   AddInfo* = ref object of InfoBase
     flags*:  seq[DfFlag]
@@ -251,6 +257,8 @@ type
     labels*: OrderedTable[string, string]
 
   DockerFileSection* = ref object
+    startLine*:   int
+    endLine*:     int
     image*:       string
     alias*:       string
     entryPoint*:  EntryPointInfo

--- a/src/docker_cmdline.nim
+++ b/src/docker_cmdline.nim
@@ -56,7 +56,10 @@ proc addBackBuildCommonPushFlags*(state: DockerInvocation) =
 
 proc addBackBuildWithoutPushFlags*(state: DockerInvocation) =
   # Here, we know 'push' isn't in the list.
-  if "load" in state.flags:
+  # add --load if it was already there or buildx is used
+  # as in buildx --load is not the default
+  # however we need to load image to inspect built image
+  if "load" in state.flags or "buildx" in state.originalArgs:
     state.newCmdLine.add("--load")
   if "output" notin state.flags:
     return
@@ -64,9 +67,10 @@ proc addBackBuildWithoutPushFlags*(state: DockerInvocation) =
     state.newCmdLine.add("--output=" & item)
 
 proc addBackBuildWithPushFlags*(state: DockerInvocation) =
-  # If this was a buildx build command that had a push in there too,
-  # we add a --load for good measure.
-  if "output" in state.flags or "load" in state.flags or "push" in state.flags:
+  # add --load if it was already there or buildx is used
+  # as in buildx --load is not the default
+  # however we need to load image to inspect built image
+  if "load" in state.flags or "buildx" in state.originalArgs:
     state.newCmdLine.add("--load")
   if "output" notin state.flags:
     return

--- a/src/dockerfile.nim
+++ b/src/dockerfile.nim
@@ -69,6 +69,7 @@ const validDockerDirectives = ["syntax", "escape"]
 proc evalOneVarSub(ctx:    DockerParse,
                    sub:    VarSub,
                    errors: var seq[string]): string
+
 proc evalSubstitutions*(ctx:    DockerParse,
                         t:      LineToken,
                         errors: var seq[string]): string =
@@ -83,8 +84,8 @@ proc evalSubstitutions*(ctx:    DockerParse,
   for item in list:
     result &= ctx.evalSubstitutions(item, errors)
 
-proc evalOrReturnEmptyString*(ctx: DockerParse,
-                              field: Option[LineToken],
+proc evalOrReturnEmptyString*(ctx:    DockerParse,
+                              field:  Option[LineToken],
                               errors: var seq[string]): string =
     if not field.isSome():
         return ""
@@ -138,7 +139,7 @@ method repr*(x: EntryPointInfo, ctx: DockerParse): string =
     result &= "ERRORS:\n" & x.error & "\n"
 
 method repr*(x: OnBuildInfo, ctx: DockerParse): string =
-  result = "ONBUILD: " & x.rawContents & "\n"
+  result = "ONBUILD: " & x.raw & "\n"
 
 method repr*(x: AddInfo, ctx: DockerParse): string =
   result = "ADD " & $(x.rawSrc) & " to " & x.rawDst
@@ -152,9 +153,9 @@ method repr*(x: CopyInfo, ctx: DockerParse): string =
     result &= " (error: " & x.error & ")"
   result &= "\n"
 
-proc lexOneLineTok(ctx: DockerParse, s: seq[Rune], i: var int): LineToken
+proc lexOneLineTok(ctx: DockerParse, d: DockerStatement, s: seq[Rune], i: var int): LineToken
 
-proc lexVarSub(ctx: DockerParse, s: seq[Rune], i: var int): VarSub =
+proc lexVarSub(ctx: DockerParse, d: DockerStatement, s: seq[Rune], i: var int): VarSub =
   result = VarSub(startix: i)
 
   i += 1
@@ -198,15 +199,18 @@ proc lexVarSub(ctx: DockerParse, s: seq[Rune], i: var int): VarSub =
     return
 
   i += 1
-  result.default = some(ctx.lexOneLineTok(s, i))
+  result.default = some(ctx.lexOneLineTok(d, s, i))
   if s[i] != Rune('}'):
     result.error = "Unterminated ${"
   else:
     i += 1
 
-proc lexQuoted(ctx: DockerParse, s: seq[Rune], q: Rune, i: var int):
+proc lexQuoted(ctx: DockerParse, d: DockerStatement, s: seq[Rune], q: Rune, i: var int):
               LineToken =
-  result = LineToken(kind: ltQuoted, quoteType: some(q), startix: i)
+  result = LineToken(kind:      ltQuoted,
+                     quoteType: some(q),
+                     startix:   i,
+                     line:      d.startLine)
   var val = ""
   while i < s.len():
     if s[i] == ctx.currentEscape:
@@ -229,7 +233,7 @@ proc lexQuoted(ctx: DockerParse, s: seq[Rune], q: Rune, i: var int):
     if s[i] == Rune('$'):
       result.contents.add(val)
       val = ""
-      result.varSubs.add(ctx.lexVarsub(s, i))
+      result.varSubs.add(ctx.lexVarsub(d, s, i))
       continue
     val &= $(s[i])
     i += 1
@@ -241,8 +245,10 @@ proc lexQuoted(ctx: DockerParse, s: seq[Rune], q: Rune, i: var int):
 const nonWordRunes = [Rune('$'), Rune('"'), Rune('\''), Rune('#'), Rune('='),
                       Rune('{'), Rune('}')]
 
-proc lexWord(ctx: DockerParse, s: seq[Rune], i: var int): LineToken =
-  result = LineToken(kind: ltWord, startix: i)
+proc lexWord(ctx: DockerParse, d: DockerStatement, s: seq[Rune], i: var int): LineToken =
+  result = LineToken(kind:      ltWord,
+                     startix:   i,
+                     line:      d.startLine)
   var val = ""
 
   while i < s.len():
@@ -252,7 +258,7 @@ proc lexWord(ctx: DockerParse, s: seq[Rune], i: var int): LineToken =
       i += 1
       continue
     if s[i] == Rune('$'):
-      let varsub = ctx.lexVarSub(s, i)
+      let varsub = ctx.lexVarSub(d, s, i)
       result.contents.add(val)
       val = ""
       result.varSubs.add(varsub)
@@ -271,34 +277,38 @@ proc lexWord(ctx: DockerParse, s: seq[Rune], i: var int): LineToken =
   result.endix = i
   return
 
-proc lexWhiteSpace(ctx: DockerParse, s: seq[Rune], i: var int): LineToken =
-  result = LineToken(kind: ltSpace, startix: i)
+proc lexWhiteSpace(ctx: DockerParse, d: DockerStatement, s: seq[Rune], i: var int): LineToken =
+  result = LineToken(kind:      ltSpace,
+                     startix:   i,
+                     line:      d.startLine)
 
   while i < s.len() and s[i].isWhiteSpace():  i += 1
   result.endix    = i
   result.contents = @[$(s[result.startix ..< result.endix])]
 
-proc lexOneLineTok(ctx: DockerParse, s: seq[Rune], i: var int): LineToken =
+proc lexOneLineTok(ctx: DockerParse, d: DockerStatement, s: seq[Rune], i: var int): LineToken =
   let c = s[i]
   case c
   of Rune('"'), Rune('\''):
     i += 1
-    return ctx.lexQuoted(s, c, i)
+    return ctx.lexQuoted(d, s, c, i)
   of Rune('$'):
-    return ctx.lexWord(s, i)
+    return ctx.lexWord(d, s, i)
   else:
     if c.isWhiteSpace():
-      return ctx.lexWhiteSpace(s, i)
+      return ctx.lexWhiteSpace(d, s, i)
     if c == ctx.currentEscape or c notin nonWordRunes:
-      return ctx.lexWord(s, i)
+      return ctx.lexWord(d, s, i)
     i += 1
-    result = LineToken(kind: ltOther, contents: @[$(c)])
+    result = LineToken(kind:      ltOther,
+                       contents:  @[$(c)],
+                       line:      d.startLine)
 
-proc lexSubableLine(ctx: DockerParse, s: string): seq[LineToken] =
+proc lexSubableLine(ctx: DockerParse, d: DockerStatement, s: string): seq[LineToken] =
   let all = s.toRunes()
   var i   = 0
-
-  while i < len(all): result.add(ctx.lexOneLineTok(all, i))
+  while i < len(all):
+    result.add(ctx.lexOneLineTok(d, all, i))
 
 proc parseOneFlag(ctx: DockerParse, toks: seq[LineToken], i: var int):
                  Option[DfFlag] =
@@ -345,7 +355,7 @@ proc nestedSubstitution(ctx:    DockerParse,
   if "$" notin val: return val
   let
     starterrlen = len(errors)
-    toks        = ctx.lexSubableLine(val)
+    toks        = ctx.lexSubableLine(DockerStatement(), val)
 
   result = ctx.evalSubstitutions(toks, errors)
 
@@ -433,7 +443,7 @@ proc parseEnvWithEq(ctx: DockerParse, toks: seq[LineToken]): seq[string] =
 
 # Returns any errors.
 proc parseEnv*(ctx: DockerParse, t: DockerCommand): seq[string] =
-  let toks = ctx.lexSubableLine(t.rawArg)
+  let toks = ctx.lexSubableLine(t, t.rawArg)
 
   if len(toks) == 0:
     return @["No argument to ENV given."]
@@ -451,12 +461,12 @@ proc parseEnv*(ctx: DockerParse, t: DockerCommand): seq[string] =
     return @["Expected the 3rd token to be a = or a space"]
 
 proc parseAddOrCopy*[T: InfoBase](ctx: DockerParse, t: DockerCommand): T =
-  let toks = ctx.lexSubableLine(t.rawArg)
+  let toks = ctx.lexSubableLine(t, t.rawArg)
   var i    = 0
   var args: seq[string]
   var errs: seq[string]
 
-  result       = T()
+  result       = T(startLine: t.startLine, endLine: t.endLine)
   result.flags = ctx.basicParseAllFlags(toks, i)
 
   skipWhiteSpace(toks, i)
@@ -480,10 +490,10 @@ proc parseAddOrCopy*[T: InfoBase](ctx: DockerParse, t: DockerCommand): T =
     result.error = errs.join("\n")
 
 proc parseFrom*(ctx: DockerParse, t: DockerCommand): FromInfo =
-  let toks = ctx.lexSubableLine(t.rawArg)
+  let toks = ctx.lexSubableLine(t, t.rawArg)
   var i    = 0
 
-  result       = FromInfo()
+  result       = FromInfo(startLine: t.startLine, endLine: t.endLine)
   result.flags = ctx.basicParseAllFlags(toks, i)
 
   skipWhiteSpace(toks, i)
@@ -542,8 +552,8 @@ proc parseFrom*(ctx: DockerParse, t: DockerCommand): FromInfo =
     result.error = "Expected end of command but got extra crap"
 
 proc parseLabel*(ctx: DockerParse, t: DockerCommand): LabelInfo =
-  result   = LabelInfo()
-  let toks = ctx.lexSubableLine(t.rawArg)
+  result   = LabelInfo(startLine: t.startLine, endLine: t.endLine)
+  let toks = ctx.lexSubableLine(t, t.rawArg)
   var
     i      = 0
     errs: seq[string]
@@ -571,7 +581,7 @@ proc parseLabel*(ctx: DockerParse, t: DockerCommand): LabelInfo =
     skipWhiteSpace(toks, i)
 
 proc parseShell*(ctx: DockerParse, t: DockerCommand): ShellInfo =
-  result = ShellInfo()
+  result = ShellInfo(startLine: t.startLine, endLine: t.endLine)
   try:
     let json = parseJson(t.rawArg)
     if json.getElems().len() == 0:
@@ -584,7 +594,7 @@ proc parseShell*(ctx: DockerParse, t: DockerCommand): ShellInfo =
 
 proc parseEntryPoint*(ctx: DockerParse, t: DockerCommand): EntryPointInfo =
   let s  = unicode.strip(t.rawArg)
-  result = EntryPointInfo(raw: s)
+  result = EntryPointInfo(raw: s, startLine: t.startLine, endLine: t.endLine)
 
   if s.startsWith("["):
     try:
@@ -596,7 +606,7 @@ proc parseEntryPoint*(ctx: DockerParse, t: DockerCommand): EntryPointInfo =
 
 proc parseCmd*(ctx: DockerParse, t: DockerCommand): CmdInfo =
   let s = unicode.strip(t.rawArg)
-  result = CmdInfo(raw: s)
+  result = CmdInfo(raw: s, startLine: t.startLine, endLine: t.endLine)
 
   if s.startsWith("["):
     try:
@@ -607,8 +617,11 @@ proc parseCmd*(ctx: DockerParse, t: DockerCommand): CmdInfo =
   else:
     result.str = s
 
+proc parseUserInfo*(ctx: DockerParse, t: DockerCommand): DfUserInfo =
+  return DfUserInfo(str: unicode.strip(t.rawArg), startLine: t.startLine, endLine: t.endLine)
+
 proc parseOnBuild*(ctx: DockerParse, t: DockerCommand): OnBuildInfo =
-  return OnBuildInfo(rawContents: t.rawArg)
+  return OnBuildInfo(raw: t.rawArg, startLine: t.startLine, endLine: t.endLine)
 
 proc `$`*(p: TopLevelToken): string =
   result = "[" & $(p.kind) & " @" & $(p.startLine)
@@ -642,7 +655,10 @@ proc parseHashLine(ctx: DockerParse, line: string) =
     arg  = unicode.strip(line[eqLoc + 1 .. ^1])
     tok  = ctx.newTok(tltDirective)
 
-  tok.directive = DockerDirective(name: name, rawArg: arg)
+  tok.directive = DockerDirective(name:      name,
+                                  rawArg:    arg,
+                                  startLine: ctx.curLine,
+                                  endLine:   ctx.curLine)
   if name == "escape":
     case arg.runeLen()
     of 1:
@@ -695,10 +711,11 @@ proc parseCommandLine(ctx: DockerParse) =
     cmd = ctx.cachedCommand
     cmd.rawArg &= line
     cmd.continuationLines.add(ctx.curLine)
+    cmd.endLine = ctx.curLine
   else:
     let tok = ctx.newTok(tltCommand)
     # Not parsing the command until after we read the joined lines
-    cmd = DockerCommand(rawArg: line)
+    cmd = DockerCommand(rawArg: line, startLine: ctx.curLine, endLine: ctx.curLine)
     ctx.commands.add(cmd)
     tok.cmd = cmd
 
@@ -730,10 +747,10 @@ proc topLevelLex(ctx: DockerParse) =
       ctx.parseHashLine(line)
 
 proc baseDockerParse*(s: Stream): DockerParse =
-  result = DockerParse(stream: s, sourceLines: s.readAll().split("\n"),
+  result = DockerParse(stream: s, sourceLines: s.readAll().splitLines(),
                        currentEscape: Rune('\\'))
-
-  for k, v in envPairs(): result.envs[k] = v
+  for k, v in envPairs():
+    result.envs[k] = v
   result.topLevelLex()
 
 template firstFromCheck() =
@@ -790,7 +807,8 @@ proc parseAndEval*(s:      Stream,
       firstFromCheck()
       res.add(parse.parseCmd(cmd))
     of "USER":
-      res.add(DfUserInfo(str: unicode.strip(cmd.rawArg)))
+      firstFromCheck()
+      res.add(parse.parseUserInfo(cmd))
     of "ONBUILD":
       firstFromCheck()
       res.add(parse.parseOnBuild(cmd))
@@ -819,7 +837,6 @@ proc evalAndExtractDockerfile*(ctx: DockerInvocation) =
   var
     labels:     OrderedTable[string, string]
     section:    DockerFileSection
-    itemFrom:   FromInfo
 
   # Note: we currently aren't using this rn.
   ctx.dfSectionAliases = OrderedTable[string, DockerFileSection]()
@@ -837,21 +854,20 @@ proc evalAndExtractDockerfile*(ctx: DockerInvocation) =
           item.stopHere = true
           return # Don't keep going!!!
 
+      # wrap up previous section
       if section != nil:
-        # For the section we were previously processing, if it has an alias,
-        # then add it to a cache so we can look up if needed.
-        if section.alias != "":
-          ctx.dfSectionAliases[section.alias] = section
-        else:
-          discard # No alias.
-      section = DockerFileSection()
+        # last section ends when new one begins
+        section.endLine = item.startLine - 1
+
+      section = DockerFileSection(startLine: item.startLine, endLine: item.endLine)
+      section.image = parse.evalOrReturnEmptyString(item.image, errors)
+      if item.tag.isSome():
+        section.image &= ":" & parse.evalSubstitutions(item.tag.get(), errors)
+      section.alias = parse.evalOrReturnEmptyString(item.asArg, errors)
+
       ctx.dfSections.add(section)
-      itemFrom = item
-      section.image = parse.evalOrReturnEmptyString(itemFrom.image, errors)
-      if itemFrom.tag.isSome():
-        section.image &= ":" &
-                 parse.evalSubstitutions(itemFrom.tag.get(), errors)
-      section.alias = parse.evalOrReturnEmptyString(itemFrom.asArg, errors)
+      if section.alias != "":
+          ctx.dfSectionAliases[section.alias] = section
     elif obj of EntryPointInfo:
       section.entryPoint = EntryPointInfo(obj)
     elif obj of CmdInfo:
@@ -865,6 +881,10 @@ proc evalAndExtractDockerfile*(ctx: DockerInvocation) =
         labels[k] = v
     # TODO: when we support CopyInfo, we need to add a case for it here
     # to save the source location as a hint for where to look for git info
+
+  if section != nil:
+    # last section endLine is the last line
+    section.endLine = len(parse.sourceLines) - 1
 
   # might have had errors walking the Dockerfile commands
   for err in errors:

--- a/tests/chalk/runner.py
+++ b/tests/chalk/runner.py
@@ -310,8 +310,9 @@ class Chalk:
         virtual: bool = False,
         config: Optional[Path] = None,
         # suppress output since all we want is the chalk report
-        log_level: ChalkLogLevel = "none",
+        log_level: ChalkLogLevel = "trace",
         env: Optional[dict[str, str]] = None,
+        ignore_errors: bool = False,
     ) -> ChalkProgram:
         return self.run(
             command="insert",
@@ -320,6 +321,7 @@ class Chalk:
             virtual=virtual,
             log_level=log_level,
             env=env,
+            ignore_errors=ignore_errors,
         )
 
     def extract(
@@ -328,7 +330,7 @@ class Chalk:
         expected_success: bool = True,
         ignore_errors: bool = False,
         config: Optional[Path] = None,
-        log_level: ChalkLogLevel = "error",
+        log_level: ChalkLogLevel = "trace",
         env: Optional[dict[str, str]] = None,
     ) -> ChalkProgram:
         return self.run(
@@ -345,7 +347,7 @@ class Chalk:
         return self.run(
             command="exec",
             exec_command=artifact,
-            log_level="error",
+            log_level="trace",
             as_parent=as_parent,
         )
 
@@ -353,7 +355,7 @@ class Chalk:
         return self.run(
             command="delete",
             target=artifact,
-            log_level="error",
+            log_level="trace",
         )
 
     def dump(self, path: Optional[Path] = None) -> ChalkProgram:
@@ -374,7 +376,7 @@ class Chalk:
         use_embedded: bool = False,
         expected_success: bool = True,
         ignore_errors: bool = False,
-        log_level: ChalkLogLevel = "error",
+        log_level: ChalkLogLevel = "trace",
         stdin: Optional[bytes] = None,
     ) -> ChalkProgram:
         hash = sha256(self.binary)
@@ -412,7 +414,7 @@ class Chalk:
         config: Optional[Path] = None,
         buildkit: bool = True,
         secrets: Optional[dict[str, Path]] = None,
-        log_level: ChalkLogLevel = "none",
+        log_level: ChalkLogLevel = "trace",
         env: Optional[dict[str, str]] = None,
         run_docker: bool = True,
     ) -> tuple[str, ChalkProgram]:

--- a/tests/data/dockerfiles/valid/entrypoint/json.Dockerfile
+++ b/tests/data/dockerfiles/valid/entrypoint/json.Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+ENTRYPOINT ["echo"]
+CMD ["hello"]

--- a/tests/data/dockerfiles/valid/entrypoint/string.Dockerfile
+++ b/tests/data/dockerfiles/valid/entrypoint/string.Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+ENTRYPOINT set -x && echo hello
+CMD foo # should not be used

--- a/tests/data/nginx/server.conf
+++ b/tests/data/nginx/server.conf
@@ -1,0 +1,11 @@
+server {
+    listen 8586 default_server;
+    listen [::]:8586 default_server;
+    server_name _;
+    access_log /dev/stdout;
+    location / {
+        proxy_pass http://server:8585/;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+    }
+}

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -137,7 +137,7 @@ def test_insert_extract_delete(copy_files: list[Path], chalk: Chalk):
     )
 
     # delete
-    delete = chalk.run(command="delete", target=artifact, log_level="none")
+    delete = chalk.run(command="delete", target=artifact)
     assert delete.report["_OPERATION"] == "delete"
 
     for key in ["HASH", "_OP_ARTIFACT_PATH", "_OP_ARTIFACT_TYPE"]:
@@ -169,7 +169,7 @@ def test_version(chalk: Chalk):
 
 
 def test_env(chalk: Chalk):
-    result = chalk.run(command="env", log_level="error")
+    result = chalk.run(command="env")
     report = result.report
 
     # fields to check: platform, hostinfo, nodename

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -65,7 +65,12 @@ def test_composable_valid(
 
     # basic check insert operation
     bin_path = copy_files[0]
-    _insert = chalk_copy.insert(artifact=bin_path)
+    _insert = chalk_copy.insert(
+        artifact=bin_path,
+        # compliance by default sends reports to localhost
+        # which will error here
+        ignore_errors=True,
+    )
     for report in _insert.reports:
         assert report["_OPERATION"] == "insert"
 
@@ -160,7 +165,6 @@ def test_composable_invalid(
         config=(configs / test_config_file).absolute(),
         replace=replace,
         stdin=b"\n" * 2**15,
-        log_level="error",
         expected_success=False,
     )
     assert expected_error in _load.stderr.decode()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,7 +136,6 @@ def test_load_url(
 ):
     chalk_copy.load(
         f"{server_chalkdust}/{path}",
-        log_level="trace",
         expected_success=expected_success,
     )
 
@@ -178,7 +177,6 @@ def test_external_configs(
 ):
     result_config = chalk_copy.run(
         command="env",
-        log_level="error",
         config=CONFIGS / config_path,
         expected_success=expected_success,
         ignore_errors=True,
@@ -192,7 +190,6 @@ def test_external_configs(
 
     result_external = chalk_copy.run(
         command="env",
-        log_level="error",
         expected_success=expected_success,
         ignore_errors=True,
     )

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -29,7 +29,6 @@ def test_exec_unchalked(
     exec_proc = chalk.run(
         command="exec",
         exec_command=bin_path,
-        log_level="none",
         as_parent=as_parent,
     )
     # first line must be linux
@@ -71,7 +70,6 @@ def test_exec_chalked(
     exec_proc = chalk.run(
         command="exec",
         exec_command=bin_path,
-        log_level="none",
         as_parent=as_parent,
     )
     # first line must be linux

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -60,7 +60,7 @@ def test_repo(
         .tag(f"{random_hex}-2", tag_message if set_tag_message else None)
     )
     artifact = copy_files[0]
-    result = chalk_copy.insert(artifact, log_level="trace")
+    result = chalk_copy.insert(artifact)
     author = re.compile(rf"^{git.author} \d+ [+-]\d+$")
     committer = re.compile(rf"^{git.committer} \d+ [+-]\d+$")
     assert result.mark.has(
@@ -90,7 +90,7 @@ def test_empty_repo(
 ):
     Git(tmp_data_dir).init()
     artifact = copy_files[0]
-    result = chalk_copy.insert(artifact, log_level="trace")
+    result = chalk_copy.insert(artifact)
     assert result.mark.has(
         BRANCH=MISSING,
         COMMIT_ID=MISSING,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -141,7 +141,6 @@ def test_imds(
     insert = chalk.insert(
         bin_path,
         config=CONFIGS / "imds.c4m",
-        log_level="trace",
         env={"VENDOR": str(tmp_file)},
     )
     assert insert.report.contains(
@@ -228,7 +227,6 @@ def test_ecs(
     insert = chalk.insert(
         bin_path,
         env={"ECS_CONTAINER_METADATA_URI": f"{server_imds}/ecs"},
-        log_level="trace",
     )
     assert insert.report.contains(
         {
@@ -263,7 +261,6 @@ def test_lambda(
             "AWS_LAMBDA_LOG_STREAM_NAME": "2023/12/25/[$LATEST]f42d28eb350e42a1b840ad55fd5232fe",
             "AWS_DEFAULT_REGION": "us-east-1",
         },
-        log_level="trace",
     )
     top, meta = (
         (
@@ -317,7 +314,7 @@ def test_imds_ecs(
         bin_path,
         config=CONFIGS / "imds.c4m",
         env={
-            "ECS_CONTAINER_METADATA_URI": "foobar",
+            "ECS_CONTAINER_METADATA_URI": f"{server_imds}/ecs",
             "VENDOR": str(tmp_file),
         },
     )
@@ -325,9 +322,9 @@ def test_imds_ecs(
         {
             "_OP_CLOUD_PROVIDER": "aws",
             "_OP_CLOUD_PROVIDER_SERVICE_TYPE": "aws_ecs",
-            "_OP_CLOUD_PROVIDER_ACCOUNT_INFO": "123456789012",
+            "_OP_CLOUD_PROVIDER_ACCOUNT_INFO": "111122223333",
             "_OP_CLOUD_PROVIDER_IP": "203.0.113.25",
-            "_OP_CLOUD_PROVIDER_REGION": "us-east-1",
+            "_OP_CLOUD_PROVIDER_REGION": "us-west-2",
             "_OP_CLOUD_PROVIDER_INSTANCE_TYPE": "t2.medium",
             "_OP_CLOUD_PROVIDER_TAGS": {
                 "Name": "foobar",
@@ -630,7 +627,6 @@ def test_tech_stack(chalk_copy: Chalk, copy_files: list[Path]):
     result = chalk_copy.insert(
         bin_path,
         config=CONFIGS / "techstack.c4m",
-        log_level="trace",
     )
     assert result.mark.has(
         INFERRED_TECH_STACKS={"language": {"PHP", "Nim"}},

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -112,7 +112,6 @@ def test_s3(tmp_data_dir: Path, copy_files: list[Path], chalk: Chalk):
     proc = chalk.insert(
         config=config,
         artifact=artifact,
-        log_level="info",
         env={"AWS_S3_BUCKET_URI": "s3://crashoverride-chalk-tests/sink-test.json"},
     )
 
@@ -257,7 +256,6 @@ def _test_server(
         target=artifact,
         config=config,
         use_embedded=False,
-        log_level="trace",
         env=env,
     )
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -154,6 +154,7 @@ def test_post_wrong_method(
             "CHALK_USAGE_URL": f"{server_http}/redirect",
             "CHALK_POST_URL": f"{server}/report",
         },
+        ignore_errors=True,
     )
     assert result
     metadata_id = result.mark["METADATA_ID"]


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

any docker build with `ENTRYPOINT` defined in base image is not wrapped correctly

## Description

This recursively looks up entrypoints in all base images
from the dockerfile build target. If ENTRYPOINT/CMD/SHELL
is not found in the dockerfile, base image is inspected
to find that. This allows to correctly wrap all builds
as we know exactly how to wrap existing entrypoints.
This in particular will fix the issue for non-shell
ENTRYPOINTs such as for lambda wrappers which expect
CMD to be a python module argument.

In addition this fixes:

* adding docker statements within the target dockerfile section
  boundary. Previously it was always added at the end of Dockerfile
* it honors any --build-arg as passed in via CLI in order
  to eval env vars in the Dockerfile (needed for base image inspection)
* improves error message when docker build fails and fallback is used.
  now exception message will be showed.
* base image config is queried directly from the registry
  via buildx imagetools. This allows to avoid any local docker
  state changes. For example `docker pull alpine --platform=linux/arm64`
  will overwrite local `alpine` image to use arm which can impact
  future builds.
* switching all tests to use trace log level by default.
  this actually found a bug in multi-platform builds as --load
  was not being used by default and so full image metadata
  was not inspected

## Testing

```
make tests args="test_docker.py"
```
