### PR TITLE
build(semver): change \u7f to \x7f

### DIFF
--- a/src/semver.nim
+++ b/src/semver.nim
@@ -54,9 +54,9 @@ proc parts(self: Version): (int, int, int, string) =
   # assumping any suffix is for pre-releases which is not ideal
   # correct but it is fine for chalk versions
   # this handles things like 1-dev < 1.0
-  # no suffix is normalized to highest ascii char code \u7f
+  # no suffix is normalized to highest ascii char code \x7f
   # hence it is always greater then any legitimate ascii string
-  let suffix = if self.suffix == "": "\u7f" else: self.suffix
+  let suffix = if self.suffix == "": "\x7f" else: self.suffix
   return (self.major, self.minor, self.patch, suffix)
 
 proc `==`*(self: Version, other: Version): bool =


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

Follow up for https://github.com/crashappsec/chalk/pull/195#discussion_r1483527333 - my review was one minute too slow.

## Description

The intention is to use the last ASCII code point (127 in decimal), to implement basic version precedence.

From the [Nim manual on string literals][manual]:

    `\x` HH      character with hex value HH; exactly two hex digits are allowed
    `\u` HHHH    unicode codepoint with hex value HHHH; exactly four hex digits are allowed
    `\u` {H+}    unicode codepoint; all hex digits enclosed in {} are used for the codepoint

[manual]: https://nim-lang.org/docs/manual.html#lexical-analysis-string-literals

## Testing

n/a.