### PR TITLE
build: using scratch for base image of public chalk image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ WORKDIR /chalk
 # vs COPY . /chalk/
 # as repo has other tools and copying only necessary files
 # optimizes docker build cache
-COPY --chmod=755 bin/devmode /chalk/bin/
 COPY config.nims /chalk/
 COPY ./src/ /chalk/src/
 # for chalk commit id
@@ -54,37 +53,11 @@ COPY ./.git/ /chalk/.git/
 RUN yes | nimble $CHALK_BUILD
 
 # -------------------------------------------------------------------
-# published as ghcr.io/crashappsec/chalk:alpine
+# official image with chalk binary for easy copy
+# in other docker builds via:
+# COPY --from=chalk /chalk /chalk
 
-FROM alpine:latest as alpine
-
-# curl     - chalk downloads some things directly with curl for the moment
-# ca-certs - even though chalk is a static binary, in order to do external
-#            calls openssl requires ca-certificates to be installed
-#            on the system
-RUN apk add --no-cache \
-    ca-certificates \
-    curl
-
-COPY --from=build /chalk/chalk /chalk
-
-ENTRYPOINT ["/chalk"]
-
-# -------------------------------------------------------------------
-# published as ghcr.io/crashappsec/chalk:ubuntu
-
-FROM ubuntu:jammy-20230126 as ubuntu
-
-# curl     - chalk downloads some things directly with curl for the moment
-# ca-certs - even though chalk is a static binary, in order to do external
-#            calls openssl requires ca-certificates to be installed
-#            on the system
-RUN apt-get update -y && \
-    apt-get install -y \
-        ca-certificates \
-        curl \
-        && \
-    apt-get clean -y
+FROM scratch
 
 COPY --from=build /chalk/chalk /chalk
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

make it easy to copy chalk into other containers

## Description

As chalk is a static binary now there is a no need to release docker image based on any distro as we can just release the raw binary image. This image is not meant to be used directly but is instead meant to be used in other docker builds such as to easily provision docker build images used in CI systems.

Once merged Ill push image to registries

## Testing

```
docker build -t chalk .
```
