### PR TITLE
feat: adding log before running plugin

### DIFF
--- a/src/collect.nim
+++ b/src/collect.nim
@@ -163,6 +163,7 @@ proc collectChalkTimeArtifactInfo*(obj: ChalkObj) =
 
   trace("Collecting chalk-time data.")
   for plugin in getAllPlugins():
+    trace("Running plugin: " & plugin.name)
     if plugin == obj.myCodec:
       trace("Filling in codec info")
       if "CHALK_ID" notin data:


### PR DESCRIPTION
this is helpful to see what plugin is currently running as some of them such as tech stack can take some time and otherwise looking at logs you cant tell what is currently running and therefore if its external call timing out or a slow plugin is currently being called
