### PR TITLE
fix(cosign): not acquiring password for signature validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Fixes possible exception when signing backup service
   would return non-json response
   [#189](https://github.com/crashappsec/chalk/pull/189)
+- Signing key backup service is only called for chalk
+  commands which require cosign private key -
+  insert/build/push.
+  As a result other commands such as `exec` do not interact
+  with the backup service.
+  [#191](https://github.com/crashappsec/chalk/pull/191)
 
 ## 0.3.2
 

--- a/src/attestation.nim
+++ b/src/attestation.nim
@@ -315,7 +315,7 @@ proc commitPassword(pri: string, gen: bool) =
     printIt = not storeIt
 
   if storeIt:
-    # If the manager doesn't work, then we need to fall back.
+    # If the backup service doesn't work, then we need to fall back.
     if not cosignPw.backupSigningKeyToService(pri):
       error("Could not store password. Either try again later, or " &
         "use the below password with the CHALK_PASSWORD environment " &
@@ -491,23 +491,25 @@ proc loadSigningSetup(): bool =
   cosignLoaded = true
   return cosignLoaded
 
-proc attemptToLoadKeys*(silent=false): bool =
+proc attemptToLoadKeys*(withPrivateKey=false, silent=false): bool =
   if getCosignLocation() == "":
     return false
 
   let withoutExtension = getKeyFileLoc()
-
   if withoutExtension == "":
       return false
 
-  var
-    pubKey = tryToLoadFile(withoutExtension & ".pub")
-    priKey = tryToLoadFile(withoutExtension & ".key")
-
+  var pubKey = tryToLoadFile(withoutExtension & ".pub")
   if pubKey == "":
     if not silent:
       error("Could not read public key.")
     return false
+
+  if not withPrivateKey:
+    cosignLoaded = true
+    return true
+
+  var priKey = tryToLoadFile(withoutExtension & ".key")
   if priKey == "":
     if not silent:
       error("Could not read public key.")
@@ -570,11 +572,14 @@ proc checkSetupStatus*() =
   # Beyond that, call canAttest()
 
   once:
-    acquirePassword()
-
-    let cmd = getBaseCommandName()
+    let
+      cmd = getBaseCommandName()
+      withPrivateKey = cmd in ["build", "push", "insert"]
     if cmd in ["setup", "help", "load", "dump", "version", "env", "exec"]:
       return
+
+    if withPrivateKey:
+      acquirePassword()
 
     if loadSigningSetup():
       # loadSigningSetup checks for the info we need to sign. If it's true,
@@ -591,7 +596,7 @@ proc checkSetupStatus*() =
 
     if cosignPw != "":
       warn("Found CHALK_PASSWORD; looking for code signing keys.")
-      if not attemptToLoadKeys(silent=true):
+      if not attemptToLoadKeys(withPrivateKey=withPrivateKey, silent=true):
         warn("Could not load code signing keys. Run `chalk setup` to generate")
       return
 
@@ -603,8 +608,8 @@ proc checkSetupStatus*() =
            "get rid of this warning, run:\n" &
            "      `chalk setup --store-password`.")
       warn("The better way is to generate a keypair with `chalk setup` " &
-           "and store the generated password in a secret manager. See " &
-           "`chalk help setup` for more information.")
+           "and store the generated password in a signing key backup service. " &
+           "See chalk help setup` for more information.")
 
 proc writeInToto(info:      DockerInvocation,
                  tag:       string,

--- a/src/commands/cmd_setup.nim
+++ b/src/commands/cmd_setup.nim
@@ -27,12 +27,11 @@ proc runCmdSetup*(gen, load: bool) =
   if load:
     # If we fall back to 'gen' we don't want attemptToLoadKeys
     # to give an error when we don't find keys.
-    if attemptToLoadKeys(silent=gen):
+    if attemptToLoadKeys(withPrivateKey=true, silent=gen):
       doReporting()
       return
     let
       base = getKeyFileLoc()
-
 
     if not gen:
       error("Failed to load signing keys. Aborting.")


### PR DESCRIPTION
cosign service wasnt handling cases when cosign service was not
accessible at all as `safeRequest` was throwing unhandled exception<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

https://github.com/crashappsec/chalk/issues/186

## Description

cosign has 3 pieces of information:

* public key
* encrypted private key
* password to decrypt private key

When loading cosign, all 3 pieces are required. However when validating
already signed signature only public key is required. Currently cosign
setup was always fetching password to decrypt private key. Changed that
to only fetch password for insert/build/push operations as they are the
only operations which can generate a signature.

## Testing

```
➜ cat dummy.c4m
log_level: "trace"
use_signing_key_backup_service = true
signing_key_backup_service_url = "http://localhost:8000"
docker.wrap_entrypoint = true
auth_config crashoverride {
  auth:  "jwt"
  token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
}

➜ rm chalk; make; rm chalk.key chalk.pub; echo ---------------------; ./chalk load dummy.c4m; echo ----------------------; ./chalk setup; echo ----------------; ./chalk exec --exec-command-name=sleep -- 1
```

