### PR TITLE
fix: honoring AWS region env vars for s3 sink config

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#9bc76daaaa15b6285c54b046e69bc75ed51038a9"
+requires "https://github.com/crashappsec/con4m#53f5f477dbc98d4e5037f02cf30116ee1686e80a"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       imds:
         condition: service_healthy
     environment:
+      AWS_REGION: ${AWS_REGION:-us-east-1}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_PROFILE: ${AWS_PROFILE:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}

--- a/tests/data/sink_configs/s3.c4m
+++ b/tests/data/sink_configs/s3.c4m
@@ -1,6 +1,7 @@
 sink_config my_s3_config {
   enabled: true
   sink:    "s3"
+  region:  env("AWS_REGION")
   uri:     env("AWS_S3_BUCKET_URI")
   secret:  env("AWS_SECRET_ACCESS_KEY")
   uid:     env("AWS_ACCESS_KEY_ID")


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

Previously if `region` config value was omitted, region was defaulted to `us-east-1` even if either `AWS_DEFAULT_REGION` or `AWS_REGION` were present. This is fixed now in nimutils
