### PR TITLE
fix: detect cloud run services without vendor info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Chalk Release Notes
 
+## HEAD
+
+- Fixed metadata reporting for GCP cloud run services
+  ([#304](https://github.com/crashappsec/chalk/pull/304))
+
 ## 0.4.0
 
 **May 28, 2024**

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -159,8 +159,8 @@ proc isGoogleHost(vendor: string): bool =
   # vendor information should be present in most services, but its not present
   # in cloud run. In cloud run we can detect the presence of a knative service
   # via ENV variables but we are being conservative in also checking resolv.conf
-  let resolv_contents = tryToLoadFile("/etc/resolv.conf")
-  return ("google.internal" in resolv_contents and
+  let resolvContents = tryToLoadFile("/etc/resolv.conf")
+  return ("google.internal" in resolvContents and
           getEnv(CLOUD_RUN_TIMEOUT_SECONDS) != "" and
           getEnv(K_SERVICE) != "")
 

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -14,7 +14,10 @@ const
   awsBaseUri     = "http://169.254.169.254/latest/"
   awsMdUri       = awsBaseUri & "meta-data/"
   awsDynUri      = awsBaseUri & "dynamic/"
-  # this env var is undocumented in GCP besides the functions-framework-php repo
+  # this env var is undocumented in GCP, but does exist in GoogleCloudPlatform repos:
+  # - https://github.com/GoogleCloudPlatform/functions-framework-php/blob/e3a4d658ab3fd127931818d26aaa3e29c622f40c/router.php#L46
+  # - https://github.com/GoogleCloudPlatform/functions-framework-python/blob/02472e7315d0fd642db26441b3cb21f799906739/src/functions_framework/_http/gunicorn.py#L35
+  # - https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/0bb6efb6c6a915bc96c50ed5aeda79d7b8e3b15e/src/options.ts#L121
   CLOUD_RUN_TIMEOUT_SECONDS = "CLOUD_RUN_TIMEOUT_SECONDS"
   K_SERVICE = "K_SERVICE"
   # special keys for special processing

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -14,6 +14,7 @@ const
   awsBaseUri     = "http://169.254.169.254/latest/"
   awsMdUri       = awsBaseUri & "meta-data/"
   awsDynUri      = awsBaseUri & "dynamic/"
+  # this env var is undocumented in GCP besides the functions-framework-php repo
   CLOUD_RUN_TIMEOUT_SECONDS = "CLOUD_RUN_TIMEOUT_SECONDS"
   K_SERVICE = "K_SERVICE"
   # special keys for special processing

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -157,9 +157,8 @@ proc isGoogleHost(vendor: string): bool =
     return true
 
   # vendor information should be present in most services, but its not present
-  # in cloud run. In cloud run we can
-  # detect the presence of a knative service via ENV variables but we are being
-  # conservative in also checking resolv.conf
+  # in cloud run. In cloud run we can detect the presence of a knative service
+  # via ENV variables but we are being conservative in also checking resolv.conf
   let resolv_contents = tryToLoadFile("/etc/resolv.conf")
   return ("google.internal" in resolv_contents and
           getEnv(CLOUD_RUN_TIMEOUT_SECONDS) != "" and


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Fixes https://github.com/crashappsec/chalk/issues/298

## Description

This PR adds an additional check for presence of cloud run-services in the vendor check. Cloud run instances lack vendor info in /sys, therefore we rely on the combined presence of dedicated environment variables and `google.internal` appearing in /etc/resolv.conf

## Testing

Deploy a chalked image to GCP and ensure we get back desired metadata
