### PR TITLE
refactor(techStackGeneric): ignore .git directories

### DIFF
--- a/src/plugins/techStackGeneric.nim
+++ b/src/plugins/techStackGeneric.nim
@@ -179,7 +179,7 @@ proc scanDirectory(directory: string, category: string, subcategory: string) =
       break
     if kind == pcFile:
       scanFile(path, category, subcategory)
-    elif kind == pcDir:
+    elif kind == pcDir and not path.endsWith(".git"):
       scanDirectory(path, category, subcategory)
 
 proc getLanguages(directory: string, langs: var HashSet[string]) =
@@ -188,7 +188,7 @@ proc getLanguages(directory: string, langs: var HashSet[string]) =
       let ext = path.splitFile().ext
       if ext != "" and ext in languages:
         langs.incl(languages[ext])
-    elif kind == pcDir:
+    elif kind == pcDir and not path.endsWith(".git"):
       getLanguages(path, langs)
 
 proc detectLanguages(): HashSet[string] =


### PR DESCRIPTION
A significant fraction of the tech stack detection execution time was often from scanning files in any `.git` directory. Prevent that.

Clearly, the speedup here depends on the relative size of the `.git` directory versus the rest of the data. But at least on one machine, this commit is a 2x speedup for running in the chalk repo:

```shell
chalk insert --use-tech-stack-detection ./foo
```

We should eventually:

- Refactor this to use a different dir walking mechanism, which can live in nimutils. One problem here is that there's nothing that prevents the recursion from producing a stack overflow in optimized builds. For debug builds, the default call depth limit is 2000 function calls (configurable with `-d:nimCallDepthLimit=n`).
- Consider ignoring other directories and files.

But let's just do this for now.

Refs: https://github.com/crashappsec/chalk/issues/249