### PR TITLE
doc: fix .cfg -> .c4m extension in docs

### DIFF
--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -1363,10 +1363,10 @@ custom_report mdlog {
 }
 ```
 
-We can test this configuration by putting it in `test.cfg` then:
+We can test this configuration by putting it in `test.c4m` then:
 
 ```
-chalk load test.cfg
+chalk load test.c4m
 echo "#!/bin/bash" > test_mark
 chalk test_mark
 cat mdlog.jsonl


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

fixes https://github.com/crashappsec/chalk/issues/158
