### PR TITLE
fix: honor $CHALK_COMPONENT_CACHE in confload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fixes a segfault when using secrets backup service
   during `chalk setup`
   [#220](https://github.com/crashappsec/chalk/pull/220)
+- Honoring cache component cache on chalk conf load
+  [#222](https://github.com/crashappsec/chalk/pull/222)
 
 ## 0.3.3
 

--- a/src/confload.nim
+++ b/src/confload.nim
@@ -70,17 +70,19 @@ proc getEmbeddedConfig(): string =
         else:
           trace("No embedded chalk mark.")
         trace("Using the default user config.  See 'chalk dump' to view.")
+      # component must be loaded before parameters
+      # otherwise loading params initializes the component first (if not present yet)
+      # which will attempt to fetch the component from source (e.g. url)
+      if selfChalk.extract.contains("$CHALK_COMPONENT_CACHE"):
+        let
+          componentInfo = selfChalk.extract["$CHALK_COMPONENT_CACHE"]
+          unpackedInfo  = unpack[OrderedTableRef[string, string]](componentInfo)
+        loadCachedComponents(unpackedInfo)
       if selfChalk.extract.contains("$CHALK_SAVED_COMPONENT_PARAMETERS"):
         let params = selfChalk.extract["$CHALK_SAVED_COMPONENT_PARAMETERS"]
         installComponentParams(unpack[seq[Box]](params))
       else:
         trace("No saved component parameters; skipping install.")
-      if selfChalk.extract.contains("$CHALK_COMPONENT_CACHE"):
-        let
-          componentInfo = selfChalk.extract["$CHALK_COMPONENT_CACHE"]
-          unpackedInfo  = unpack[OrderedTableRef[string, string]](componentInfo)
-
-        loadCachedComponents(unpackedInfo)
   else:
     trace("Since this binary can't be marked, using the default config.")
 


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

containers were failing to startup as `connect.c4m` was changed after the release in the chalkdust bucket

## Description

when loading components on chalk startup, if a component was from a URL and had any parameters, it would be re-fetched from the URL again which is not desired as the URL content can change hence causing a failure.

this was caused by loading parameters before loading component source which would initialize the component and if missing would re-fetch it again from URL. By loading source first it removes that possibility.

## Testing

load components from URL and then ensure they dont change on load
