### PR TITLE
feat: extracting exec command name from args 

### DIFF
--- a/configs/connect.c4m
+++ b/configs/connect.c4m
@@ -51,6 +51,7 @@ attestation.key_provider             = "get"
 docker.wrap_entrypoint               = true
 run_sbom_tools                       = true
 run_sast_tools                       = true
+~exec.command_name_from_args         = true
 ~env_always_show                     = [
   "AWS_ROLE_ARN",
   "KUBERNETES_PORT_443_TCP_ADDR",

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2022,7 +2022,27 @@ well.
     doc: """
 This is the name of the program to run, when running the 'exec' command.  This command will end up being the process you directly spawned; chalking happens in a forked-off process.
 
-You must set a value for this variable or pass the --exec-command-name flag to be able to use the 'exec' command.
+To use `exec` command you must either:
+
+* set a value for this variable
+* pass `--exec-command-name` flag
+* when `command_name_from_arg` is enabled, first arg will be used as command name
+"""
+  }
+
+  field command_name_from_args {
+    type:     bool
+    default:  true
+    shortdoc: "Exec: when empty extract command name from first arg"
+    doc: """
+Allow command name to be extracted from args
+
+```
+chalk exec -- <cmd> <args>
+```
+
+This is especially useful when wrapping other commands by simply
+adding `chalk exec --` prefix.
 """
   }
 

--- a/src/dockerfile.nim
+++ b/src/dockerfile.nim
@@ -643,6 +643,12 @@ proc `$`*(p: TopLevelToken): string =
 proc `$`*(p: DockerParse): string =
   for token in p.tokens: result &= $token & "\n"
 
+proc `$`*(c: CmdInfo): string =
+  if c.str != "":
+    return c.str
+  else:
+    return $(c.json)
+
 proc newTok(ctx: DockerParse, kind: TopLevelTokenType): TopLevelToken =
   result = TopLevelToken(kind: kind, startLine: ctx.curLine, errors: @[])
   ctx.tokens.add(result)

--- a/src/util.nim
+++ b/src/util.nim
@@ -507,3 +507,7 @@ proc `&`*(a: JsonNode, b: JsonNode): JsonNode =
     result.add(i)
   for i in b.items():
     result.add(i)
+
+proc `&=`*(a: var JsonNode, b: JsonNode) =
+  for i in b.items():
+    a.add(i)


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] https://github.com/crashappsec/chalk/pull/147


## Description

Instead of requiring --exec-command-name, allowing to extract command name from exec args:

```
chalk exec -- <cmd> [...args]
```

This is controlled by new config `exec.command_name_from_args` which is enabled by default.

This allows to simplify docker wrapping. For example for Dockerfile:

```
FROM alpine
CMD ["foo", "bar"]
```

previously wrapping resulted in:

```
FROM alpine
ENTRYPOINT ["/chalk", "--exec-command-name", "foo", "--"]
CMD ["bar"]
```

As `CMD` was being adjusted, it was not intuitive. By allowing command name to be extracted from args, it allows to wrap with:

```
FROM alpine
ENTRYPOINT ["/chalk", "--"]
CMD ["foo", "bar"]
```


## Testing

<!-- What are the steps needed to test this PR? -->
