### PR TITLE
build: 0.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Chalk Release Notes
 
-## Main
+## 0.3.5
+
+**Apr 05, 2024**
 
 ## Breaking Changes
 
@@ -15,7 +17,7 @@
   installed. Previously, any chalk sub-scan such as
   during `chalk exec` had misleading error logs.
   [#248](https://github.com/crashappsec/chalk/pull/248)
-- `chalk docker ...` did not exit with non-zero exit code
+- `chalk docker ...` now exits with a non-zero exit code
   when `docker` is not installed.
   [#256](https://github.com/crashappsec/chalk/pull/256)
 - Fixed parsing CLI params when wrapping `docker`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We currently support the following versions in terms of security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.4   | :white_check_mark: |
-| < 0.3.4 | :x:                |
+| 0.3.5   | :white_check_mark: |
+| < 0.3.5 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -52,7 +52,7 @@
 ##     the more basic per-op stuff such as "_CHALKS" and "ACTION_ID" I did not.
 
 ## CHALK SCHEMA
-chalk_version :=   "0.3.5-dev"
+chalk_version :=   "0.3.5"
 ascii_magic   :=   "dadfedabbadabbed"
 
 # Field starting with an underscore (_) are "system" metadata fields, that


### PR DESCRIPTION
Let's create a patch release for the current changes on `main`.

I confirm that the binaries built successfully for the current release targets.

Compare with the changes in the previous release PR: https://github.com/crashappsec/chalk/pull/244/files