### PR TITLE
feat: allow to download chalk by multiple urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,7 @@
     multi-platform builds.
   - `docker.download_arch_binary` - whether to automatically
     download chalk binaries for other architectures.
-  - `docker.download_arch_binary_url` - URL template where
+  - `docker.download_arch_binary_urls` - URL template where
     to download chalk binaries.
   - `docker.install_binfmt` - for multi-platform builds
     automatically install binfmt when not all platforms

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -1740,7 +1740,7 @@ can be found via these configurations in the order of precedence:
 
 * `docker.arch_binary_locations`
 * `docker.arch_binary_locations_path`
-* `docker.download_arch_binary` via `docker.download_arch_binary_url`
+* `docker.download_arch_binary` via `docker.download_arch_binary_urls`
 
 If there isn't an architecture match, and no binary can be found,
 docker entrypoint is aborted.
@@ -1827,6 +1827,9 @@ For example tree of the config path:
         └── v8/
             └── chalk
 ```
+
+If `download_arch_binary` is true, chalk will download other architecture
+binaries into this folder.
 """
   }
 
@@ -1842,18 +1845,25 @@ Which version of binary is downloaded is controlled by
 """
   }
 
-  field download_arch_binary_url {
-    type:     string
-    default:  "https://dl.crashoverride.run/chalk/chalk-{version}-{os}-{architecture}"
+  field download_arch_binary_urls {
+    type:     list[string]
+    default:  ["https://dl.crashoverride.run/chalk/chalk-{version}-{os}-{architecture}",
+               # this allows to download pre-release builds
+               "https://dl.crashoverride.run/chalk-commit-builds/chalk-{commit}-{os}-{architecture}"]
     shortdoc: "URL template where to download chalk binaries"
     doc:      """
-Template for a URL where to download the chalk binary when `download_arch_binary`
-is true. The template can render these variables:
+List of templates of URLs where to download the chalk binary when `download_arch_binary`
+is true. Each template can render these variables:
 
 * `{version}`
 * `{commit}`
 * `{os}`
 * `{architecture}`
+
+Chalk is attempted to be downloaded from each URL in the order they are defined.
+
+Downloaded chalk is saved to `arch_binary_locations_path` so that future lookups
+can lookup already downloaded binary.
 """
   }
 

--- a/tests/functional/data/configs/docker_wrap.c4m
+++ b/tests/functional/data/configs/docker_wrap.c4m
@@ -1,5 +1,5 @@
 docker.wrap_entrypoint = true
-docker.download_arch_binary_url = env("CHALK_SERVER") + "/dummy/chalk-%version-%os-%architecture"
+docker.download_arch_binary_urls = [env("CHALK_SERVER") + "/dummy/chalk-%version-%os-%architecture"]
 docker.arch_binary_locations_path = env("CHALK_TMP")
 report_template terminal_insert {
   key._IMAGE_ENTRYPOINT.use = true


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

As setup-chalk-action allows to download chalks pinned by their commit build, by only downloading chalk from a single release url, it will potentially break multi-platform builds. By attempting to download from a release url first and if failed downloading from a commit build it will allow chalk to fully function both with release and pre-release builds without requiring to update user-configs.

## Testing

```
➜ make tests args="test_docker.py::test_multiplatform_build[valid/sample_1-True]"
```
