### PR TITLE
ci: add black to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
+    hooks:
+      - id: black
+
   # - repo: local
   #   hooks:
   # - id: licenseheaders

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,14 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 22.12.0 # sync:black:tests/poetry.lock
     hooks:
       - id: black
+
+  - repo: https://github.com/crashappsec/pre-commit-sync
+    rev: 0.1.0.a3
+    hooks:
+      - id: pre-commit-sync
 
   # - repo: local
   #   hooks:


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

closes https://github.com/crashappsec/chalk/issues/213

## Description

automatically validate/fix py formatting issues in PRs
