### PR TITLE
fix: handling non-json responses from signing backup service

### DIFF
--- a/src/attestation.nim
+++ b/src/attestation.nim
@@ -5,7 +5,7 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
-import base64, chalkjson, config, httpclient, net, os, selfextract, 
+import base64, chalkjson, config, httpclient, net, os, selfextract,
        sinks, uri, nimutils/sinks
 
 const
@@ -147,7 +147,7 @@ template callTheSigningKeyBackupService(base: string, prKey: string, bodytxt: un
                                  retries           = 2,
                                  firstRetryDelayMs = 100)
 
-  trace("Signing Key Backup Service URL: " & $uri)  
+  trace("Signing Key Backup Service URL: " & $uri)
   trace("Signing Key Backup Service HTTP headers: " & $authHeaders)
   trace("Signing Key Backup Service status code: " & response.status)
   trace("Signing Key Backup Service response: " & response.body)
@@ -196,15 +196,13 @@ proc restoreSigningKeyFromService*(prkey: string): bool =
 
   let response = callTheSigningKeyBackupService(base, prKey, "", HttpGet)
 
-  if not response.code.is2xx():
-    # authentication issue / token expiration - begin reauth
-    if response.code == Http401:
-      # parse json response and save / return values()
-      let jsonNodeReason = parseJson(response.body())
-      trace("JSON body of response from Signing key Backup Service: " & $jsonNodeReason)
-    else:
-      warn("Could not retrieve encrypted signing key: " & response.status & "\n" & "Will not be able to sign / verify.")
-      return false
+  if response.code == Http401:
+    # authentication issue / token expiration
+    trace("JSON body of response from Signing key Backup Service: " & response.body())
+    return false
+  elif not response.code.is2xx():
+    warn("Could not retrieve encrypted signing key: " & response.status & "\n" & "Will not be able to sign / verify.")
+    return false
 
   var
     body:    string
@@ -214,7 +212,7 @@ proc restoreSigningKeyFromService*(prkey: string): bool =
     hexBits = response.body()
     body    = parseHexStr($hexBits)
 
-    if len(body) != 40: 
+    if len(body) != 40:
       error("Encrypted key returned from server is incorrect size. Received" & $len(body) & "bytes, exected 40 bytes.")
       return false
 
@@ -351,7 +349,7 @@ proc acquirePassword(optfile = ""): bool {.discardable.} =
     if prikey == "":
       return false
 
-  # Use Chalk Data API key to retrieve previously saved encrypted secret 
+  # Use Chalk Data API key to retrieve previously saved encrypted secret
   #  from API, then use retrieved private key to decrypt
   if restoreSigningKeyFromService(prikey):
     return true
@@ -522,7 +520,7 @@ proc attemptToGenKeys*(): bool =
     return false
 
   let keyOutLoc = getKeyFileLoc()
-  
+
   if keyOutLoc == "":
     return false
 
@@ -546,7 +544,7 @@ proc attemptToGenKeys*(): bool =
     cosignLoaded = true
 
     result = saveSigningSetup(pubKey, priKey, true)
-    
+
 proc canAttest*(): bool =
   if getCosignLocation() == "":
     return false


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

https://github.com/crashappsec/chalk/issues/186

## Description

not in all cases service returns valid json for non-200 responses and so we should not parse it assuming it has valid json which caused segfault

## Testing

point signing service to dummy endpoint which doesnt return json back
