### PR TITLE
fix: honoring CHALK_PASSWORD during chalk setup

### DIFF
--- a/configs/connect.c4m
+++ b/configs/connect.c4m
@@ -31,6 +31,7 @@ custom_report crashoverride {
   ~use_when:        ["insert", "build", "exec"]
 }
 
+use_signing_key_backup_service       = true
 docker.wrap_entrypoint               = true
 run_sbom_tools                       = true
 run_sast_tools                       = true

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2676,7 +2676,7 @@ validate in the transparency log.
 
   field use_signing_key_backup_service {
     type:    bool
-    default: true
+    default: false
     shortdoc: "Use signing key backup service to save & retrieve keys"
     doc: """
 Any signing keys generated or imported are encrypted by a randomly


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

env var`CHALK_PASSWORD` is not honored during `chalk setup`. as such if we attempt to use it in CI, new password is generated each time regardless of env var.

## Description

If `CHALK_PASSWORD` is set, previously it was ignored during chalk setup and another password was always used.

This will allow also enabling cosigning much easier in CI as consistent chalk password can be provided to `chalk setup`.

In addition disabling signing key backup service as that is only accessible via crashoverride.run and we can make it enabled there by default. Otherwise doing chalk setup locally without connect.c4m shows not-applicable errors.

## Testing

```
export CHALK_PASSWORD=foobar
./chalk setup --trace
```
