### PR TITLE
fix(docker): requiring docker >20 for --build-context support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   As a result other commands such as `exec` do not interact
   with the backup service.
   [#191](https://github.com/crashappsec/chalk/pull/191)
+- Fixing docker build attempting to use `--build-context`
+  on older docker versions which did not support that flag.
+  [#207](https://github.com/crashappsec/chalk/pull/207)
 
 ## 0.3.2
 

--- a/src/docker_base.nim
+++ b/src/docker_base.nim
@@ -149,6 +149,8 @@ proc makeFileAvailableToDocker*(ctx:     DockerInvocation,
   if hasUser and chmod == "":
     chmod = "0444"
 
+  let chmodstr = if chmod == "": "" else: "--chmod=" & chmod & " "
+
   if move:
     trace("Making file available to docker via move: " & loc)
   else:
@@ -157,10 +159,6 @@ proc makeFileAvailableToDocker*(ctx:     DockerInvocation,
   if supportsBuildContextFlag():
     once:
       trace("Docker injection method: --build-context")
-
-    var chmodstr = ""
-    if chmod != "":
-      chmodstr = "--chmod=" & chmod & " "
 
     ctx.newCmdLine.add("--build-context")
     ctx.newCmdLine.add("chalkexedir" & $(contextCounter) & "=" & dir & "")
@@ -198,8 +196,8 @@ proc makeFileAvailableToDocker*(ctx:     DockerInvocation,
         copyFile(loc, dstLoc)
         trace("Copied " & loc & " to " & dstLoc)
 
-      if chmod != "" and supportsCopyChmod():
-        ctx.addedInstructions.add("COPY --chmod= " & chmod &
+      if chmodstr != "" and supportsCopyChmod():
+        ctx.addedInstructions.add("COPY " & chmodstr &
                                   file & " " & " /" & newname)
       elif chmod != "":
         # TODO detect user from base image if possible but thats not

--- a/src/docker_base.nim
+++ b/src/docker_base.nim
@@ -101,7 +101,7 @@ template hasBuildx*(): bool =
 
 template supportsBuildContextFlag*(): bool =
   # https://github.com/docker/buildx/releases/tag/v0.8.0
-  getBuildXVersion() >= parseVersion("0.8")
+  getDockerVersion() >= parseVersion("21") and getBuildXVersion() >= parseVersion("0.8")
 
 template supportsCopyChmod*(): bool =
   # > the --chmod option requires BuildKit.


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

https://github.com/crashappsec/chalk/issues/206

## Description

looks like even if buildx is installed in older docker versions, --build-context arg is not supported

cant find release docs for this doc so just going by local version experiments. for reference release docs https://docs.docker.com/engine/release-notes/23.0/

## Testing

```
➜ echo 'FROM alpine' | docker run -i --rm -v ./chalk:/chalk --entrypoint=/chalk -v /var/run/docker.sock:/var/run/docker.sock docker:20.10.24 docker build -t test  -f - .
```
