### PR TITLE
fix: fixing chalk custom keys validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed metadata reporting for GCP cloud run services
   ([#304](https://github.com/crashappsec/chalk/pull/304))
+- Fixes custom key name validation
+  ([#307](https://github.com/crashappsec/chalk/pull/307))
 
 ### New Features
 

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -757,7 +757,7 @@ clearly to types supported by JSON.
 
   field standard {
     type:        bool
-    require:     false
+    default:     false
     stack_limit: 0
     hidden:      true
     doc:         """
@@ -3807,11 +3807,11 @@ func key_name_validation() {
     if attr_get(base + "standard", bool) { continue; }
     kind     := attr_get(base + "kind", int)
     if kind == ChalkTimeHost or kind == ChalkTimeArtifact {
-      if key_name.find("X-") == 0 { continue; }
+      if key_name.find("X_") == 0 { continue; }
     }
-    elif key_name.find("_X-") == 0 { continue; }
+    elif key_name.find("_X_") == 0 { continue; }
     return ("Custom key '" + key_name + "' is invalid. Chalkable custom " +
-            "keys must start with X- (or _X- for non-chalkable keys)")
+            "keys must start with X_ (or _X_ for non-chalkable keys)")
   }
 }
 

--- a/tests/functional/data/configs/custom_keys.c4m
+++ b/tests/functional/data/configs/custom_keys.c4m
@@ -1,0 +1,56 @@
+keyspec X_REPORT_VALUE {
+  kind:     ChalkTimeHost
+  type:     string
+  value:    "hello"
+}
+keyspec X_REPORT_ENV_VAR {
+  kind:     ChalkTimeHost
+  type:     string
+  value:    env("ENV_VAR")
+}
+keyspec X_REPORT_CMD {
+  kind:     ChalkTimeHost
+  type:     string
+  value:    strip(run("echo mars"))
+}
+keyspec X_REPORT_FUNC {
+  kind:     ChalkTimeHost
+  type:     string
+  callback: func key_callback
+}
+
+keyspec X_MARK_VALUE {
+  kind:     ChalkTimeArtifact
+  type:     string
+  value:    "hello"
+}
+keyspec X_MARK_ENV_VAR {
+  kind:     ChalkTimeArtifact
+  type:     string
+  value:    env("ENV_VAR")
+}
+keyspec X_MARK_CMD {
+  kind:     ChalkTimeArtifact
+  type:     string
+  value:    strip(run("echo mars"))
+}
+keyspec X_MARK_FUNC {
+  kind:     ChalkTimeArtifact
+  type:     string
+  callback: func key_callback
+}
+
+func key_callback(contexts) {
+  return "hello " + env("ENV_VAR")
+}
+
+report_template insertion_default {
+  key.X_REPORT_VALUE.use   = true
+  key.X_REPORT_ENV_VAR.use = true
+  key.X_REPORT_CMD.use     = true
+  key.X_REPORT_FUNC.use    = true
+  key.X_MARK_VALUE.use     = true
+  key.X_MARK_ENV_VAR.use   = true
+  key.X_MARK_CMD.use       = true
+  key.X_MARK_FUNC.use      = true
+}

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -500,3 +500,25 @@ def test_no_certs(chalk_default: Chalk, server_chalkdust: str):
         tty=False,
         volumes={chalk_default.binary: "/chalk"},
     )
+
+
+@pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
+def test_custom_keys(chalk: Chalk, copy_files: list[Path]):
+    bin_path = copy_files[0]
+    insert = chalk.insert(
+        bin_path,
+        config=CONFIGS / "custom_keys.c4m",
+        env={"ENV_VAR": "world"},
+    )
+    assert insert.report.has(
+        X_REPORT_VALUE="hello",
+        X_REPORT_ENV_VAR="world",
+        X_REPORT_CMD="mars",
+        X_REPORT_FUNC="hello world",
+    )
+    assert insert.mark.has(
+        X_MARK_VALUE="hello",
+        X_MARK_ENV_VAR="world",
+        X_MARK_CMD="mars",
+        X_MARK_FUNC="hello world",
+    )


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

key validation enforced custom keys to start with `X-` or `_X-` which is invalid con4m syntax. Changing to `X-` and `_X_`.

Also adding test case how custom keys can be added to reports and chalk marks.


## Testing

```
➜ make tests args="test_config.py::test_custom_keys"
```
