### PR TITLE
fix: docker command name is honored while wrapping docker exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   installed. Previously, any chalk sub-scan such as
   during `chalk exec` had misleading error logs.
   [#248](https://github.com/crashappsec/chalk/pull/248)
+- Fixed parsing CLI params when wrapping `docker`
+  (rename `chalk` exe to `docker`) and a docker command
+  had a "docker" param.
+  [#257](https://github.com/crashappsec/chalk/pull/257)
 
 ## 0.3.4
 

--- a/src/confload.nim
+++ b/src/confload.nim
@@ -177,14 +177,11 @@ proc loadAllConfigs*() =
   let
     toStream = newStringStream
     stack    = newConfigStack()
+    exeName  = getMyAppPath().splitPath().tail
 
-  case getMyAppPath().splitPath().tail
+  case exeName
   of "docker":
-    if "docker" notin params:
-      if len(params) != 0 and params[0] == "chalk":
-        params = params[1 .. ^1]
-      else:
-        params = @["docker"] & params
+    params = @[exeName] & params
   else: discard
 
   con4mRuntime = stack

--- a/src/util.nim
+++ b/src/util.nim
@@ -375,11 +375,14 @@ proc findExePath*(cmdName:    string,
       let
         subscan   = runChalkSubScan(location, "extract")
         allchalks = subscan.getAllChalks()
-      if len(allChalks) != 0 and allChalks[0].extract != nil and
-         "$CHALK_IMPLEMENTATION_NAME" in allChalks[0].extract:
-        continue
-      else:
+        isChalk   = (
+          len(allChalks) != 0 and
+          allChalks[0].extract != nil and
+         "$CHALK_IMPLEMENTATION_NAME" in allChalks[0].extract
+        )
+      if not isChalk:
         newExes.add(location)
+        break
 
     endNativeCodecsOnly()
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -110,6 +110,25 @@ def test_build(
     assert image_id
 
 
+def test_docker_context(chalk: Chalk, tmp_data_dir: Path):
+    """
+    Test docker can build when a context is "docker"
+    """
+    shutil.copy(chalk.binary, tmp_data_dir / "docker")
+    cwd = tmp_data_dir / "cwd"
+    context = cwd / "docker"
+    context.mkdir(parents=True)
+    path = os.environ["PATH"]
+
+    _, build = Docker.build(
+        cwd=cwd,
+        dockerfile=DOCKERFILES / "valid" / "sample_2" / "Dockerfile",
+        context="docker",
+        env={"PATH": f"{tmp_data_dir}:{path}"},
+    )
+    assert ChalkProgram.from_program(build)
+
+
 @pytest.mark.parametrize("dockerfile", [DOCKERFILES / "valid" / "sample_1"])
 def test_multiple_tags(
     chalk: Chalk,

--- a/tests/utils/docker.py
+++ b/tests/utils/docker.py
@@ -66,6 +66,7 @@ class Docker:
         expected_success: bool = True,
         buildkit: bool = True,
         secrets: Optional[dict[str, Path]] = None,
+        env: Optional[dict[str, str]] = None,
     ) -> tuple[str, Program]:
         """
         run docker build with parameters
@@ -85,7 +86,7 @@ class Docker:
                     buildkit=buildkit,
                 ),
                 expected_exit_code=int(not expected_success),
-                env=Docker.build_env(buildkit=buildkit),
+                env={**Docker.build_env(buildkit=buildkit), **(env or {})},
                 cwd=cwd,
             )
         )


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

unable to execute docker command which has "docker" as an arg somewhere in the params

https://github.com/zaproxy/zaproxy/actions/runs/8452961393/job/23155525385#step:9:482

## Description

previously "docker" was only wrapped when "docker" was not present anywhere in the flags. That is a bad assumption as for example a valid docker context can be a folder "docker". Right now if the exe name is "docker" its always appended to the CLI params hence allowing chalk to correctly validate CLI args.

## Testing

```
➜ make tests args="test_docker.py::test_docker_context --logs"
```

