### PR TITLE
fix: loading cosign keys correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   [#229](https://github.com/crashappsec/chalk/pull/229)
 - Fixes chalking zip file reporting git-repo keys
   [#230](https://github.com/crashappsec/chalk/issues/230)
+- Fixes cosign not honoring `CHALK_PASSWORD` in all operations
+  [#232](https://github.com/crashappsec/chalk/pull/232)
 
 ## 0.3.3
 

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -1782,6 +1782,7 @@ running insert commands.
   key.METADATA_ID.use                         = true
   key.SIGNATURE.use                           = true
   key._SIGNATURE.use                          = true
+  key._VALIDATED_SIGNATURE.use                = true
   key._VIRTUAL.use                            = true
   key._CURRENT_HASH.use                       = true
   key._IMAGE_ID.use                           = true


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

fixes https://github.com/crashappsec/chalk/issues/231

## Description

withPrivateKey wasnt being honored in all places where cosign key material needed to be loaded:

* it was always trying to load private key even for commands not requiring it
* it didnt load private key for docker command hence docker builds werent being signed


## Testing

<!-- What are the steps needed to test this PR? -->
see issue above