### PR TITLE
fix: chalk load revalidates already cached components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - When building Chalk on macOS, downloading root certs
   could fail due to missing quotes around the URL
   ([nimutils #68](https://github.com/crashappsec/nimutils/pull/68))
+- Regression:`chalk load` did not revalidate previously loaded
+  components in Chalk since >=0.4.0
+  ([#313](https://github.com/crashappsec/chalk/pull/313))
 
 ## 0.4.1
 

--- a/tests/functional/data/configs/validation/valid_2.c4m
+++ b/tests/functional/data/configs/validation/valid_2.c4m
@@ -1,0 +1,1 @@
+log_level = "error"

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -90,6 +90,35 @@ def test_invalid_load(chalk_copy: Chalk, test_config_file: str, use_embedded: bo
 
 
 @pytest.mark.parametrize(
+    "copy_files",
+    [[CONFIGS / "validation" / "valid_2.c4m"]],
+    indirect=True,
+)
+def test_load_valid_then_invalid(chalk_copy: Chalk, copy_files: list[Path]):
+    config = copy_files[0]
+    # call chalk load on valid config
+    chalk_copy.load(
+        config,
+        expected_success=True,
+        replace=False,
+    )
+    # mutate config to be invalid
+    with config.open("a") as fid:
+        fid.write("\nlog_level = debug")
+    chalk_copy.load(
+        config,
+        expected_success=False,
+        replace=False,
+    )
+    # chalk should still have valid config embedded
+    # and further calls should not fail and not have any errors
+    extract = chalk_copy.extract(chalk_copy.binary)
+    for report in extract.reports:
+        assert report["_OPERATION"] == "extract"
+        assert "_OP_ERRORS" not in report
+
+
+@pytest.mark.parametrize(
     "test_config_file, expected_error",
     [
         ("validation/valid_1.c4m", VALIDATION_ERROR),


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

fixes https://github.com/crashappsec/chalk/issues/312

## Description

test config function reloads all cached components which means if previously cached component would be reloaded, the test funcion would reload its previous definition hence not actually testing the new definition. By ignoring the component to be loaded, this ensures the new definition is not replaced by anything hence all components can be successfully validated.

## Testing

```
➜ make tests args="test_config.py::test_load_valid_then_invalid --pdb"
```
