### PR TITLE
build: adding -dev support to chalk version

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -1,7 +1,7 @@
 import std/[strformat, strutils]
 from src/config_version import getChalkVersion
 
-version       = getChalkVersion()
+version       = getChalkVersion(withSuffix = false)
 author        = "John Viega"
 description   = "Software artifact metadata to make it easy to tie " &
                 "deployments to source code and collect metadata."

--- a/src/config_version.nim
+++ b/src/config_version.nim
@@ -4,13 +4,17 @@
 ## So we have this separate file for now.
 import std/[os, strscans, strutils]
 
-proc getChalkVersion*(): string =
+proc getChalkVersion*(withSuffix = true): string =
   ## Returns the value of `chalk_version` in `base_keyspecs.c4m`.
   result = ""
   const path = currentSourcePath().parentDir() / "configs" / "base_keyspecs.c4m"
   for line in path.staticRead().splitLines():
     const pattern = """chalk_version$s:=$s"$i.$i.$i$*"$."""
     let (isMatch, major, minor, patch, suffix) = line.scanTuple(pattern)
-    if isMatch and major == 0 and minor in 0..100 and patch in 0..100 and suffix == "":
-      return $major & '.' & $minor & '.' & $patch
+    if isMatch and major >= 0 and minor >= 0 and patch >= 0:
+      let version = $major & '.' & $minor & '.' & $patch
+      if withSuffix:
+        return version & suffix
+      else:
+        return version
   raise newException(ValueError, "Couldn't get `chalk_version` value from " & path)

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -52,7 +52,7 @@
 ##     the more basic per-op stuff such as "_CHALKS" and "ACTION_ID" I did not.
 
 ## CHALK SCHEMA
-chalk_version :=   "0.3.3"
+chalk_version :=   "0.3.3-dev"
 ascii_magic   :=   "dadfedabbadabbed"
 
 # Field starting with an underscore (_) are "system" metadata fields, that


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

dev builds when chalk is not on a release results in showing version as if its for a release

## Description

this will allow to bump version to `*-dev` immediately after the release to denote chalk is for a dev version

this is especially useful for publishing chalk to other platforms such as to docker hub/etc

## Testing

as nimble does not support suffixes, its ignored there:

```
➜ nimble version | tail -n1
0.3.3

➜ make version
0.3.3-dev

➜ ./chalk version 2> /dev/null | grep -i version
 ┊ Chalk Version  ┊ 0.3.3-dev                                   ┊
```
