### PR TITLE
fix(confload): don't enable color when stdout is a tty

### DIFF
--- a/src/confload.nim
+++ b/src/confload.nim
@@ -86,7 +86,8 @@ proc findOptionalConf(state: ConfigState): Option[string] =
 
 proc loadLocalStructs*(state: ConfigState) =
   chalkConfig = state.attrs.loadChalkConfig()
-  if chalkConfig.color.isSome(): setShowColor(chalkConfig.color.get())
+  if chalkConfig.color.isSome() and isatty(1) == 1:
+    setShowColor(chalkConfig.color.get())
   setLogLevel(chalkConfig.logLevel)
   var configPath: seq[string] = @[]
   for path in chalkConfig.configPath:


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [ ] Updated `CHANGELOG.md` if necessary

## Issue

#297

## Description

Try to disable color when stdout is not a tty.

## Testing

Check color in output under various conditions.
