### PR TITLE
feat: allow bypassing chalk via CHALK_BYPASS environment variable

### DIFF
--- a/src/bypass.nim
+++ b/src/bypass.nim
@@ -1,0 +1,66 @@
+import std/[os, osproc, parseopt, strformat, strutils]
+
+type
+  bypassCmd = enum
+    bcNone
+    bcDocker = "docker"
+    bcExec = "exec"
+
+proc err(msg: string) =
+  ## Writes `msg` to stderr, then quits with an exit code of 1.
+  stderr.writeLine &"error: {msg}"
+  quit 1
+
+proc handleBypass*() =
+  ## Does nothing when the `CHALK_BYPASS` environment variable is unset.
+  ##
+  ## However, if that environment variable is set, and the command is:
+  ##
+  ## - `docker`: executes the rest of the command line with docker, without chalk.
+  ##
+  ## - `exec`: executes the rest of the command line, without chalk.
+  ##
+  ## - Something else or missing: quits with exit code 1.
+  const bypassEnvVar = "CHALK_BYPASS"
+
+  if getEnv(bypassEnvVar) == "":
+    return
+
+  var p = initOptParser()
+  var bypassCmd = bcNone
+  const msg =
+    &"{bypassEnvVar} was set, but the chalk command is not '{bcDocker}' or '{bcExec}'. Quitting."
+
+  for kind, key, _ in getopt(p):
+    case kind
+    of cmdArgument:
+      case key
+      of $bcDocker, $bcExec:
+        bypassCmd = parseEnum[bypassCmd](key)
+        break
+      else:
+        err(msg)
+    of cmdShortOption, cmdLongOption:
+      # Ignore any option that appears before an argument.
+      discard
+    of cmdEnd:
+      err(msg)
+
+  if bypassCmd == bcNone:
+    err(msg)
+
+  # Run the rest of the command line that appears after `docker` or `exec`.
+  let cmd =
+    case bypassCmd
+    of bcDocker:
+      $bcDocker & " " & cmdLineRest(p)
+    of bcExec:
+      cmdLineRest(p)
+    of bcNone:
+      doAssert false
+      "" # Cannot happen.
+
+  stderr.writeLine &"chalk: the {bypassEnvVar} environment variable is set."
+  stderr.writeLine &"Running the following command without chalk:\n  {cmd}"
+  let exitCode = execCmd(cmd)
+  quit exitCode

--- a/src/chalk.nim
+++ b/src/chalk.nim
@@ -7,10 +7,11 @@
 
 # Note that imports cause topics and plugins to register.
 {.warning[UnusedImport]: off.}
-import "."/[config, confload, commands, norecurse, sinks, docker_base,
+import "."/[bypass, config, confload, commands, norecurse, sinks, docker_base,
             attestation, util]
 
 when isMainModule:
+  handleBypass()        # bypass.nim
   setupSignalHandlers() # util.nim
   setupTerminal()       # util.nim
   ioSetup()             # sinks.nim


### PR DESCRIPTION
## Description

@nettrino and I had a good discussion earlier today about bypassing chalk (issue https://github.com/crashappsec/chalk/issues/224). Here's a sketch of a possible implementation.

This is the "avoid as much chalk as possible" flavor, optimizing for a completely independent, minimal code path.

It allows bypassing the exec command:

```console
$ CHALK_BYPASS=1 chalk exec echo hi
chalk: the CHALK_BYPASS environment variable is set.
Running the following command without chalk:
  echo hi
hi
```

and bypassing the docker command:

```console
$ CHALK_BYPASS=1 chalk docker --version
chalk: the CHALK_BYPASS environment variable is set.
Running the following command without chalk:
  docker --version
Docker version 25.0.3, build 4debf411d1
```

and errors when the command is not docker or exec:

```console
$ CHALK_BYPASS=1 chalk version
error: CHALK_BYPASS was set, but the chalk command is not 'docker' or 'exec'. Quitting.
```

Refs: #224

## Testing

Run commands like illustrated above.

## To-do

If we wanted to continue in this direction:

- [ ] Tests
- [ ] Docs
- [ ] Consider handling `chalk` being named `docker`