### PR TITLE
feat: add _GCP_PROJECT_METADATA key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   could fail due to missing quotes around the URL
   ([nimutils #68](https://github.com/crashappsec/nimutils/pull/68))
 
+### New Features
+
+- New chalk keys:
+
+  - New key holding GCP project metadata: `_GCP_PROJECT_METADATA`
+    ([#311](https://github.com/crashappsec/chalk/pull/31))
+
 ## 0.4.1
 
 **May 30, 2024**

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -4661,6 +4661,18 @@ See https://cloud.google.com/compute/docs/metadata/overview for more
 """
 }
 
+keyspec _GCP_PROJECT_METADATA {
+    kind:             RunTimeHost
+    type:             dict[string, `x]
+    standard:         true
+    since:            "0.4.2"
+    doc: """
+JSON containing project attributes, such as the project id and numeric id
+
+See https://cloud.google.com/compute/docs/metadata/overview for more.
+"""
+}
+
 keyspec _AWS_INSTANCE_IDENTITY_DOCUMENT {
     kind:             RunTimeHost
     type:             dict[string, `x]

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -195,7 +195,8 @@ Can capture data both during build and during process run time.
 plugin cloud_metadata {
     enabled:         true
     priority:        1000
-    post_run_keys:   ["_GCP_INSTANCE_METADATA", "_AZURE_INSTANCE_METADATA",
+    post_run_keys:   ["_GCP_INSTANCE_METADATA", "_GCP_PROJECT_METADATA",
+    "_AZURE_INSTANCE_METADATA",
     "_OP_CLOUD_PROVIDER", "_OP_CLOUD_PROVIDER_SERVICE_TYPE",
     "_OP_CLOUD_PROVIDER_ACCOUNT_INFO", "_OP_CLOUD_PROVIDER_REGION",
     "_OP_CLOUD_PROVIDER_REGION", "_OP_CLOUD_PROVIDER_IP",

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -377,6 +377,7 @@ report and subtract from it.
   key._OP_CLOUD_PROVIDER_INSTANCE_TYPE.use    = true
   key._AZURE_INSTANCE_METADATA.use            = true
   key._GCP_INSTANCE_METADATA.use              = true
+  key._GCP_PROJECT_METADATA.use               = true
   key._AWS_INSTANCE_IDENTITY_DOCUMENT.use     = true
   key._AWS_INSTANCE_IDENTITY_PKCS7.use        = true
   key._AWS_INSTANCE_IDENTITY_SIGNATURE.use    = true
@@ -582,6 +583,7 @@ doc: """
   # json
   key._AZURE_INSTANCE_METADATA.use                   = true
   key._GCP_INSTANCE_METADATA.use                     = true
+  key._GCP_PROJECT_METADATA.use                      = true
   key._AWS_IAM_INFO.use                              = true
   key._AWS_IDENTITY_CREDENTIALS_EC2_INFO.use         = true
   key._AWS_IDENTITY_CREDENTIALS_EC2_SECURITY_CREDENTIALS_EC2_INSTANCE.use = true
@@ -1052,6 +1054,7 @@ container.
   # json
   key._AZURE_INSTANCE_METADATA.use                   = true
   key._GCP_INSTANCE_METADATA.use                     = true
+  key._GCP_PROJECT_METADATA.use                      = true
   key._AWS_IAM_INFO.use                              = true
   key._AWS_IDENTITY_CREDENTIALS_EC2_INFO.use         = true
   key._AWS_IDENTITY_CREDENTIALS_EC2_SECURITY_CREDENTIALS_EC2_INSTANCE.use = true
@@ -1507,6 +1510,7 @@ and keep the run-time key.
   # json
   key._AZURE_INSTANCE_METADATA.use                   = true
   key._GCP_INSTANCE_METADATA.use                     = true
+  key._GCP_PROJECT_METADATA.use                      = true
   key._AWS_IAM_INFO.use                              = true
   key._AWS_IDENTITY_CREDENTIALS_EC2_INFO.use         = true
   key._AWS_IDENTITY_CREDENTIALS_EC2_SECURITY_CREDENTIALS_EC2_INSTANCE.use = true

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2608,6 +2608,14 @@ end users.
     doc:     "Path where to check AWS board vendor if running in AWS, Google or Microsoft nodes"
   }
 
+  # added after discussion in https://github.com/crashappsec/chalk/pull/311
+  field sys_resolv_path {
+    type:    string
+    default: "/etc/resolv.conf"
+    hidden:  true
+    doc:     "The path for /etc/resolv.conf or equivalent that allows us to infer service or provider from contents"
+  }
+
   field sys_product_path {
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
     type:    string

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -142,6 +142,7 @@ This is mostly a copy of insert template however all keys are immutable.
   # json
   ~key._AZURE_INSTANCE_METADATA.use                   = true
   ~key._GCP_INSTANCE_METADATA.use                     = true
+  ~key._GCP_PROJECT_METADATA.use                      = true
   ~key._AWS_IAM_INFO.use                              = true
   ~key._AWS_IDENTITY_CREDENTIALS_EC2_INFO.use         = true
   ~key._AWS_IDENTITY_CREDENTIALS_EC2_SECURITY_CREDENTIALS_EC2_INSTANCE.use = true

--- a/tests/functional/data/configs/resolv.c4m
+++ b/tests/functional/data/configs/resolv.c4m
@@ -1,0 +1,3 @@
+if env_exists("TEST_RESOLV") {
+  cloud_provider.cloud_instance_hw_identifiers.sys_resolv_path: env("TEST_RESOLV")
+}

--- a/tests/functional/imds/app.py
+++ b/tests/functional/imds/app.py
@@ -7,7 +7,6 @@ import json
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 
-
 PREFIX = "/latest"
 TOKEN = "token"
 TAGS = {
@@ -519,6 +518,9 @@ RESPONSES = {
         }
     ),
     # GCP
+    "/computeMetadata/v1/project": json.dumps(
+        {"numericProjectId": 434557252559, "projectId": "gcp-integration-423910"}
+    ),
     "/computeMetadata/v1/instance": json.dumps(
         {
             "attributes": {


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Additional improvement over https://github.com/crashappsec/chalk/issues/298

## Description

Project information is not included in the instance metadata, therefore this exposes a separate key `_GCP_PROJECT_METADATA` with project info, if one is found

## Testing

Deploy a chalked image to GCP and check that project metadata is populated