### PR TITLE
fix: including fix from nimutils for subprocess run

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#884d82268f891432c7a1fbcbcc25443d3d3b30b0"
+requires "https://github.com/crashappsec/con4m#8e8e3ba653f85b8dbd8829fc8e300237b7482e21"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally

--- a/tests/data/configs/docker_cmd.c4m
+++ b/tests/data/configs/docker_cmd.c4m
@@ -1,0 +1,1 @@
+default_command: "docker"

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -721,11 +721,11 @@ def test_docker_diff_user(chalk_default: Chalk):
     assert result
 
 
-def test_docker_default_command(chalk: Chalk, tmp_data_dir: Path):
-    assert chalk.load(CONFIGS / "docker_cmd.c4m")
+def test_docker_default_command(chalk_copy: Chalk, tmp_data_dir: Path):
+    assert chalk_copy.load(CONFIGS / "docker_cmd.c4m")
     expected = Docker.version()
     docker = tmp_data_dir / "docker"
-    shutil.copy(chalk.binary, docker)
+    shutil.copy(chalk_copy.binary, docker)
     actual = run([str(docker), "--version"])
     assert actual
     assert actual.text == expected.text

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -4,6 +4,7 @@
 # (see https://crashoverride.com/docs/chalk)
 import itertools
 import platform
+import shutil
 import time
 from contextlib import ExitStack
 from pathlib import Path
@@ -30,6 +31,7 @@ from .conf import (
 )
 from .utils.docker import Docker
 from .utils.log import get_logger
+from .utils.os import run
 
 
 logger = get_logger()
@@ -717,4 +719,13 @@ def test_docker_diff_user(chalk_default: Chalk):
     )
     result = ChalkProgram.from_program(program)
     assert result
-    assert not result.errors
+
+
+def test_docker_default_command(chalk: Chalk, tmp_data_dir: Path):
+    assert chalk.load(CONFIGS / "docker_cmd.c4m")
+    expected = Docker.version()
+    docker = tmp_data_dir / "docker"
+    shutil.copy(chalk.binary, docker)
+    actual = run([str(docker), "--version"])
+    assert actual
+    assert actual.text == expected.text

--- a/tests/utils/docker.py
+++ b/tests/utils/docker.py
@@ -186,6 +186,10 @@ class Docker:
         )
 
     @staticmethod
+    def version() -> Program:
+        return run(["docker", "--version"])
+
+    @staticmethod
     def pull(tag: str) -> Program:
         return run(["docker", "pull", tag])
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

`docker --version` hangs when `docker` is a chalk binary

## Description

previously subprocess run() wasn't being ended in all cases which is fixed now. it surfaced when doing `docker --version` when docker was a chalk binary as there was no IO to wrap in that case command was hanging in the switchboard loop

## Testing

```
make
cp chalk docker
./docker --version
```
