### PR TITLE
fix: segfault in chalk backup service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Main
 
+### Fixes
+
+- Fixes a segfault when using secrets backup service
+  during `chalk setup`
+  [#220](https://github.com/crashappsec/chalk/pull/220)
+
 ## 0.3.3
 
 ### New Features


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

backup service bug in attestion.nim causes segfault

## Description

the safeRequest refactor now creates and closes the client which wasnt correctly refactored and wasnt caught.

there are no tests for this and its not easy to add them as it will require adding JWTs in the mix. upcoming refactor for signing keys will refactor this and will make it easier to test this


## Testing

```
➜ chalk load configs/connect.c4m
➜ rm *.{key,pub}; ./chalk setup --trace
```
