### PR TITLE
fix: fixing sink segfaulting with mismatched http schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   [#220](https://github.com/crashappsec/chalk/pull/220)
 - Honoring cache component cache on chalk conf load
   [#222](https://github.com/crashappsec/chalk/pull/222)
+- Fixes a segfault when accidentally providing `http://`
+  URL to a sink instead of `https://`
+  [#223](https://github.com/crashappsec/chalk/pull/223)
 
 ## 0.3.3
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#8e8e3ba653f85b8dbd8829fc8e300237b7482e21"
+requires "https://github.com/crashappsec/con4m#ec18af0716633d966b8aa0bb7d69ae6a49d18ec3"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     working_dir: /chalk/server
     volumes:
       - .:/chalk
+    environment:
+      REDIRECT: https://tls.chalk.local:5858
     healthcheck:
       test:
         - CMD-SHELL

--- a/server/server/api.py
+++ b/server/server/api.py
@@ -6,6 +6,7 @@ import dataclasses
 import logging.config
 from typing import Any, Optional
 
+import os
 import sqlalchemy
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
@@ -63,6 +64,17 @@ async def redirect_to_docs():
 @app.get("/version")
 async def version():
     return {"version": __version__}
+
+
+if os.environ.get("REDIRECT"):
+
+    @app.post("/redirect")
+    async def redirect():
+        redirect = os.environ.get("REDIRECT")
+        return RedirectResponse(
+            f"{redirect}/report",
+            status_code=status.HTTP_301_MOVED_PERMANENTLY,
+        )
 
 
 @app.post("/ping")

--- a/src/reportcache.nim
+++ b/src/reportcache.nim
@@ -100,7 +100,7 @@ template tracePublish(topic, m: string, prevSuccesses = false) =
   if startSubscriptions == 0 and prevSuccesses:
     discard
   else:
-    var n = publish(topic, msg)
+    let n = publish(topic, msg)
 
     if topic in quietTopics:
       # Here we DO Will not get added to the report cache.

--- a/tests/data/sink_configs/post_http_local.c4m
+++ b/tests/data/sink_configs/post_http_local.c4m
@@ -1,4 +1,4 @@
-crashoverride_usage_reporting_url = "http://chalk.crashoverride.local:8585/ping"
+crashoverride_usage_reporting_url = env("CHALK_USAGE_URL")
 log_level = "trace"
 
 auth_config my_basic_config {

--- a/tests/data/sink_configs/post_https_local.c4m
+++ b/tests/data/sink_configs/post_https_local.c4m
@@ -1,4 +1,4 @@
-crashoverride_usage_reporting_url = "https://chalk.crashoverride.local:8585/ping"
+crashoverride_usage_reporting_url = env("CHALK_USAGE_URL")
 log_level = "trace"
 
 auth_config my_jwt_config {


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] https://github.com/crashappsec/nimutils/pull/60

## Issue

https://github.com/crashappsec/nimutils/pull/60

## Description

chalk would segfault when accidentally providing `http` scheme to `https` server which would redirect `http`->`https`
