### PR TITLE
fix: docker login breaks when docker is chalk binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - Fixing docker build attempting to use `--build-context`
   on older docker versions which did not support that flag.
   [#207](https://github.com/crashappsec/chalk/pull/207)
+- Fixes `echo foo | chalk docker login --password-stdin`
+  as `stdin` was not being closed in the pipe to docker
+  process.
+  [#209](https://github.com/crashappsec/chalk/pull/209)
 
 ## 0.3.2
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SOURCES+=$(shell find src/ -name '*.md')
 SOURCES+=$(shell find ../con4m -name '*.nim' 2> /dev/null)
 SOURCES+=$(shell find ../con4m -name '*.c4m' 2> /dev/null)
 SOURCES+=$(shell find ../nimutils -name '*.nim' 2> /dev/null)
+SOURCES+=$(shell find ../nimutils -name '*.c' 2> /dev/null)
 SOURCES+=src/docs/CHANGELOG.md
 
 VERSION=$(shell cat src/configs/base_keyspecs.c4m \

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#ee3df100a930ba4f642ae314640123e742d8f529"
+requires "https://github.com/crashappsec/con4m#884d82268f891432c7a1fbcbcc25443d3d3b30b0"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

fixes https://github.com/crashappsec/chalk/issues/194

## Description

fixed was in https://github.com/crashappsec/nimutils/pull/46

## Testing

```
echo foo | ./chalk docker login --password-stdin --username=bar
```
