### PR TITLE
fix: chalk setup does not save existing keys

### DIFF
--- a/configs/connect.c4m
+++ b/configs/connect.c4m
@@ -31,6 +31,7 @@ custom_report crashoverride {
   ~use_when:        ["insert", "build", "exec"]
 }
 
+use_signing_key_backup_service       = true
 docker.wrap_entrypoint               = true
 run_sbom_tools                       = true
 run_sast_tools                       = true

--- a/src/attestation.nim
+++ b/src/attestation.nim
@@ -512,10 +512,7 @@ proc attemptToLoadKeys*(silent=false): bool =
   cosignLoaded = true
 
   # Ensure any changed chalk keys are saved to self
-  let savedCommandName = getCommandName()
-  setCommandName("setup")
-  result = selfChalk.writeSelfConfig()
-  setCommandName(savedCommandName)
+  result = saveSigningSetup(pubKey, priKey, true)
 
   return true
 

--- a/src/commands/cmd_setup.nim
+++ b/src/commands/cmd_setup.nim
@@ -49,4 +49,3 @@ proc runCmdSetup*(gen, load: bool) =
   else:
     error("Failed to generate signing keys. Aborting.")
     quitChalk(1)
-    

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2676,7 +2676,7 @@ validate in the transparency log.
 
   field use_signing_key_backup_service {
     type:    bool
-    default: true
+    default: false
     shortdoc: "Use signing key backup service to save & retrieve keys"
     doc: """
 Any signing keys generated or imported are encrypted by a randomly


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

When `chalk.pub`/`chalk.key` and `CHALK_PASSWORD` is already provided, chalk would not save them into chalkmark. Chalkmark was only updated when new key material was being generated. As such it was not possible to reuse existing keys aside from sharing binary itself.

## Testing

```
➜ make tests args="test_command.py::test_setup_existing_keys --logs --pdb"
```
