### PR TITLE
fix: runCommand returns non-zero exit code for non-existing exes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   installed. Previously, any chalk sub-scan such as
   during `chalk exec` had misleading error logs.
   [#248](https://github.com/crashappsec/chalk/pull/248)
+- `chalk docker ...` did not exit with non-zero exit code
+  when `docker` is not installed.
+  [#256](https://github.com/crashappsec/chalk/pull/256)
 - Fixed parsing CLI params when wrapping `docker`
   (rename `chalk` exe to `docker`) and a docker command
   had a "docker" param.

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#23309b7c4ad492576509b84f6969a1a43c862057"
+requires "https://github.com/crashappsec/con4m#973bb0a8bfc0745a30f6f6285a9fd81e6196b647"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -71,6 +71,17 @@ def do_docker_cleanup() -> Iterator[None]:
                 Docker.remove_images(list(images))
 
 
+def test_no_docker(chalk: Chalk):
+    _, build = chalk.docker_build(
+        context=DOCKERFILES / "valid" / "sample_1",
+        env={"PATH": ""},
+        expected_success=False,
+        # dont run sanity docker subcommand
+        run_docker=False,
+    )
+    assert build.exit_code > 0
+
+
 @pytest.mark.parametrize("buildkit", [True, False])
 @pytest.mark.parametrize(
     "cwd, dockerfile, tag",


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

https://github.com/crashappsec/nimutils/pull/65

## Description

Running `chalk docker ...` when `docker` is not installed would not exit with appropriate exit code.

## Testing

run `chalk docker ...` without `docker` being on `PATH`
