### PR TITLE
refactor(techStackGeneric): improve getProcNames

### DIFF
--- a/src/plugins/techStackGeneric.nim
+++ b/src/plugins/techStackGeneric.nim
@@ -176,22 +176,29 @@ proc hostHasTechStack(scope: hostScope, proc_names: HashSet[string]): bool =
 proc scanDirectory(directory: string, category: string, subcategory: string) =
   if inFileScope[category][subcategory]:
     return
-  for kind, path in walkDir(directory):
+  for filePath in walkDir(directory):
     if inFileScope[category][subcategory]:
       break
-    if kind == pcFile:
-      scanFile(path, category, subcategory)
-    elif kind == pcDir:
-      scanDirectory(path, category, subcategory)
+    if filePath.kind == pcFile:
+      scanFile(filePath.path, category, subcategory)
+      continue
+    if filePath.kind == pcDir:
+      scanDirectory(filePath.path, category, subcategory)
+      continue
 
 proc getLanguages(directory: string, langs: var HashSet[string]) =
-  for kind, path in walkDir(directory):
-    if kind == pcFile:
-      let ext = path.splitFile().ext
-      if ext != "" and ext in languages:
-        langs.incl(languages[ext])
-    elif kind == pcDir:
-      getLanguages(path, langs)
+  for filePath in walkDir(directory):
+    if filePath.kind == pcFile:
+      let splFile = splitFile(filePath.path)
+      if splFile.ext == "":
+        continue
+      if splFile.ext notin languages:
+        continue
+      langs.incl(languages[splFile.ext])
+      continue
+    if filePath.kind == pcDir:
+      getLanguages(filePath.path, langs)
+      continue
 
 proc detectLanguages(): HashSet[string] =
   result = initHashSet[string]()


### PR DESCRIPTION
### Description

The `getProcNames` procedure was doing a couple of strange things:

- It was trying to read files at `/proc/foo/status`, where `foo` is the name of a *file*, not directory, in `/proc`.
- It scanned each file at `/proc/[pid]/status` more than once (instead, once per digit of the pid).

This wasn't producing any incorrect results because:

- It caught and ignored the exceptions from opening nonexistent files.
- The name values are added to a `HashSet[string]`, which deduplicates them.

It was also doing some further unnecessary work: it kept scanning lines of `/proc/[pid]/status` even after it found the `Name` value (which is specified to be on the first line).

This PR fixes those issues.

Note that `/proc/[pid]/comm` also [exists in Linux since 2.6.33](https://www.man7.org/linux/man-pages/man5/proc.5.html) (2010-02-24), but that's less portable.

Refs: #249 (to a tiny degree)

### Testing

Add to `plugins/techStackDetection.nim`

```nim
when isMainModule:
  echo getProcNames()
```

and run `nim r plugins/techStackDetection.nim`

It'll be easier to add tests for this kind of thing when we're running unit tests in CI.