### PR TITLE
fix: chalk not parsing some git ref objects

### DIFF
--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -373,7 +373,7 @@ proc findPackedGitCommit(vcsDir, commitId: string): string =
 proc loadObject(info: RepoInfo, refId: string): Table[string, string] =
   let
     objFile     = info.vcsDir.joinPath(gitObjects, refId[0 ..< 2], refId[2 .. ^1])
-    objFileData = tryToLoadFile(objFile).strip()
+    objFileData = tryToLoadFile(objFile)
 
   var objData: string
   try:
@@ -442,7 +442,7 @@ proc loadObject(info: RepoInfo, refId: string): Table[string, string] =
       result[gitMessage] = objData[iMessageStart ..< iMessageEnd].strip()
 
   except:
-    warn("unable to retrieve Git ref data: " & refId)
+    warn("unable to retrieve Git ref data: " & refId & " due to: " & getCurrentExceptionMsg())
 
 proc loadAuthor(info: RepoInfo, commitId: string) =
   let fields = info.loadObject(commitId)

--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -49,7 +49,6 @@ const
   keyOrigin        = "ORIGIN_URI"
   keyCommit        = "COMMIT_ID"
   keyCommitSigned  = "COMMIT_SIGNED"
-  keySigned        = "COMMIT_SIGNED"
   keyBranch        = "BRANCH"
   keyAuthor        = "AUTHOR"
   keyAuthorDate    = "DATE_AUTHORED"


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

flaky tests such as https://github.com/crashappsec/chalk/actions/runs/8282914433/job/22664882760

## Description

root was was there was unnecessary .strip() and sometimes git objects end with `\n` which is part of a compressed data-stream hence by removing it zips checksum wasnt able to validate which is why it was making some tests flaky which were asserting git plugin keys

## Testing

looks like chalk v0.3.3 tag ends with newline so interact with chalk repo with that tag being present:

```
➜ cat .git/refs/tags/v0.3.3
fe750922dda1d33c407b41a7aeae7b17acdae78c

➜ cat .git/objects/fe/750922dda1d33c407b41a7aeae7b17acdae78c | hexdump -C | tail -n3
000002f0  c4 33 f5 7d af be 23 df  7d 1a f3 91 df 63 50 ac  |.3.}..#.}....cP.|
00000300  f3 df 26 f2 13 db 38 3e  0a                       |..&...8>.|
00000309
```
