### PR TITLE
fix: error docker inspect logs during chalk exec

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 - [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
 - [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
 - [ ] Filled out the template to a useful degree
+- [ ] Updated `CHANGELOG.md` if necessary
 
 ## Issue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   `AWS_DEFAULT_REGION` environment variables were not set
   [#246](https://github.com/crashappsec/chalk/pull/246)
 
+### Fixes
+
+- The Docker codec is now bypassed when "docker" is not
+  installed. Previously, any chalk sub-scan such as
+  during `chalk exec` had misleading error logs.
+  [#248](https://github.com/crashappsec/chalk/pull/248)
+
 ## 0.3.4
 
 **Mar 18, 2024**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixes
 
-- The Docker codec is now bypassed when "docker" is not
+- The Docker codec is now bypassed when `docker` is not
   installed. Previously, any chalk sub-scan such as
   during `chalk exec` had misleading error logs.
   [#248](https://github.com/crashappsec/chalk/pull/248)

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -412,7 +412,6 @@ var
   chalkConfig*:           ChalkConfig
   con4mRuntime*:          ConfigStack
   commandName*:           string
-  dockerExeLocation*:     string = ""
   gitExeLocation*:        string = ""
   sshKeyscanExeLocation*: string = ""
 

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -84,6 +84,7 @@ type
                                c: Option[string]) {.cdecl.}
   Plugin* = ref object
     name*:                     string
+    enabled*:                  bool
     configInfo*:               PluginSpec
     getChalkTimeHostInfo*:     ChalkTimeHostCb
     getChalkTimeArtifactInfo*: ChalkTimeArtifactCb

--- a/src/commands/cmd_extract.nim
+++ b/src/commands/cmd_extract.nim
@@ -7,8 +7,7 @@
 
 ## The `chalk extract` command.
 
-import ".."/[config, collect, reporting, plugins/codecDocker, plugin_api,
-             docker_base]
+import ".."/[config, collect, reporting, plugins/codecDocker, plugin_api]
 
 template processDockerChalkList(chalkList: seq[ChalkObj]) =
   for item in chalkList:
@@ -57,26 +56,22 @@ template coreExtractContainers() =
 
 
 proc runCmdExtract*(path: seq[string]) {.exportc,cdecl.} =
-  setDockerExeLocation()
   setContextDirectories(path)
   initCollection()
   coreExtractFiles(path)
   doReporting()
 
 proc runCmdExtractImages*() =
-  setDockerExeLocation()
   initCollection()
   coreExtractImages()
   doReporting()
 
 proc runCmdExtractContainers*() =
-  setDockerExeLocation()
   initCollection()
   coreExtractContainers()
   doReporting()
 
 proc runCmdExtractAll*(path: seq[string]) =
-  setDockerExeLocation()
   setContextDirectories(path)
   initCollection()
   coreExtractFiles(path)

--- a/src/docker_base.nim
+++ b/src/docker_base.nim
@@ -30,11 +30,10 @@ template extractBoxedDockerHash*(value: Box): Box =
 
 proc getDockerExeLocation*(): string =
   once:
-    trace("Searching PATH for 'docker'")
     let
       dockerConfigPath = chalkConfig.getDockerExe()
       dockerExeOpt     = findExePath("docker",
-                                     configPath = dockerConfigPath,
+                                     configPath      = dockerConfigPath,
                                      ignoreChalkExes = true)
     dockerExeLocation = dockerExeOpt.get("")
     if dockerExeLocation == "":

--- a/src/plugin_api.nim
+++ b/src/plugin_api.nim
@@ -20,6 +20,9 @@ import "."/[config, chalkjson, util]
 # should all be pre-checked.
 
 proc callGetChalkTimeHostInfo*(plugin: Plugin): ChalkDict =
+  if not plugin.enabled:
+    return ChalkDict()
+
   let cb = plugin.getChalkTimeHostInfo
 
   # explicit callback check - otherwise it results in segfault
@@ -31,6 +34,9 @@ proc callGetChalkTimeHostInfo*(plugin: Plugin): ChalkDict =
 
 proc callGetChalkTimeArtifactInfo*(plugin: Plugin, obj: ChalkObj):
          ChalkDict =
+  if not plugin.enabled:
+    return ChalkDict()
+
   let cb = plugin.getChalkTimeArtifactInfo
 
   # explicit callback check - otherwise it results in segfault
@@ -42,6 +48,9 @@ proc callGetChalkTimeArtifactInfo*(plugin: Plugin, obj: ChalkObj):
 
 proc callGetRunTimeArtifactInfo*(plugin: Plugin, obj: ChalkObj, b: bool):
          ChalkDict =
+  if not plugin.enabled:
+    return ChalkDict()
+
   let cb = plugin.getRunTimeArtifactInfo
 
   # explicit callback check - otherwise it results in segfault
@@ -53,6 +62,9 @@ proc callGetRunTimeArtifactInfo*(plugin: Plugin, obj: ChalkObj, b: bool):
 
 proc callGetRunTimeHostInfo*(plugin: Plugin, objs: seq[ChalkObj]):
          ChalkDict =
+  if not plugin.enabled:
+    return ChalkDict()
+
   let cb = plugin.getRunTimeHostInfo
 
   # explicit callback check - otherwise it results in segfault
@@ -594,7 +606,8 @@ proc newPlugin*(
                   getChalkTimeArtifactInfo: ctArtCallback,
                   getRunTimeArtifactInfo:   rtArtCallback,
                   getRunTimeHostInfo:       rtHostCallback,
-                  internalState:            cache)
+                  internalState:            cache,
+                  enabled:                  true)
 
   if not result.checkPlugin(codec = false):
     result = Plugin(nil)
@@ -612,7 +625,8 @@ proc newCodec*(
   handleWrite:        HandleWriteCb       = HandleWritecb(defaultCodecWrite),
   nativeObjPlatforms: seq[string]         =  @[],
   cache:              RootRef             = RootRef(nil),
-  commentStart:       string              = "#"):
+  commentStart:       string              = "#",
+  enabled:            bool                = true):
     Plugin {.discardable, cdecl.} =
 
   result = Plugin(name:                     name,
@@ -627,7 +641,8 @@ proc newCodec*(
                   handleWrite:              handleWrite,
                   nativeObjPlatforms:       nativeObjPlatforms,
                   internalState:            cache,
-                  commentStart:             commentStart)
+                  commentStart:             commentStart,
+                  enabled:                  enabled)
 
   if not result.checkPlugin(codec = true):
     result = Plugin(nil)

--- a/src/plugins/codecDocker.nim
+++ b/src/plugins/codecDocker.nim
@@ -6,9 +6,7 @@
 ##
 import ".."/[config, docker_base, chalkjson, attestation_api, plugin_api, util]
 
-const
-  markFile     = "chalk.json"
-  markLocation = "/chalk.json"
+const markLocation = "/chalk.json"
 
 proc dockerGetChalkId*(self: Plugin, chalk: ChalkObj): string {.cdecl.} =
   if chalk.extract != nil and "CHALK_ID" in chalk.extract:
@@ -601,6 +599,9 @@ proc dockerExtractChalkMark*(chalk: ChalkObj): ChalkDict {.exportc, cdecl.} =
   addUnmarked(chalk.name)
 
 proc loadCodecDocker*() =
-  newCodec("docker",
-           rtArtCallback = RunTimeArtifactCb(dockerGetRunTimeArtifactInfo),
-           getChalkId    = ChalkIdCb(dockerGetChalkId))
+  if getDockerExeLocation() == "":
+    warn("Disabling docker codec as docker command is not available")
+  else:
+    newCodec("docker",
+             rtArtCallback = RunTimeArtifactCb(dockerGetRunTimeArtifactInfo),
+             getChalkId    = ChalkIdCb(dockerGetChalkId))

--- a/src/plugins/codecDocker.nim
+++ b/src/plugins/codecDocker.nim
@@ -599,7 +599,9 @@ proc dockerExtractChalkMark*(chalk: ChalkObj): ChalkDict {.exportc, cdecl.} =
   addUnmarked(chalk.name)
 
 proc loadCodecDocker*() =
-  if getDockerExeLocation() == "":
+  # cant use getDockerExePath as that uses codecs to ignore chalk
+  # wrappings hence we just check if anything docker is on PATH here
+  if nimutils.findExePath("docker") == "":
     warn("Disabling docker codec as docker command is not available")
   else:
     newCodec("docker",

--- a/src/plugins/codecDocker.nim
+++ b/src/plugins/codecDocker.nim
@@ -510,7 +510,7 @@ proc inspectImage(chalk: ChalkObj): bool {.discardable.} =
     cmdOut = runDockerGetEverything(@["inspect", chalk.name])
 
   if cmdOut.getExit() != 0:
-    trace(chalk.name & ": Docker inspect image failed: " & cmdOut.getStdErr())
+    info(chalk.name & ": Docker inspect image failed: " & cmdOut.getStdErr())
     return false
 
   let contents = cmdOut.getStdOut().parseJson().getElems()[0]

--- a/src/plugins/codecDocker.nim
+++ b/src/plugins/codecDocker.nim
@@ -512,7 +512,7 @@ proc inspectImage(chalk: ChalkObj): bool {.discardable.} =
     cmdOut = runDockerGetEverything(@["inspect", chalk.name])
 
   if cmdOut.getExit() != 0:
-    info(chalk.name & ": Docker inspect image failed: " & cmdOut.getStdErr())
+    trace(chalk.name & ": Docker inspect image failed: " & cmdOut.getStdErr())
     return false
 
   let contents = cmdOut.getStdOut().parseJson().getElems()[0]
@@ -530,7 +530,7 @@ proc inspectContainer(chalk: ChalkObj) =
     cmdOut = runDockerGetEverything(@["container", "inspect", id])
 
   if cmdout.getExit() != 0:
-    warn(chalk.userRef & ": Container inspection failed (no longer running?)")
+    warn(chalk.userRef & ": Could not perform container inspection (no longer running?)")
     return
 
   let

--- a/src/plugins/codecDocker.nim
+++ b/src/plugins/codecDocker.nim
@@ -601,9 +601,10 @@ proc dockerExtractChalkMark*(chalk: ChalkObj): ChalkDict {.exportc, cdecl.} =
 proc loadCodecDocker*() =
   # cant use getDockerExePath as that uses codecs to ignore chalk
   # wrappings hence we just check if anything docker is on PATH here
-  if nimutils.findExePath("docker") == "":
+  let enabled = nimutils.findExePath("docker") != ""
+  if not enabled:
     warn("Disabling docker codec as docker command is not available")
-  else:
-    newCodec("docker",
-             rtArtCallback = RunTimeArtifactCb(dockerGetRunTimeArtifactInfo),
-             getChalkId    = ChalkIdCb(dockerGetChalkId))
+  newCodec("docker",
+           rtArtCallback = RunTimeArtifactCb(dockerGetRunTimeArtifactInfo),
+           getChalkId    = ChalkIdCb(dockerGetChalkId),
+           enabled       = enabled)

--- a/src/util.nim
+++ b/src/util.nim
@@ -363,7 +363,7 @@ proc findExePath*(cmdName:    string,
     # takes precedence over rest of dirs in PATH
     paths = @[configPath.get()] & paths
 
-  trace("Searching path for " & cmdName)
+  trace("Searching PATH for " & cmdName)
   var foundExes = findAllExePaths(cmdName, paths, usePath)
 
   if ignoreChalkExes:
@@ -386,10 +386,10 @@ proc findExePath*(cmdName:    string,
     foundExes = newExes
 
   if foundExes.len() == 0:
-    trace("Could not find '" & cmdName & "' in path.")
+    trace("Could not find '" & cmdName & "' in PATH.")
     return none(string)
 
-  trace("Found '" & cmdName & "' in path: " & foundExes[0])
+  trace("Found '" & cmdName & "' in PATH: " & foundExes[0])
   return some(foundExes[0])
 
 proc handleExec*(prioritizedExes: seq[string], args: seq[string]) {.noreturn.} =

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -51,7 +51,7 @@ RUN mkdir -p /.cache/pypoetry \
 COPY pyproject.toml poetry.lock $WORKDIR/
 RUN poetry install --no-plugins
 
-COPY --from=gcr.io/projectsigstore/cosign /ko-app/cosign /usr/local/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v2.2.3 /ko-app/cosign /usr/local/bin/cosign
 COPY --from=docker:24 /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=docker/buildx-bin:0.11.2 /buildx /usr/lib/docker/cli-plugins/docker-buildx
 


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Fixes https://github.com/crashappsec/chalk/issues/247

## Description

* disables docker codec if `docker` is not installed which removes the misleading error log on `chalk exec`
* explicitly falling back to `docker` command for better stderr when `docker` is not installed during `chalk docker ...`
