### PR TITLE
fix(cmd_version): fix typo of Build Date

### DIFF
--- a/src/commands/cmd_version.nim
+++ b/src/commands/cmd_version.nim
@@ -16,7 +16,7 @@ proc runCmdVersion*() =
   cells.add(@["Commit ID", getChalkCommitId()])
   cells.add(@["Build OS", hostOS])
   cells.add(@["Build CPU", hostCPU])
-  cells.add(@["Build Data", CompileDate])
+  cells.add(@["Build Date", CompileDate])
   cells.add(@["Build Time", CompileTime])
 
   var table = cells.quickTable(verticalHeaders = true, borders = BorderTypical)


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Description

Trivial PR: change "Build Data" to "Build Date" in the output of the version command. All the other rows are "data" too, so I guess it's supposed to say Date.

With the most recent chalk release (chalk 0.3.1, 2024-01-23):

```console
$ chalk version

 ┌┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┬┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
 ┊ Chalk Version  ┊ 0.3.1                                       ┊
 ┊ Commit ID      ┊ 646e9886f2ca74bc0c8b5ebd94d68f7b01d7d0d2    ┊
 ┊ Build OS       ┊ linux                                       ┊
 ┊ Build CPU      ┊ amd64                                       ┊
 ┊ Build Data     ┊ 2024-01-23                                  ┊
 ┊ Build Time     ┊ 17:00:15                                    ┊
 └┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┴┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┘
```

## Testing

None.

The tests don't currently check the exact output of this command, given that this was the only occurrence of "Build Data" in the codebase. But given the recent rendering bug on some platforms, maybe a test for that would be worthwhile adding later.