### PR TITLE
feat: falling back to mozilla CAs when system has no certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Main
 
+### New Features
+
+- Chalk falls back to bundled Mozilla CA Store when there
+  are no system TLS certs to use (e.g. busybox container).
+  [#196](https://github.com/crashappsec/chalk/pull/196)
+
 ### Fixes
 
 - Fixes possible exception when signing backup service

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#d2a081b93d72cad4a86bcd51bbf6fbe4934a845e"
+requires "https://github.com/crashappsec/con4m#ee3df100a930ba4f642ae314640123e742d8f529"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally

--- a/src/attestation.nim
+++ b/src/attestation.nim
@@ -141,16 +141,14 @@ proc callTheSigningKeyBackupService(base:    string,
     authHeaders = auth.implementation.injectHeaders(auth, headers)
 
   # Call the API with authz header - rety twice with backoff
-  uri       = parseUri(url)
-  context   = newContext(verifyMode = CVerifyPeer)
-  client    = newHttpClient(sslContext = context, timeout = timeout)
   try:
-    response = client.safeRequest(url = uri,
-                                  httpMethod        = mth,
-                                  headers           = authHeaders,
-                                  body              = bodytxt,
-                                  retries           = 2,
-                                  firstRetryDelayMs = 100)
+    response = safeRequest(url = url,
+                           httpMethod        = mth,
+                           headers           = authHeaders,
+                           body              = bodytxt,
+                           timeout           = timeout,
+                           retries           = 2,
+                           firstRetryDelayMs = 100)
 
     trace("Signing Key Backup Service URL: " & $uri)
     trace("Signing Key Backup Service HTTP headers: " & $authHeaders)

--- a/src/plugins/awsEcs.nim
+++ b/src/plugins/awsEcs.nim
@@ -25,11 +25,9 @@ if ecsUrl == "":
 proc requestECSMetadata(path: string): Option[Box] =
   let url = ecsUrl & path
   var body = ""
-  info(url)
   try:
     var
-      client = newHttpClient()
-      resp   = client.safeRequest(url)
+      resp   = safeRequest(url)
     if resp.code != Http200:
       error("ecs: " & url & " returned " & resp.status)
       return none(Box)

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -5,7 +5,6 @@
 import json
 from pathlib import Path
 from typing import Any, Callable
-from unittest import mock
 
 import boto3
 import os


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] https://github.com/crashappsec/nimutils/pull/45
- [x] https://github.com/crashappsec/con4m/pull/119

## Issue

```
➜ docker run -it --rm ghcr.io/crashappsec/chalk:0.3.3-dev load https://chalkdust.io/connect.c4m
warn:  ~/.local/chalk/chalk.log: could not resolve sink filename. disabling sink
warn:  default_out: sink is not enabled and cannot be subscribed for topic report
warn:  default_out: sink is not enabled and cannot be subscribed for topic audit
info:  Attempting to load module from: https://chalkdust.io/connect.c4m
error: No SSL/TLS CA certificates found.
```

## Description

this will allow chalk to communicate with external APIs even when system has no certs such as in busybox containers

most of the change is in nimutils and then its bubbled up to con4m and chalk

## Testing

existing tests cover SSL coverage. to test busybox case:

```
➜ docker run -it --rm -v $PWD:$PWD -w $PWD busybox ./chalk --debug load https://chalkdust.io/connect.c4m
```
