### PR TITLE
build(nimble): no longer strip debug builds

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -76,7 +76,7 @@ before install:
 
 # Add --trace if needed.
 after build:
-  when not defined(debug):
+  when defined(release):
     exec "set -x && strip " & bin[0]
   exec "set -x && ./" & bin[0] & " --debug --no-use-external-config --skip-command-report load default"
 


### PR DESCRIPTION
The post-build hook attempted to strip only release builds, but it stripped all builds because [Nimble doesn't support checking custom defines in a nimble file][1]. Check against `release` instead, which is built-in.

Before this PR:

```console
$ nimble build -d:debug
[...]
$ file ./chalk
./chalk: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```

With this PR:

```console
$ nimble build -d:debug
[...]
$ file ./chalk
chalk: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped
```

Closes: https://github.com/crashappsec/chalk/issues/288

[1]: https://www.github.com/nim-lang/nimble/issues/605

## Testing

- run `nimble build -d:debug`, and verify that the binary is not stripped
- run `nimble build`, and verify that the binary is stripped