### PR TITLE
fix: requiring region for s3 sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Main
 
+## Breaking Changes
+
+- S3 sinks must specify bucket region
+  [#246](https://github.com/crashappsec/chalk/pull/246)
+
 ## 0.3.4
 
 **Mar 18, 2024**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Breaking Changes
 
-- S3 sinks must specify bucket region
+- S3 sinks must now specify the bucket region. Previously
+  it defaulted to `us-east-1` if the `AWS_REGION` or
+  `AWS_DEFAULT_REGION` environment variables were not set
   [#246](https://github.com/crashappsec/chalk/pull/246)
 
 ## 0.3.4

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -88,7 +88,7 @@ sink s3 {
   ~secret:        true
   ~token:         false
   ~uri:           true
-  ~region:        false
+  ~region:        true
   ~extra:         false
   ~on_write_msg:  false
   shortdoc:       "S3 object storage"
@@ -100,7 +100,7 @@ sink s3 {
 | `secret` | `string` | true | A valid AWS auth token |
 | `token` | `string` | false | AWS session token |
 | `uri` | `string` | true | The URI for the bucket in `s3:` format; see below |
-| `region` | `string` | false | The region (defaults to "us-east-1") |
+| `region` | `string` | true | The region |
 | `extra` | `string` | false | A prefix added to the object path within the bucket |
 
 To ensure uniqueness, each run of chalk constructs a unique object


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

fixes https://github.com/crashappsec/chalk/issues/161

## Description

as buckets are specific to regions, the parameter should be required to avoid any potential aws API issues as otherwise AWS_REGION env vars might not reflect correct bucket region.

## Testing

add s3 sink config without region

## Other

do we think this is an UX regression? or being explicit in s3 sink config is a good thing? my opinion is that explicit config is better. for example consider docker image wrapped with chalk and its configured to send reports to a bucket in us-east-1 but then the container runs in us-west-1 lambda. Lambda will set `AWS_REGION` to us-west-1 hence  sink default region will be incorrect. thoughts?
