### PR TITLE
fix: showing chalk docker report in github on extract

### DIFF
--- a/src/configs/ioconfig.c4m
+++ b/src/configs/ioconfig.c4m
@@ -26,7 +26,7 @@ custom_report github_group_chalk_time {
   enabled:         false
   report_template: "terminal_insert"
   sink_configs:    ["github_json_group"]
-  use_when:        ["insert", "build"]
+  use_when:        ["insert", "extract", "build", "push"]
 }
 
 if not using_tty() {


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

running `chalk extract` in github does not show any report back:

![image](https://github.com/crashappsec/chalk/assets/932940/8358f78b-80fe-4d49-a6eb-30cab215c2ea)


## Description

this will show the report using github sink filter for `extract` and `push`, same as we do for `build` and `insert`

## Testing

<!-- What are the steps needed to test this PR? -->
