### PR TITLE
ci: run tests on draft pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
     paths:
       - src/**
       - tests/**


### PR DESCRIPTION


- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

#149

## Description

Before this commit, tests only ran on a draft PR when it was marked as ready for review.

Make the tests run when a draft PR is opened or updated, even if it wasn't marked as ready for review.

Closes: #149

## Testing

I'll see if the tests run while this PR is a draft, but it may not touch enough files.