### PR TITLE
build: pinning cosign

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/crashappsec/nim:ubuntu-2.0.0 as nim
-FROM gcr.io/projectsigstore/cosign as cosign
+FROM gcr.io/projectsigstore/cosign:v2.2.3 as cosign
 
 # -------------------------------------------------------------------
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree

## Issue

tests are failing

https://github.com/sigstore/cosign/issues/3620

## Description

looks like hotfixes to cosign v1 are published as :latest tags and there is no v2 tag for grabbing latest v2 cosign versions so pinning to latest v2 for now
