### PR TITLE
feat: BUILD_ORIGIN_ID/KEY and BUILD_ORIGIN_OWNER_ID/KEY keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 - Fixed metadata reporting for GCP cloud run services
   ([#304](https://github.com/crashappsec/chalk/pull/304))
 
+### New Features
+
+- New chalk keys:
+
+  - Keys to uniquely identify origin repository as per
+    CI/CD system:
+    - `BUILD_ORIGIN_ID`
+    - `BUILD_ORIGIN_OWNER_ID`
+
+  ([#303](https://github.com/crashappsec/chalk/pull/303))
+
 ## 0.4.0
 
 **May 28, 2024**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     - `BUILD_ORIGIN_ID`
     - `BUILD_ORIGIN_KEY`
     - `BUILD_ORIGIN_OWNER_ID`
+    - `BUILD_ORIGIN_OWNER_KEY`
 
     For example, the `BUILD_ORIGIN_ID` for a GitHub repo
     will not be changed by renaming that repo. Chalk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,16 @@
 
 - New chalk keys:
 
-  - Keys to uniquely identify origin repository as per
-    CI/CD system:
+  - Keys to uniquely identify the origin repository, using
+    a stable identifier provided by the CI/CD system:
+
     - `BUILD_ORIGIN_ID`
     - `BUILD_ORIGIN_OWNER_ID`
+
+    For example, the `BUILD_ORIGIN_ID` for a GitHub repo
+    will not be changed by renaming that repo. Chalk
+    already had e.g. the `ORIGIN_URI` key, but that value
+    could change over time due to such repo renaming.
 
   ([#303](https://github.com/crashappsec/chalk/pull/303))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,13 @@
 
 - New chalk keys:
 
-  - Keys to uniquely identify the origin repository, using
-    a stable identifier provided by the CI/CD system:
+  - Keys to identify the origin repository, using
+    an identifier provided by the CI/CD system:
 
     - `BUILD_ORIGIN_ID`
     - `BUILD_ORIGIN_KEY`
     - `BUILD_ORIGIN_OWNER_ID`
     - `BUILD_ORIGIN_OWNER_KEY`
-
-    For example, the `BUILD_ORIGIN_ID` for a GitHub repo
-    will not be changed by renaming that repo. Chalk
-    already had e.g. the `ORIGIN_URI` key, but that value
-    could change over time due to such repo renaming.
 
   ([#303](https://github.com/crashappsec/chalk/pull/303))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     a stable identifier provided by the CI/CD system:
 
     - `BUILD_ORIGIN_ID`
+    - `BUILD_ORIGIN_KEY`
     - `BUILD_ORIGIN_OWNER_ID`
 
     For example, the `BUILD_ORIGIN_ID` for a GitHub repo

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -80,6 +80,7 @@ or vice versa.
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
   key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
@@ -177,6 +178,7 @@ mark_template mark_large {
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
   key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
@@ -272,6 +274,7 @@ use the mark template named `reproducable`.
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
   key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -334,6 +337,7 @@ the time and the nonce removed.
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
   key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -82,6 +82,7 @@ or vice versa.
   key.BUILD_ORIGIN_ID.use                     = true
   key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
+  key.BUILD_ORIGIN_OWNER_KEY.use              = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -180,6 +181,7 @@ mark_template mark_large {
   key.BUILD_ORIGIN_ID.use                     = true
   key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
+  key.BUILD_ORIGIN_OWNER_KEY.use              = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -276,6 +278,7 @@ use the mark template named `reproducable`.
   key.BUILD_ORIGIN_ID.use                     = true
   key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
+  key.BUILD_ORIGIN_OWNER_KEY.use              = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
   key.EMBEDDED_CHALK.use                      = true
@@ -339,6 +342,7 @@ the time and the nonce removed.
   key.BUILD_ORIGIN_ID.use                     = true
   key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
+  key.BUILD_ORIGIN_OWNER_KEY.use              = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
   key.EMBEDDED_CHALK.use                      = true

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -79,6 +79,8 @@ or vice versa.
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
+  key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -174,6 +176,8 @@ mark_template mark_large {
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
+  key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -267,6 +271,8 @@ use the mark template named `reproducable`.
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
+  key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
   key.EMBEDDED_CHALK.use                      = true
@@ -327,6 +333,8 @@ the time and the nonce removed.
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
+  key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
   key.EMBEDDED_CHALK.use                      = true

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1149,6 +1149,18 @@ the repo belongs.
 """
 }
 
+keyspec BUILD_ORIGIN_OWNER_KEY {
+  kind:     ChalkTimeHost
+  type:     string
+  standard: true
+  since:    "0.4.1"
+  shortdoc: "Key of the owner of ORIGIN_URI in the CI/CD system"
+  doc:      """
+Similar to BUILD_ORIGIN_KEY, this reports the key of the owner
+of the repo for easy lookup in CI/CD APIs.
+"""
+}
+
 keyspec BUILD_ID {
     kind:             ChalkTimeHost
     type:             string

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1113,12 +1113,12 @@ keyspec BUILD_ORIGIN_ID {
   since:    "0.4.1"
   shortdoc: "ID of the ORIGIN_URI in the CI/CD system"
   doc:      """
-The ORIGIN_URI key reports the URI of the git origin remote. However,
-that value might not be unique within the build system: for example,
-renaming a repo on GitHub will change the ORIGIN_URI. But that won't
-change GitHub's internal repo ID. This field will report, when
-available, the build system's internal origin repo ID so that the repo
-can be uniquely identified over time.
+The ORIGIN_URI key reports the URI of the git origin remote.
+This key, if available, will report the repo ID of the repository
+as it is stored internally by the CI/CD system.
+
+For GitHub this corresponds to repo REST ID.
+For GitLab this is the project ID.
 """
 }
 
@@ -1129,10 +1129,11 @@ keyspec BUILD_ORIGIN_KEY {
   since:    "0.4.1"
   shortdoc: "Key of the ORIGIN_URI in the CI/CD system"
   doc:      """
-Similar to BUILD_ORIGIN_ID but some CI/CD systems use another key
-to refer to a repository in their APIs. For example, GitHub uses
-different ids to refer to the repo in REST of GraphQL APIs.
-This key allows to submit repository key for easy lookup in CI/CD APIs.
+Similar to BUILD_ORIGIN_ID and this reports supplemental repository
+key for easier CI/CD API interactions.
+
+For GitHub this corresponds to repo GraphQL node_id.
+For GitLab this is not used.
 """
 }
 
@@ -1143,9 +1144,12 @@ keyspec BUILD_ORIGIN_OWNER_ID {
   since:    "0.4.1"
   shortdoc: "ID of the owner of ORIGIN_URI in the CI/CD system"
   doc:      """
-Reports, if available, the owner ID of the ORIGIN_URI.
-For example, in GitHub it will be the organization ID to which
-the repo belongs.
+The ORIGIN_URI key reports the URI of the git origin remote.
+This key, if available, will report the repo owners ID of the repository
+as it is stored internally by the CI/CD system.
+
+For GitHub this corresponds to repo's org/user REST ID.
+For GitLab this is the namespace ID.
 """
 }
 
@@ -1156,8 +1160,11 @@ keyspec BUILD_ORIGIN_OWNER_KEY {
   since:    "0.4.1"
   shortdoc: "Key of the owner of ORIGIN_URI in the CI/CD system"
   doc:      """
-Similar to BUILD_ORIGIN_KEY, this reports the key of the owner
-of the repo for easy lookup in CI/CD APIs.
+Similar to BUILD_ORIGIN_OWNER_ID and this reports supplemental owner
+key for easier CI/CD API interactions.
+
+For GitHub this corresponds to repos user/org GraphQL node_id.
+For GitLab this is not used.
 """
 }
 

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1106,8 +1106,37 @@ the artifact was chalked.
 """
 }
 
+keyspec BUILD_ORIGIN_ID {
+  kind:     ChalkTimeHost
+  type:     string
+  standard: true
+  since:    "0.4.1"
+  shortdoc: "ID of the ORIGIN_URI in the CI/CD system"
+  doc:      """
+ORIGIN_URI reports git's origin remote URI. That value however
+might not be unique within the build system. For example GitHub
+allows to rename repos and as such over time ORIGIN_URI might change
+however GitHub's internal repo ID will not. This field will report,
+when available, build systems internal origin repo ID so that it
+can be uniquely identified.
+"""
+}
+
+keyspec BUILD_ORIGIN_OWNER_ID {
+  kind:     ChalkTimeHost
+  type:     string
+  standard: true
+  since:    "0.4.1"
+  shortdoc: "ID of the owner of ORIGIN_URI in the CI/CD system"
+  doc:      """
+Reports, if available, the owner ID of the ORIGIN_URI.
+For example in GitHub it will be the organization ID to which
+the repo belongs to.
+"""
+}
+
 keyspec BUILD_ID {
-    kind:             ChalkTimeArtifact
+    kind:             ChalkTimeHost
     type:             string
     standard:         true
     since:            "0.1.0"
@@ -1120,7 +1149,7 @@ associated job ID.
 }
 
 keyspec BUILD_URI {
-    kind:                ChalkTimeArtifact
+    kind:                ChalkTimeHost
     type:                string
     standard:            true
     since:               "0.1.0"
@@ -1137,7 +1166,7 @@ key's documentation for more detail).
 }
 
 keyspec BUILD_API_URI {
-    kind:                ChalkTimeArtifact
+    kind:                ChalkTimeHost
     type:                string
     standard:            true
     since:               "0.1.0"
@@ -1155,7 +1184,7 @@ key's documentation for more detail).
 }
 
 keyspec BUILD_TRIGGER {
-    kind:             ChalkTimeArtifact
+    kind:             ChalkTimeHost
     type:             string
     standard:         true
     since:            "0.1.0"
@@ -1166,7 +1195,7 @@ Any recorded build trigger found at chalk time.
 }
 
 keyspec BUILD_CONTACT {
-    kind:             ChalkTimeArtifact
+    kind:             ChalkTimeHost
     type:             list[string]
     standard:         true
     since:            "0.1.0"

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1122,6 +1122,20 @@ can be uniquely identified over time.
 """
 }
 
+keyspec BUILD_ORIGIN_KEY {
+  kind:     ChalkTimeHost
+  type:     string
+  standard: true
+  since:    "0.4.1"
+  shortdoc: "Key of the ORIGIN_URI in the CI/CD system"
+  doc:      """
+Similar to BUILD_ORIGIN_ID but some CI/CD systems use another key
+to refer to a repository in their APIs. For example, GitHub uses
+different ids to refer to the repo in REST of GraphQL APIs.
+This key allows to submit repository key for easy lookup in CI/CD APIs.
+"""
+}
+
 keyspec BUILD_ORIGIN_OWNER_ID {
   kind:     ChalkTimeHost
   type:     string

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1113,12 +1113,12 @@ keyspec BUILD_ORIGIN_ID {
   since:    "0.4.1"
   shortdoc: "ID of the ORIGIN_URI in the CI/CD system"
   doc:      """
-ORIGIN_URI reports git's origin remote URI. That value however
-might not be unique within the build system. For example GitHub
-allows to rename repos and as such over time ORIGIN_URI might change
-however GitHub's internal repo ID will not. This field will report,
-when available, build systems internal origin repo ID so that it
-can be uniquely identified.
+The ORIGIN_URI key reports the URI of the git origin remote. However,
+that value might not be unique within the build system: for example,
+renaming a repo on GitHub will change the ORIGIN_URI. But that won't
+change GitHub's internal repo ID. This field will report, when
+available, the build system's internal origin repo ID so that the repo
+can be uniquely identified over time.
 """
 }
 
@@ -1130,8 +1130,8 @@ keyspec BUILD_ORIGIN_OWNER_ID {
   shortdoc: "ID of the owner of ORIGIN_URI in the CI/CD system"
   doc:      """
 Reports, if available, the owner ID of the ORIGIN_URI.
-For example in GitHub it will be the organization ID to which
-the repo belongs to.
+For example, in GitHub it will be the organization ID to which
+the repo belongs.
 """
 }
 

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -114,7 +114,7 @@ plugin ci_github {
     pre_run_keys:    ["BUILD_ID", "BUILD_URI", "BUILD_API_URI",
                       "BUILD_TRIGGER", "BUILD_CONTACT",
                       "BUILD_ORIGIN_ID", "BUILD_ORIGIN_OWNER_ID",
-                      "BUILD_ORIGIN_KEY"]
+                      "BUILD_ORIGIN_KEY", "BUILD_ORIGIN_OWNER_KEY"]
     doc: """
 Collects information about associated build jobs in github actions.
 

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -112,7 +112,8 @@ artifacts will be attached to that info.
 plugin ci_github {
     enabled:         true
     pre_run_keys:    ["BUILD_ID", "BUILD_URI", "BUILD_API_URI",
-                     "BUILD_TRIGGER", "BUILD_CONTACT"]
+                      "BUILD_TRIGGER", "BUILD_CONTACT",
+                      "BUILD_ORIGIN_ID", "BUILD_ORIGIN_OWNER_ID"]
     doc: """
 Collects information about associated build jobs in github actions.
 
@@ -133,7 +134,8 @@ This only collects data when adding chalk marks.
 plugin ci_gitlab {
     enabled:         true
     pre_run_keys:    ["BUILD_ID", "BUILD_URI", "BUILD_API_URI",
-                      "BUILD_TRIGGER", "BUILD_CONTACT"]
+                      "BUILD_TRIGGER", "BUILD_CONTACT",
+                      "BUILD_ORIGIN_ID", "BUILD_ORIGIN_OWNER_ID"]
     doc: """
 Collects information about associated build jobs in Gitlab.
 

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -113,7 +113,8 @@ plugin ci_github {
     enabled:         true
     pre_run_keys:    ["BUILD_ID", "BUILD_URI", "BUILD_API_URI",
                       "BUILD_TRIGGER", "BUILD_CONTACT",
-                      "BUILD_ORIGIN_ID", "BUILD_ORIGIN_OWNER_ID"]
+                      "BUILD_ORIGIN_ID", "BUILD_ORIGIN_OWNER_ID",
+                      "BUILD_ORIGIN_KEY"]
     doc: """
 Collects information about associated build jobs in github actions.
 

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -90,6 +90,7 @@ report and subtract from it.
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
   key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
@@ -651,6 +652,7 @@ doc: """
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
   key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
@@ -1104,6 +1106,7 @@ container.
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
   key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
@@ -1557,6 +1560,7 @@ and keep the run-time key.
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
   key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -89,6 +89,8 @@ report and subtract from it.
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
+  key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -648,6 +650,8 @@ doc: """
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
+  key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -1099,6 +1103,8 @@ container.
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
+  key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -1550,6 +1556,8 @@ and keep the run-time key.
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
   key.BUILD_CONTACT.use                       = true
+  key.BUILD_ORIGIN_ID.use                     = true
+  key.BUILD_ORIGIN_OWNER_ID.use               = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -92,6 +92,7 @@ report and subtract from it.
   key.BUILD_ORIGIN_ID.use                     = true
   key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
+  key.BUILD_ORIGIN_OWNER_KEY.use              = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -654,6 +655,7 @@ doc: """
   key.BUILD_ORIGIN_ID.use                     = true
   key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
+  key.BUILD_ORIGIN_OWNER_KEY.use              = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -1108,6 +1110,7 @@ container.
   key.BUILD_ORIGIN_ID.use                     = true
   key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
+  key.BUILD_ORIGIN_OWNER_KEY.use              = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true
@@ -1562,6 +1565,7 @@ and keep the run-time key.
   key.BUILD_ORIGIN_ID.use                     = true
   key.BUILD_ORIGIN_KEY.use                    = true
   key.BUILD_ORIGIN_OWNER_ID.use               = true
+  key.BUILD_ORIGIN_OWNER_KEY.use              = true
   key.CHALK_RAND.use                          = true
   key.OLD_CHALK_METADATA_HASH.use             = true
   key.OLD_CHALK_METADATA_ID.use               = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -197,6 +197,8 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.BUILD_API_URI.use                       = true
   ~key.BUILD_TRIGGER.use                       = true
   ~key.BUILD_CONTACT.use                       = true
+  ~key.BUILD_ORIGIN_ID.use                     = true
+  ~key.BUILD_ORIGIN_OWNER_ID.use               = true
   ~key.CHALK_RAND.use                          = true
   ~key.OLD_CHALK_METADATA_HASH.use             = true
   ~key.OLD_CHALK_METADATA_ID.use               = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -200,6 +200,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.BUILD_ORIGIN_ID.use                     = true
   ~key.BUILD_ORIGIN_KEY.use                    = true
   ~key.BUILD_ORIGIN_OWNER_ID.use               = true
+  ~key.BUILD_ORIGIN_OWNER_KEY.use              = true
   ~key.CHALK_RAND.use                          = true
   ~key.OLD_CHALK_METADATA_HASH.use             = true
   ~key.OLD_CHALK_METADATA_ID.use               = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -198,6 +198,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.BUILD_TRIGGER.use                       = true
   ~key.BUILD_CONTACT.use                       = true
   ~key.BUILD_ORIGIN_ID.use                     = true
+  ~key.BUILD_ORIGIN_KEY.use                    = true
   ~key.BUILD_ORIGIN_OWNER_ID.use               = true
   ~key.CHALK_RAND.use                          = true
   ~key.OLD_CHALK_METADATA_HASH.use             = true

--- a/src/plugins/ciGithub.nim
+++ b/src/plugins/ciGithub.nim
@@ -14,51 +14,52 @@ import ".."/[config, plugin_api]
 proc githubGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
   result = ChalkDict()
 
-  # https://docs.github.com/en/actions/
-  #              learn-github-actions/variables#default-environment-variables
+  # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
   let
-    CI                = getEnv("CI")
-    GITHUB_SHA        = getEnv("GITHUB_SHA")
-    GITHUB_SERVER_URL = getEnv("GITHUB_SERVER_URL")
-    GITHUB_REPOSITORY = getEnv("GITHUB_REPOSITORY")
-    GITHUB_RUN_ID     = getEnv("GITHUB_RUN_ID")
-    GITHUB_API_URL    = getEnv("GITHUB_API_URL")
-    GITHUB_ACTOR      = getEnv("GITHUB_ACTOR")
-    GITHUB_EVENT_NAME = getEnv("GITHUB_EVENT_NAME")
-    GITHUB_REF_TYPE   = getEnv("GITHUB_REF_TYPE")
+    CI                         = getEnv("CI")
+    GITHUB_SHA                 = getEnv("GITHUB_SHA")
+    GITHUB_SERVER_URL          = getEnv("GITHUB_SERVER_URL")
+    GITHUB_REPOSITORY          = getEnv("GITHUB_REPOSITORY")
+    GITHUB_REPOSITORY_ID       = getEnv("GITHUB_REPOSITORY_ID")
+    GITHUB_REPOSITORY_OWNER_ID = getEnv("GITHUB_REPOSITORY_OWNER_ID")
+    GITHUB_RUN_ID              = getEnv("GITHUB_RUN_ID")
+    GITHUB_API_URL             = getEnv("GITHUB_API_URL")
+    GITHUB_ACTOR               = getEnv("GITHUB_ACTOR")
+    GITHUB_EVENT_NAME          = getEnv("GITHUB_EVENT_NAME")
+    GITHUB_REF_TYPE            = getEnv("GITHUB_REF_TYPE")
 
   # probably not running in github CI
   if CI == "" and GITHUB_SHA == "": return
 
-  if GITHUB_RUN_ID != "":  result["BUILD_ID"] = pack(GITHUB_RUN_ID)
+  result.setIfNeeded("BUILD_ID",              GITHUB_RUN_ID)
+  result.setIfNeeded("BUILD_ORIGIN_ID",       GITHUB_REPOSITORY_ID)
+  result.setIfNeeded("BUILD_ORIGIN_OWNER_ID", GITHUB_REPOSITORY_OWNER_ID)
+  result.setIfNeeded("BUILD_API_URI",         GITHUB_API_URL)
 
   if (GITHUB_SERVER_URL != "" and GITHUB_REPOSITORY != "" and
       GITHUB_RUN_ID != ""):
-    result["BUILD_URI"] = pack(
+    result.setIfNeeded("BUILD_URI", (
       GITHUB_SERVER_URL.strip(leading = false, chars = {'/'}) & "/" &
       GITHUB_REPOSITORY.strip(chars = {'/'}) & "/actions/runs/" &
       GITHUB_RUN_ID
-    )
+    ))
 
-  if GITHUB_API_URL != "": result["BUILD_API_URI"] = pack(GITHUB_API_URL)
-
-  # https://docs.github.com/en/actions/using-workflows/
-  #                                    events-that-trigger-workflows
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
   if GITHUB_EVENT_NAME != "" and GITHUB_REF_TYPE != "":
     if GITHUB_EVENT_NAME == "push" and GITHUB_REF_TYPE == "tag":
-      result["BUILD_TRIGGER"] = pack("tag")
+      result.setIfNeeded("BUILD_TRIGGER", "tag")
     elif GITHUB_EVENT_NAME == "push":
-      result["BUILD_TRIGGER"] = pack("push")
+      result.setIfNeeded("BUILD_TRIGGER", "push")
     elif GITHUB_EVENT_NAME == "workflow_dispatch":
-      result["BUILD_TRIGGER"] = pack("manual")
+      result.setIfNeeded("BUILD_TRIGGER", "manual")
     elif GITHUB_EVENT_NAME == "workflow_call":
-      result["BUILD_TRIGGER"] = pack("external")
+      result.setIfNeeded("BUILD_TRIGGER", "external")
     elif GITHUB_EVENT_NAME == "schedule":
-      result["BUILD_TRIGGER"] = pack("schedule")
+      result.setIfNeeded("BUILD_TRIGGER", "schedule")
     else:
-      result["BUILD_TRIGGER"] = pack("other: " & GITHUB_EVENT_NAME)
+      result.setIfNeeded("BUILD_TRIGGER", "other: " & GITHUB_EVENT_NAME)
 
-  if GITHUB_ACTOR != "": result["BUILD_CONTACT"] = pack(@[GITHUB_ACTOR])
+  if GITHUB_ACTOR != "": result.setIfNeeded("BUILD_CONTACT", @[GITHUB_ACTOR])
 
 proc loadCiGitHub*() =
   newPlugin("ci_github",

--- a/src/plugins/ciGitlab.nim
+++ b/src/plugins/ciGitlab.nim
@@ -16,32 +16,32 @@ proc gitlabGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.}  =
 
   # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
   let
-    CI                = getEnv("CI")
-    GITLAB_CI         = getEnv("GITLAB_CI")
-    GITLAB_JOB_URL    = getEnv("CI_JOB_URL")
-    GITLAB_JOB_ID     = getEnv("CI_JOB_ID")
-    GITLAB_API_URL    = getEnv("CI_API_V4_URL")
-    GITLAB_USER       = getEnv("GITLAB_USER_LOGIN")
-    GITLAB_EVENT_NAME = getEnv("CI_PIPELINE_SOURCE")
+    CI                  = getEnv("CI")
+    GITLAB_CI           = getEnv("GITLAB_CI")
+    GITLAB_JOB_URL      = getEnv("CI_JOB_URL")
+    GITLAB_JOB_ID       = getEnv("CI_JOB_ID")
+    GITLAB_API_URL      = getEnv("CI_API_V4_URL")
+    GITLAB_PROJECT_ID   = getEnv("CI_PROJECT_ID")
+    GITLAB_NAMESPACE_ID = getEnv("CI_PROJECT_NAMESPACE_ID")
+    GITLAB_USER         = getEnv("GITLAB_USER_LOGIN")
+    GITLAB_EVENT_NAME   = getEnv("CI_PIPELINE_SOURCE")
 
   # probably not running in gitlab CI
   if CI == "" and GITLAB_CI == "": return
 
-  if GITLAB_JOB_ID != "":  result["BUILD_ID"]      = pack(GITLAB_JOB_ID)
+  result.setIfNeeded("BUILD_ID",              GITLAB_JOB_ID)
+  result.setIfNeeded("BUILD_URI",             GITLAB_JOB_URL)
+  result.setIfNeeded("BUILD_API_URI",         GITLAB_API_URL)
+  result.setIfNeeded("BUILD_ORIGIN_ID",       GITLAB_PROJECT_ID)
+  result.setIfNeeded("BUILD_ORIGIN_OWNER_ID", GITLAB_NAMESPACE_ID)
 
-  if GITLAB_JOB_URL != "": result["BUILD_URI"]     = pack(GITLAB_JOB_URL)
-
-  if GITLAB_API_URL != "": result["BUILD_API_URI"] = pack(GITLAB_API_URL)
-
-  # https://docs.gitlab.com/ee/ci/jobs
-  #                     /job_control.html#common-if-clauses-for-rules
-  if GITLAB_EVENT_NAME != "" :
-      result["BUILD_TRIGGER"] = pack(GITLAB_EVENT_NAME)
+  # https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules
+  result.setIfNeeded("BUILD_TRIGGER", GITLAB_EVENT_NAME)
 
   # Lots of potential 'user' vars to pick from here, long term will likely
   #  need to be configurable as different customers will attach different
   #  meaning to different user value depending on their pipeline
-  if GITLAB_USER != "": result["BUILD_CONTACT"] = pack(@[GITLAB_USER])
+  if GITLAB_USER != "": result.setIfNeeded("BUILD_CONTACT", @[GITLAB_USER])
 
 proc loadCiGitlab*() =
   newPlugin("ci_gitlab",

--- a/tests/functional/imds/app.py
+++ b/tests/functional/imds/app.py
@@ -599,6 +599,11 @@ RESPONSES = {
             "zone": "projects/11111111111/zones/europe-west1-b",
         }
     ),
+    "/repos/octocat/Hello-World": json.dumps(
+        {
+            "node_id": "abc",
+        }
+    ),
 }
 
 
@@ -610,7 +615,7 @@ def health():
     return
 
 
-@app.put(f"/latest/api/token", response_class=PlainTextResponse)
+@app.put("/latest/api/token", response_class=PlainTextResponse)
 def token():
     return TOKEN
 

--- a/tests/functional/imds/app.py
+++ b/tests/functional/imds/app.py
@@ -602,6 +602,9 @@ RESPONSES = {
     "/repos/octocat/Hello-World": json.dumps(
         {
             "node_id": "abc",
+            "owner": {
+                "node_id": "xyz",
+            },
         }
     ),
 }

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -55,7 +55,7 @@ def test_codeowners(tmp_data_dir: Path, chalk: Chalk):
 
 
 @pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
-def test_github(copy_files: list[Path], chalk: Chalk):
+def test_github(copy_files: list[Path], chalk: Chalk, server_imds: str):
     bin_path = copy_files[0]
     artifact = ArtifactInfo.one_elf(
         bin_path,
@@ -64,8 +64,9 @@ def test_github(copy_files: list[Path], chalk: Chalk):
             "BUILD_TRIGGER": "tag",
             "BUILD_CONTACT": ["octocat"],
             "BUILD_URI": "https://github.com/octocat/Hello-World/actions/runs/1658821493",
-            "BUILD_API_URI": "https://api.github.com",
+            "BUILD_API_URI": server_imds,
             "BUILD_ORIGIN_ID": "123",
+            "BUILD_ORIGIN_KEY": "abc",
             "BUILD_ORIGIN_OWNER_ID": "456",
         },
     )
@@ -78,7 +79,7 @@ def test_github(copy_files: list[Path], chalk: Chalk):
             "GITHUB_SERVER_URL": "https://github.com",
             "GITHUB_REPOSITORY": "octocat/Hello-World",
             "GITHUB_RUN_ID": "1658821493",
-            "GITHUB_API_URL": "https://api.github.com",
+            "GITHUB_API_URL": server_imds,
             "GITHUB_ACTOR": "octocat",
             "GITHUB_REPOSITORY_ID": "123",
             "GITHUB_REPOSITORY_OWNER_ID": "456",

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -68,6 +68,7 @@ def test_github(copy_files: list[Path], chalk: Chalk, server_imds: str):
             "BUILD_ORIGIN_ID": "123",
             "BUILD_ORIGIN_KEY": "abc",
             "BUILD_ORIGIN_OWNER_ID": "456",
+            "BUILD_ORIGIN_OWNER_KEY": "xyz",
         },
     )
     insert = chalk.insert(

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -65,6 +65,8 @@ def test_github(copy_files: list[Path], chalk: Chalk):
             "BUILD_CONTACT": ["octocat"],
             "BUILD_URI": "https://github.com/octocat/Hello-World/actions/runs/1658821493",
             "BUILD_API_URI": "https://api.github.com",
+            "BUILD_ORIGIN_ID": "123",
+            "BUILD_ORIGIN_OWNER_ID": "456",
         },
     )
     insert = chalk.insert(
@@ -78,6 +80,8 @@ def test_github(copy_files: list[Path], chalk: Chalk):
             "GITHUB_RUN_ID": "1658821493",
             "GITHUB_API_URL": "https://api.github.com",
             "GITHUB_ACTOR": "octocat",
+            "GITHUB_REPOSITORY_ID": "123",
+            "GITHUB_REPOSITORY_OWNER_ID": "456",
             # there are a bunch of variations of these
             # but for now at least we test basic flow
             "GITHUB_EVENT_NAME": "push",
@@ -104,6 +108,8 @@ def test_gitlab(copy_files: list[Path], chalk: Chalk):
             "BUILD_CONTACT": ["user"],
             "BUILD_URI": "https://gitlab.com/gitlab-org/gitlab/-/jobs/4999820578",
             "BUILD_API_URI": "https://gitlab.com/api/v4",
+            "BUILD_ORIGIN_ID": "123",
+            "BUILD_ORIGIN_OWNER_ID": "456",
         },
     )
     insert = chalk.insert(
@@ -117,6 +123,8 @@ def test_gitlab(copy_files: list[Path], chalk: Chalk):
             "CI_API_V4_URL": "https://gitlab.com/api/v4",
             "GITLAB_USER_LOGIN": "user",
             "CI_PIPELINE_SOURCE": "push",
+            "CI_PROJECT_ID": "123",
+            "CI_PROJECT_NAMESPACE_ID": "456",
         },
     )
     validate_chalk_report(


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

fixes https://github.com/crashappsec/chalk/issues/261

## Description

Will allow to uniquely identify a repo as ORIGIN_URI is not guaranteed to be unique. Note this only works in CI systems which support functionality and therefore wont work everywhere such as in Jenkins.

## Testing

```
➜ make tests args="test_plugins.py::test_github"
➜ make tests args="test_plugins.py::test_gitlab"
```
