### PR TITLE
fix: macos certs download url was not quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes
 
-- On MacOS builds, downloading root certs was failing
-  due to missing quotes around the url
+- When building Chalk on macOS, downloading root certs
+  could fail due to missing quotes around the URL
   ([nimutils #68](https://github.com/crashappsec/nimutils/pull/68))
 
 ## 0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- On MacOS builds, downloading root certs was failing
+  due to missing quotes around the url
+  ([nimutils #68](https://github.com/crashappsec/nimutils/pull/68))
+
 ## 0.4.1
 
 **May 30, 2024**

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#476a59c3eac2ee5232f23e231e9cfb8ed1af10e3"
+requires "https://github.com/crashappsec/con4m#dc5e76564d7abb962dc6519fd81f34760091b34d"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

macos builds were failing in some cases

## Description

downloading root cert url was not quoted correctly in curl command

## Testing

run build on mac
