### PR TITLE
feat: external tools if not installed run via docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 - Regression:`chalk load` did not revalidate previously loaded
   components in Chalk since >=0.4.0
   ([#313](https://github.com/crashappsec/chalk/pull/313))
-- `semgrep` external tool now scans chalk context folder
-  vs previously it always scanned `cwd()`. This resulted
-  in incorrect scans when docker context was outside of
-  `cwd()`.
+- The external tool `semgrep` now correctly scans the
+  Chalk context folder. Previously, it always scanned the
+  current working directory, which produced incorrect
+  scans when the Docker context was outside that
+  directory.
   ([#314](https://github.com/crashappsec/chalk/pull/314))
 
 ### New Features
@@ -23,11 +24,9 @@
   - New key holding GCP project metadata: `_GCP_PROJECT_METADATA`
     ([#311](https://github.com/crashappsec/chalk/pull/31))
 
-- Chalk external tools (syft and semgrep) when not already
-  installed, if docker is available, run via docker vs
-  installing them on the host system.
-  This avoid requiring any system requirements to install
-  the external tool.
+- The Chalk external tools `syft` and `semgrep` are now run via Docker
+  when they are not installed and Docker is available. This avoids the
+  need to install them on the host system.
   ([#314](https://github.com/crashappsec/chalk/pull/314))
 
 ## 0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Regression:`chalk load` did not revalidate previously loaded
   components in Chalk since >=0.4.0
   ([#313](https://github.com/crashappsec/chalk/pull/313))
+- `semgrep` external tool now scans chalk context folder
+  vs previously it always scanned `cwd()`. This resulted
+  in incorrect scans when docker context was outside of
+  `cwd()`.
+  ([#314](https://github.com/crashappsec/chalk/pull/314))
 
 ### New Features
 
@@ -17,6 +22,13 @@
 
   - New key holding GCP project metadata: `_GCP_PROJECT_METADATA`
     ([#311](https://github.com/crashappsec/chalk/pull/31))
+
+- Chalk external tools (syft and semgrep) when not already
+  installed, if docker is available, run via docker vs
+  installing them on the host system.
+  This avoid requiring any system requirements to install
+  the external tool.
+  ([#314](https://github.com/crashappsec/chalk/pull/314))
 
 ## 0.4.1
 

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -14,7 +14,7 @@
 
 import std/[httpclient]
 import pkg/[con4m/st, nimutils/jwt]
-import "."/[config, reporting, sinks, chalkjson]
+import "."/[config, reporting, sinks, chalkjson, docker/exe]
 
 proc getChalkCommand(args: seq[Box], unused: ConfigState): Option[Box] =
   return some(pack(getCommandName()))
@@ -111,7 +111,7 @@ proc memoizeInChalkmark(args: seq[Box], s: ConfigState): Option[Box] =
   selfChalkSetSubKey(memoizeKey, name, value)
   return valueOpt
 
-proc c4mParseJson*(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
+proc c4mParseJson(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   let
     data = unpack[string](args[0])
   try:
@@ -122,6 +122,9 @@ proc c4mParseJson*(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   except:
     error("Could not parse JSON: " & getCurrentExceptionMsg())
     return none(Box)
+
+proc dockerExe(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
+  return some(pack(getDockerExeLocation()))
 
 let chalkCon4mBuiltins* = [
     ("version() -> string",
@@ -222,6 +225,12 @@ Same as `url_post()`, but takes a certificate file location in the final
 parameter, with which HTTPS connections must authenticate against.
 """,
      @["parsing"]),
+     ("docker_exe() -> string",
+      BuiltInFn(dockerExe),
+      """
+Find non-chalked docker executable path.
+""",
+      @["chalk"]),
 
 ]
 

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1379,7 +1379,7 @@ metadata.
 
 keyspec SBOM {
     kind:             ChalkTimeArtifact
-    type:             dict[string, `x]
+    type:             dict[string, dict[string, `x]]
     standard:         true
     since:            "0.1.0"
     shortdoc: "SBOM(s) collected at Chalk time"

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023, Crash Override, Inc.
+## Copyright (c) 2023-2024, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -18,31 +18,68 @@ tool semgrep {
   semgrep_format:         "sarif"
   semgrep_metrics:        "on"
   semgrep_other_flags:    ""
+  semgrep_container:      "semgrep/semgrep"
+  semgrep_entrypoint:     "semgrep"
   doc: """
 This runs the semgrep static analyizer.  If it doesn't exist in the
-path, chalk will attempt to install it via 'python3 -m pip install semgrep'.
+path, chalk will:
+
+1. use docker (if present) to run semgrep
+2. attempt to install it via 'pipx install semgrep'
+3. attempt to install it via 'python3 -m pip install semgrep'
 
 You can configure the following fields in the tool.semgrep object:
 
+semgrep_container:      Name of docker container to use to run semgrep
+semgrep_entrypoint:     What entrypoint to use to run semgrep
 semgrep_config_profile: The semgrep profile to use.  Defaults to 'auto'
 semgrep_format:         The output format flag to pass. Defaults to 'sarif'
 semgrep_metrics:        Whether to ping semgrep. 'on' or 'off'. Defaults to 'on' to be compatible with config=auto
 """
 }
 
-
-
-func find_semgrep(ignore) {
+func find_semgrep(path) {
   result := find_exe("semgrep", ["/tmp/semgrep.env/bin", "~/.local/bin"])
-
   if result == "" {
-    trace("find_semgrep: Unable to find semgrep in $PATH")
+    docker_path := docker_exe()
+    if docker_path == "" {
+      trace("find_semgrep: Unable to find semgrep in $PATH and docker is not available")
+    } elif tool.semgrep.semgrep_entrypoint != "" and tool.semgrep.semgrep_container != "" {
+      trace("find_semgrep: Using docker for running semgrep")
+      dir := path
+      if not is_dir(path) {
+        dir, _ := path_split(path)
+      }
+      # to allow to use relative path within cwd of the config_profile
+      cwd_volume := ""
+      if dir != cwd() {
+        cwd_volume := "-v " + cwd() + ":" + cwd() + " "
+      }
+      # to allow to use config from outside of cwd, such as in ~
+      config_volume := ""
+      config := resolve_path(tool.semgrep.semgrep_config_profile)
+      if is_file(config) {
+        config_volume := "-v " + config + ":" + config + " "
+      }
+      return (
+        docker_path + " run " +
+        "--rm " +
+        "--entrypoint=" + tool.semgrep.semgrep_entrypoint + " " +
+        "-w " + dir + " " +
+        "-v " + dir + ":" + dir + " " +
+        cwd_volume +
+        config_volume +
+        tool.semgrep.semgrep_container
+      )
+    } else {
+      trace("find_semgrep: Unable to find semgrep in $PATH and docker is disabled")
+    }
   } else {
     trace("found semgrep at: " + result)
   }
 }
 
-func install_semgrep(ignore) {
+func install_semgrep(path) {
   # perfer pipx for installation
   trace("attempting to install semgrep via pipx...")
   output, code := system("pipx install semgrep")
@@ -67,28 +104,28 @@ func install_semgrep(ignore) {
   return false
 }
 
-func get_semgrep_args(artifact) {
-  result := "ci --config=" + tool.semgrep.semgrep_config_profile
+func get_semgrep_args(path) {
+  result := "scan --config=" + tool.semgrep.semgrep_config_profile
   result := result + " --" + tool.semgrep.semgrep_format + " "
-  result := result + "--metrics " + tool.semgrep.semgrep_metrics + " "
-  result := result + tool.semgrep.semgrep_other_flags + " 2>/dev/null"
-  trace("semgrep args: " + result)
+  result := result + "--metrics=" + tool.semgrep.semgrep_metrics + " "
+  result := result + tool.semgrep.semgrep_other_flags + " "
+  result := result + path + " 2>/dev/null"
 }
 
 func load_semgrep_results(out: string, code) {
   result := {}
 
-  validIndicator := "\"results\": "
-  emptyIndicator := "\"results\": []"
+  if code != 0 {
+    error("semgrep failed to run properly; ignoring")
+    echo(out)
+    return {}
+  }
 
-  if not contains(out, validIndicator) {
-    warn("semgrep did not run properly; ignoring")
+  if not starts_with(strip(out), "{") {
+    error("semgrep did not run properly - invalid json returned; ignoring")
+    echo(out)
+    return {}
   }
-  elif contains(out, emptyIndicator) {
-    info("semgrep didn't find any components; ignoring.")
-  }
-  else {
-    trace("semgrep ran with results")
-    return { "SAST" : out }
-  }
+
+  return { "SAST" : parse_json(out) }
 }

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -18,8 +18,10 @@ tool semgrep {
   semgrep_format:         "sarif"
   semgrep_metrics:        "on"
   semgrep_other_flags:    ""
+  semgrep_exe_dirs:       ["/tmp/semgrep.env/bin", "~/.local/bin"]
   semgrep_container:      "semgrep/semgrep"
   semgrep_entrypoint:     "semgrep"
+  semgrep_prefer_docker:  false
   doc: """
 This runs the semgrep static analyizer.  If it doesn't exist in the
 path, chalk will:
@@ -30,53 +32,82 @@ path, chalk will:
 
 You can configure the following fields in the tool.semgrep object:
 
-semgrep_container:      The name of the docker container to use to run semgrep
-semgrep_entrypoint:     The entrypoint to use to run semgrep
-semgrep_config_profile: The semgrep profile to use.  Defaults to 'auto'
-semgrep_format:         The output format flag to pass. Defaults to 'sarif'
-semgrep_metrics:        Whether to ping semgrep. 'on' or 'off'. Defaults to 'on' to be compatible with config=auto
+semgrep_prefer_docker:  When true, docker is preferred over system-installed semgrep.
+                        Defaults to `false`.
+semgrep_container:      The name of the docker container to use to run semgrep.
+                        Defaults to 'semgrep/semgrep' from Docker Hub.
+semgrep_entrypoint:     The entrypoint to use to run semgrep.
+                        Defaults to 'semgrep'.
+semgrep_exe_dirs:       In addition to $PATH, where to search for semgrep.
+                        Defaults to ["/tmp/semgrep.env/bin", "~/.local/bin"].
+semgrep_config_profile: The semgrep profile to use.
+                        Defaults to 'auto'.
+semgrep_format:         The output format flag to pass.
+                        Defaults to  'sarif'.
+semgrep_metrics:        Whether to ping semgrep. 'on' or 'off'.
+                        Defaults to 'on' to be compatible with config=auto
 """
 }
 
-func find_semgrep(path) {
-  result := find_exe("semgrep", ["/tmp/semgrep.env/bin", "~/.local/bin"])
-  if result == "" {
-    docker_path := docker_exe()
-    if docker_path == "" {
-      trace("find_semgrep: Unable to find semgrep in $PATH and docker is not available")
-    } elif tool.semgrep.semgrep_entrypoint != "" and tool.semgrep.semgrep_container != "" {
-      trace("find_semgrep: Using docker for running semgrep")
-      dir := path
-      if not is_dir(path) {
-        dir, _ := path_split(path)
-      }
-      # Allow using a relative path within cwd of the config_profile
-      cwd_volume := ""
-      if dir != cwd() {
-        cwd_volume := "-v " + cwd() + ":" + cwd() + " "
-      }
-      # Allow using a config from outside of cwd, such as in ~
-      config_volume := ""
-      config := resolve_path(tool.semgrep.semgrep_config_profile)
-      if is_file(config) {
-        config_volume := "-v " + config + ":" + config + " "
-      }
-      return (
-        docker_path + " run " +
-        "--rm " +
-        "--entrypoint=" + tool.semgrep.semgrep_entrypoint + " " +
-        "-w " + dir + " " +
-        "-v " + dir + ":" + dir + " " +
-        cwd_volume +
-        config_volume +
-        tool.semgrep.semgrep_container
-      )
-    } else {
-      trace("find_semgrep: Unable to find semgrep in $PATH and docker is disabled")
-    }
-  } else {
-    trace("found semgrep at: " + result)
+func semgrep_docker(path) {
+  result := ""
+  if tool.semgrep.semgrep_entrypoint == "" or tool.semgrep.semgrep_container == "" {
+    trace("find_semgrep: docker is disabled - both container and entrypoint must be defined")
+    return
   }
+  docker_path := docker_exe()
+  if docker_path == "" {
+    trace("find_semgrep: docker is missing; unable to use docker for semgrep")
+    return
+  }
+  dir := path
+  if not is_dir(path) {
+    dir, _ := path_split(path)
+  }
+  # Allow using a relative path within cwd of the config_profile
+  cwd_volume := ""
+  if dir != cwd() {
+    cwd_volume := "-v " + cwd() + ":" + cwd() + " "
+  }
+  # Allow using a config from outside of cwd, such as in ~
+  config_volume := ""
+  config := resolve_path(tool.semgrep.semgrep_config_profile)
+  if is_file(config) {
+    config_volume := "-v " + config + ":" + config + " "
+  }
+  return (
+    docker_path + " run " +
+    "--rm " +
+    "--entrypoint=" + tool.semgrep.semgrep_entrypoint + " " +
+    "-w " + dir + " " +
+    "-v " + dir + ":" + dir + " " +
+    cwd_volume +
+    config_volume +
+    tool.semgrep.semgrep_container
+  )
+}
+
+func semgrep_system() {
+  result := find_exe("semgrep", tool.semgrep.semgrep_exe_dirs)
+  if result == "" {
+    trace("find_semgrep: Unable to find semgrep in $PATH")
+  } else {
+    trace("find_semgrep: found semgrep in $PATH: " + result)
+  }
+}
+
+func find_semgrep(path) {
+  if tool.semgrep.semgrep_prefer_docker {
+    result := semgrep_docker(path)
+    if result != "" {
+      return
+    }
+  }
+  result := semgrep_system()
+  if result != "" {
+    return result
+  }
+  result := semgrep_docker(path)
 }
 
 func install_semgrep(path) {

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -25,13 +25,13 @@ This runs the semgrep static analyizer.  If it doesn't exist in the
 path, chalk will:
 
 1. use docker (if present) to run semgrep
-2. attempt to install it via 'pipx install semgrep'
-3. attempt to install it via 'python3 -m pip install semgrep'
+2. otherwise, attempt to install it via 'pipx install semgrep'
+3. otherwise, attempt to install it via 'python3 -m pip install semgrep'
 
 You can configure the following fields in the tool.semgrep object:
 
-semgrep_container:      Name of docker container to use to run semgrep
-semgrep_entrypoint:     What entrypoint to use to run semgrep
+semgrep_container:      The name of the docker container to use to run semgrep
+semgrep_entrypoint:     The entrypoint to use to run semgrep
 semgrep_config_profile: The semgrep profile to use.  Defaults to 'auto'
 semgrep_format:         The output format flag to pass. Defaults to 'sarif'
 semgrep_metrics:        Whether to ping semgrep. 'on' or 'off'. Defaults to 'on' to be compatible with config=auto
@@ -50,12 +50,12 @@ func find_semgrep(path) {
       if not is_dir(path) {
         dir, _ := path_split(path)
       }
-      # to allow to use relative path within cwd of the config_profile
+      # Allow using a relative path within cwd of the config_profile
       cwd_volume := ""
       if dir != cwd() {
         cwd_volume := "-v " + cwd() + ":" + cwd() + " "
       }
-      # to allow to use config from outside of cwd, such as in ~
+      # Allow using a config from outside of cwd, such as in ~
       config_volume := ""
       config := resolve_path(tool.semgrep.semgrep_config_profile)
       if is_file(config) {
@@ -105,6 +105,8 @@ func install_semgrep(path) {
 }
 
 func get_semgrep_args(path) {
+  # `semgrep ci` does not support specifying a target. Use the `scan` subcommand instead.
+  # https://github.com/semgrep/semgrep/issues/10305
   result := "scan --config=" + tool.semgrep.semgrep_config_profile
   result := result + " --" + tool.semgrep.semgrep_format + " "
   result := result + "--metrics=" + tool.semgrep.semgrep_metrics + " "
@@ -122,7 +124,7 @@ func load_semgrep_results(out: string, code) {
   }
 
   if not starts_with(strip(out), "{") {
-    error("semgrep did not run properly - invalid json returned; ignoring")
+    error("semgrep did not run properly - invalid JSON returned; ignoring")
     echo(out)
     return {}
   }

--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -9,17 +9,18 @@
 
 tool syft {
   ~kind: "sbom"
-  ~get_tool_location: func find_syft(string) -> string
-  ~attempt_install:   func install_syft(string) -> bool
-  ~get_command_args:  func get_syft_args(string) -> string
-  ~produce_keys:      (func extract_syft_sbom(string, int) ->
-                                                  dict[string, string])
-  syft_exe_dir:      "/tmp"
-  syft_installer:    "https://raw.githubusercontent.com/anchore/syft/main/install.sh"
-  syft_container:    "anchore/syft"
-  syft_entrypoint:   "/syft"
-  syft_argv:         " -o cyclonedx-json"  # CycloneDX by default.
-  ~doc:              """
+  ~get_tool_location:  func find_syft(string) -> string
+  ~attempt_install:    func install_syft(string) -> bool
+  ~get_command_args:   func get_syft_args(string) -> string
+  ~produce_keys:       (func extract_syft_sbom(string, int) ->
+                                                   dict[string, string])
+  syft_exe_dir:       "/tmp"
+  syft_installer:     "https://raw.githubusercontent.com/anchore/syft/main/install.sh"
+  syft_container:     "anchore/syft"
+  syft_entrypoint:    "/syft"
+  syft_prefer_docker: false
+  syft_argv:          " -o cyclonedx-json"  # CycloneDX by default.
+  ~doc:               """
 This runs the syft SBOM tool.  If it can't be found in the current path,
 chalk will:
 
@@ -29,36 +30,63 @@ chalk will:
 
 You can configure the following fields in the tool.syft object:
 
-syft_exe_dir:    Where to try to install syft, if not found.  Defaults to "/tmp"
-syft_container:  Name of docker container to use to run syft
-syft_entrypoint: What entrypoint to use inside the container
-syft_installer:  Location of the official syft installer.
-syft_argv:       Command-line flags to pass to syft. Defaults to:
-                 -o cyclone-json
+syft_prefer_docker: When true, docker is preferred over system-installed syft.
+                    Defaults to `false`.
+syft_container:     The name of docker container to use to run syft.
+                    Defaults to 'anchore/syft' from Docker Hub.
+syft_entrypoint:    The entrypoint to use inside the container.
+                    Defaults to '/syft'.
+syft_exe_dir:       Where to try to install syft, if not found.
+                    Defaults to '/tmp'.
+syft_installer:     URL of the official syft installer script.
+                    Defaults to 'https://raw.githubusercontent.com/anchore/syft/main/install.sh'.
+syft_argv:          Command-line flags to pass to syft.
+                    Defaults to '-o cyclone-json'
 """
 }
 
-func find_syft(path) {
-  result := find_exe("syft", ["/tmp"]) # /tmp is in addition to $PATH
-  if result == "" {
-    docker_path := docker_exe()
-    if docker_path == "" {
-      trace("find_syft: Unable to find syft in $PATH and docker is not available")
-    } elif tool.syft.syft_entrypoint != "" and tool.syft.syft_container != "" {
-      trace("find_syft: Using docker for running syft")
-      return (
-        docker_path + " run " +
-        "--rm " +
-        "--entrypoint=" + tool.syft.syft_entrypoint + " " +
-        "-v " + path + ":" + path + " " +
-        tool.syft.syft_container
-      )
-    } else {
-      trace("find_syft: Unable to find syft in $PATH and docker is disabled")
-    }
-  } else {
-    trace("found syft at: " + result)
+func syft_docker(path) {
+  result := ""
+  if tool.syft.syft_entrypoint == "" or tool.syft.syft_container == "" {
+    trace("find_syft: docker is disabled - both container and entrypoint must be defined")
+    return
   }
+  docker_path := docker_exe()
+  if docker_path == "" {
+    trace("find_syft: docker is missing; unable to use docker for syft")
+    return
+  }
+  trace("find_syft: using docker for running syft")
+  return (
+    docker_path + " run " +
+    "--rm " +
+    "--entrypoint=" + tool.syft.syft_entrypoint + " " +
+    "-v " + path + ":" + path + " " +
+    tool.syft.syft_container
+  )
+}
+
+func syft_system() {
+  result := find_exe("syft", [tool.syft.syft_exe_dir]) # /tmp is in addition to $PATH
+  if result == "" {
+    trace("find_syft: Unable to find syft in $PATH")
+  } else {
+    trace("find_syft: found syft in $PATH: " + result)
+  }
+}
+
+func find_syft(path) {
+  if tool.syft.syft_prefer_docker {
+    result := syft_docker(path)
+    if result != "" {
+      return
+    }
+  }
+  result := syft_system()
+  if result != "" {
+    return result
+  }
+  result := syft_docker(path)
 }
 
 func install_syft(path) {

--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023, Crash Override, Inc.
+## Copyright (c) 2023-2024, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -16,44 +16,62 @@ tool syft {
                                                   dict[string, string])
   syft_exe_dir:      "/tmp"
   syft_installer:    "https://raw.githubusercontent.com/anchore/syft/main/install.sh"
+  syft_container:    "anchore/syft"
+  syft_entrypoint:   "/syft"
   syft_argv:         " -o cyclonedx-json"  # CycloneDX by default.
   ~doc:              """
 This runs the syft SBOM tool.  If it can't be found in the current path,
-chalk will attempt to install it into /tmp, via the official installer,
-located at `https://raw.githubusercontent.com/anchore/syft/main/install.sh`
+chalk will:
+
+1. use docker (if present) to run syft
+2. attempt to install it into /tmp, via the official installer,
+   located at `https://raw.githubusercontent.com/anchore/syft/main/install.sh`
 
 You can configure the following fields in the tool.syft object:
 
-syft_exe_dir:   Where to try to install syft, if not found.  Defaults to "/tmp"
-syft_installer: Location of the official syft installer.
-syft_argv:      Command-line flags to pass to syft. Defaults to:
-                -o cyclone-json
+syft_exe_dir:    Where to try to install syft, if not found.  Defaults to "/tmp"
+syft_container:  Name of docker container to use to run syft
+syft_entrypoint: What entrypoint to use inside the container
+syft_installer:  Location of the official syft installer.
+syft_argv:       Command-line flags to pass to syft. Defaults to:
+                 -o cyclone-json
 """
 }
 
-func find_syft(ignore) {
+func find_syft(path) {
   result := find_exe("syft", ["/tmp"]) # /tmp is in addition to $PATH
-
   if result == "" {
-    trace("find_syft: Unable to find syft in $PATH")
+    docker_path := docker_exe()
+    if docker_path == "" {
+      trace("find_syft: Unable to find syft in $PATH and docker is not available")
+    } elif tool.syft.syft_entrypoint != "" and tool.syft.syft_container != "" {
+      trace("find_syft: Using docker for running syft")
+      return (
+        docker_path + " run " +
+        "--rm " +
+        "--entrypoint=" + tool.syft.syft_entrypoint + " " +
+        "-v " + path + ":" + path + " " +
+        tool.syft.syft_container
+      )
+    } else {
+      trace("find_syft: Unable to find syft in $PATH and docker is disabled")
+    }
   } else {
     trace("found syft at: " + result)
   }
 }
 
-func install_syft(ignore) {
+func install_syft(path) {
   info("Attempting to install syft from " + tool.syft.syft_installer)
 
   contents := url_get(tool.syft.syft_installer)
 
   if not starts_with(contents, "#!") {
-    error("Unable to install syft into: " + tool.syft.syft_exe_dir + ": " +
-    contents)
-
+    error("Syft installer is not a valid shell script due to lack of shebang")
     return false
   }
 
-  trace("Downloaded syft successfully.")
+  trace("Downloaded syft installer script successfully.")
 
   installer := to_tmp_file(contents, ".sh")
   cmdline   := "sh " + installer + " -b " + tool.syft.syft_exe_dir
@@ -75,8 +93,6 @@ func install_syft(ignore) {
 
 func get_syft_args(path) {
   result := path + tool.syft.syft_argv + " 2>/dev/null"
-
-  trace("args to syft: " + result)
 }
 
 func extract_syft_sbom(out: string, code) {
@@ -85,18 +101,14 @@ func extract_syft_sbom(out: string, code) {
   if code != 0 {
     error("syft failed to run properly; ignoring")
     echo(out)
+    return {}
   }
 
-  validIndicator := "\"component"
-  emptyIndicator := "\"components\": []"
+  if not starts_with(strip(out), "{") {
+    error("syft did not run properly - invalid json returned; ignoring")
+    echo(out)
+    return {}
+  }
 
-  if not contains(out, validIndicator) {
-    warn("syft did not run properly; ignoring")
-  }
-  elif contains(out, emptyIndicator) {
-    info("syft didn't find any components; ignoring.")
-  }
-  else {
-     return { "SBOM" : out }
-  }
+  return { "SBOM" : parse_json(out) }
 }

--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -24,7 +24,7 @@ This runs the syft SBOM tool.  If it can't be found in the current path,
 chalk will:
 
 1. use docker (if present) to run syft
-2. attempt to install it into /tmp, via the official installer,
+2. otherwise, attempt to install it into /tmp, via the official installer,
    located at `https://raw.githubusercontent.com/anchore/syft/main/install.sh`
 
 You can configure the following fields in the tool.syft object:
@@ -105,7 +105,7 @@ func extract_syft_sbom(out: string, code) {
   }
 
   if not starts_with(strip(out), "{") {
-    error("syft did not run properly - invalid json returned; ignoring")
+    error("syft did not run properly - invalid JSON returned; ignoring")
     echo(out)
     return {}
   }

--- a/src/plugins/externalTool.nim
+++ b/src/plugins/externalTool.nim
@@ -39,6 +39,10 @@ proc runOneTool(info: PIInfo, path: string): ChalkDict =
       return
     exe = ensureRunCallback[string](info.obj.getToolLocation, args)
 
+  if exe == "":
+    trace(info.name & ": could not be found. skipping")
+    return
+
   let
     argv = ensureRunCallback[string](info.obj.getCommandArgs, args)
     cmd  = exe & " " & argv.strip()

--- a/src/plugins/externalTool.nim
+++ b/src/plugins/externalTool.nim
@@ -8,102 +8,73 @@
 ## This plugin uses information from the config file to set metadata
 ## keys.
 
-import std/algorithm
-import ".."/[config, chalkjson, plugin_api]
+import std/[algorithm, sequtils]
+import ".."/[config, plugin_api, util]
 
-type
-  PIInfo      = ref object
-    name: string
-    obj: ToolInfo
+type PIInfo = ref object
+  name: string
+  obj:  ToolInfo
 
-template broken(cb: CallbackObj, info: PIInfo) =
-  error("missing implementation of " & $(cb) & " for tool: " & info.name)
-  return false
+proc ensureRunCallback[T](cb: CallbackObj, args: seq[Box]): T =
+  let value = runCallback(cb, args)
+  if value.isNone():
+    raise newException(ValueError, "missing implemenetation of " & $(cb))
+  return unpack[T](value.get())
 
-proc runOneTool(info: PIInfo, path: string, dict: var ChalkDict): bool =
-  var
-    args   = @[pack(path)]
-    locbox = runCallback(info.obj.getToolLocation, args)
+var toolCache = initTable[string, ChalkDict]()
+proc runOneTool(info: PIInfo, path: string): ChalkDict =
+  let key = info.name & ":" & path
+  if key in toolCache:
+    return toolCache[key]
 
-  if locBox.isNone(): broken(info.obj.getToolLocation, info)
-  var
-    path   = unpack[string](locBox.get()).strip()
+  trace("Running tool: " & info.name)
+  result = ChalkDict()
+  let args = @[pack(path)]
+  var exe  = ensureRunCallback[string](info.obj.getToolLocation, args)
 
-  if path == "":
-    let installed = runCallback(info.obj.attemptInstall, args)
-    if installed.isNone(): broken(info.obj.attemptInstall, info)
-    if not unpack[bool](installed.get()): return false
-    locbox = runCallback(info.obj.getToolLocation, args)
-    if locBox.isNone(): broken(info.obj.getToolLocation, info)
-    path = unpack[string](locBox.get()).strip()
-
-  let argv = runCallback(info.obj.getCommandArgs, args)
-  if argv.isNone(): broken(info.obj.getCommandArgs, info)
-  let
-    cmd    = pack(path & " " & unpack[string](argv.get()).strip())
-    outs   = unpack[seq[Box]](c4mSystem(@[cmd]).get())
+  if exe == "":
+    let installed = ensureRunCallback[bool](info.obj.attemptInstall, args)
+    if not installed:
+      trace(info.name & ": could not be installed. skipping")
+      return
+    exe = ensureRunCallback[string](info.obj.getToolLocation, args)
 
   let
-    retOpt = runCallback(info.obj.produceKeys, outs)
-  if retOpt.isNone(): broken(info.obj.produceKeys, info)
+    argv = ensureRunCallback[string](info.obj.getCommandArgs, args)
+    cmd  = exe & " " & argv.strip()
+  trace(cmd)
   let
-    d   = unpack[ChalkDict](retOpt.get())
+    outs = unpack[seq[Box]](c4mSystem(@[pack(cmd)]).get())
 
-  if len(d) == 0: return false
+  let d = ensureRunCallback[ChalkDict](info.obj.produceKeys, outs)
+  if len(d) == 0:
+    trace(info.name & ": produced no keys. skipping")
+    return
   if d.contains("error"):
-    error(unpack[string](d["error"]))
-    return false
+    error(info.name & ": " & unpack[string](d["error"]))
+    return
   if d.contains("warn"):
-    warn(unpack[string](d["warn"]))
+    warn(info.name & ": " & unpack[string](d["warn"]))
     d.del("warn")
   if d.contains("info"):
-    warn(unpack[string](d["info"]))
+    info(info.name & ": " & unpack[string](d["info"]))
     d.del("info")
 
-  # The ChalkDict returned is of the form: chalkKey: chalkContents.
-  # For instance, it might come back SBOM : "{arbitrary sbom as a
-  # string}" If the string we get back parses as valid JSON, we will
-  # expand it out.  If not, we use it as-is.
-  #
-  # These k/v pairs will be merged into the dict field, which will take
-  # the form, SBOM : { info.name : chalkContents }
-  #
-  # Where the ChalkContents is either a JSON object or a string
-  # literal.
+  trace(info.name & ": produced keys " & $(d.keys().toSeq()))
+  toolCache[key] = d
+  return d
 
-  for k, v in d:
-    var kindChalkDict: ChalkDict
-    if k in dict:
-      kindChalkDict = unpack[ChalkDict](dict[k])
-    else:
-      kindChalkDict = ChalkDict()
-
-    kindChalkDict[info.name] = v
-    for k, v in kindChalkDict:
-      try:
-        # Attempt to parse as a JSON object.  If not, treat it as a string,
-        # but encode it into a JSON object.
-        let
-          asJson = parseJson(unpack[string](v))
-          asBox  = asJson.nimJsonToBox()
-        kindChalkDict[k] = asBox
-      except:
-        kindChalkDict[k] = pack[string](escapeJson(unpack[string](v)))
-
-    dict[k] = pack(kindChalkDict)
-
-  return info.obj.stopOnSuccess
-
-template toolBase(s: string) {.dirty.} =
+template toolBase(path: string) {.dirty.} =
   result = ChalkDict()
 
   var
-    toolInfo: Table[string, seq[(int, PIInfo)]]
+    toolInfo = initTable[string, seq[(int, PIInfo)]]()
   let
-    runSbom = get[bool](chalkConfig, "run_sbom_tools")
-    runSast = get[bool](chalkConfig, "run_sast_tools")
+    runSbom  = get[bool](chalkConfig, "run_sbom_tools")
+    runSast  = get[bool](chalkConfig, "run_sast_tools")
 
   # tools should only run during insert operations
+  # note this is a subset of chalkable operations
   if getCommandName() notin @["build", "insert"]:
     return result
 
@@ -112,23 +83,33 @@ template toolBase(s: string) {.dirty.} =
     if not runSbom and v.kind == "sbom": continue
     if not runSast and v.kind == "sast": continue
 
-    let priority = v.priority
+    let tool = (v.priority, PIInfo(name: k, obj: v))
     if v.kind notin toolInfo:
-      toolInfo[v.kind] =  @[(priority, PIInfo(name: k, obj: v))]
+      toolInfo[v.kind] = @[tool]
     else:
-      toolInfo[v.kind].add((priority, PIInfo(name: k, obj: v)))
+      toolInfo[v.kind].add(tool)
 
   for k, v in toolInfo:
-    var sortArr = v
-    sortArr.sort()
-    for (ignore, info) in sortArr:
-      trace("Running tool: " & info.name)
-      if info.runOneTool(s, result): break
+    for (ignore, info) in v.sorted():
+      try:
+        let data = info.runOneTool(path)
+        # merge multiple tools into a single structure
+        # for example first tool returns:
+        # { SBOM: { foo: {...} } }
+        # and second tool returns:
+        # { SBOM: { bar: {...} } }
+        # merged structure should be:
+        # { SBOM: { foo: {...}, bar: {...} } }
+        result.merge(data.nestWith(info.name))
+        if len(data) >= 0 and info.obj.stopOnSuccess:
+          break
+      except:
+        error(info.name & ": " & getCurrentExceptionMsg())
 
-proc toolGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
+proc toolGetChalkTimeHostInfo(self: Plugin): ChalkDict {.cdecl.} =
   toolBase(resolvePath(getContextDirectories()[0]))
 
-proc toolGetChalkTimeArtifactInfo*(self: Plugin, obj: ChalkObj):
+proc toolGetChalkTimeArtifactInfo(self: Plugin, obj: ChalkObj):
                                  ChalkDict {.cdecl.} =
   if obj.fsRef != "":
     toolbase(resolvePath(obj.fsRef))

--- a/src/util.nim
+++ b/src/util.nim
@@ -582,8 +582,22 @@ proc merge*(self: ChalkDict, other: ChalkDict): ChalkDict {.discardable.} =
   for k, v in other:
     if k in self and self[k].kind == MkSeq and v.kind == MkSeq:
       self[k] &= v
+    elif k in self and self[k].kind == MkTable and v.kind == MkTable:
+      let
+        mine   = unpack[ChalkDict](self[k])
+        theirs = unpack[ChalkDict](v)
+      for kk, vv in theirs:
+        mine[kk] = vv
+      self[k] = pack(mine)
     else:
       self[k] = v
+
+proc nestWith*(self: ChalkDict, key: string): ChalkDict =
+  result = ChalkDict()
+  for k, v in self:
+    let value = ChalkDict()
+    value[key] = v
+    result[k] = pack(value)
 
 proc strip*(items: seq[string], leading = true, trailing = true, chars = Whitespace): seq[string] =
   result = @[]

--- a/tests/functional/data/configs/composable/valid/sast/enable_sast.c4m
+++ b/tests/functional/data/configs/composable/valid/sast/enable_sast.c4m
@@ -12,3 +12,9 @@ mark_template.mark_default.key.SAST.use: true
 mark_template.minimal.key.SAST.use: true
 
 tool.semgrep.semgrep_config_profile: "rule.yaml"
+
+if env("EXTERNAL_TOOL_USE_DOCKER") != "False" {
+  tool.semgrep.semgrep_prefer_docker = true
+} else {
+  tool.semgrep.semgrep_entrypoint    = ""
+}

--- a/tests/functional/data/configs/composable/valid/sboms/enable_sboms.c4m
+++ b/tests/functional/data/configs/composable/valid/sboms/enable_sboms.c4m
@@ -7,3 +7,9 @@ mark_template.mark_default.key.SBOM.use: true
 
 # `chalk docker build` uses the `minimal` template.
 mark_template.minimal.key.SBOM.use: true
+
+if env("EXTERNAL_TOOL_USE_DOCKER") != "False" {
+  tool.syft.syft_prefer_docker = true
+} else {
+  tool.syft.syft_entrypoint    = ""
+}

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -920,7 +920,9 @@ def test_semgrep(tmp_data_dir: Path, test_file: str, chalk_copy: Chalk):
                                     {
                                         "physicalLocation": {
                                             "artifactLocation": {
-                                                "uri": "helloworld.py",
+                                                "uri": str(
+                                                    tmp_data_dir / "helloworld.py"
+                                                ),
                                                 "uriBaseId": "%SRCROOT%",
                                             },
                                             "region": {

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -2,11 +2,11 @@
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
-import os
 import re
 import shutil
 from pathlib import Path
 
+import os
 import pytest
 
 from .chalk.runner import Chalk, ChalkMark
@@ -22,6 +22,7 @@ from .utils.dict import ANY
 from .utils.docker import Docker
 from .utils.git import Git
 from .utils.log import get_logger
+
 
 logger = get_logger()
 
@@ -843,8 +844,9 @@ def test_syft_docker(chalk_copy: Chalk, test_file: str, random_hex: str):
     assert chalk_mark.contains(sbom_data)
 
 
+@pytest.mark.parametrize("use_docker", [True, False])
 @pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
-def test_syft_binary(copy_files: list[Path], chalk_copy: Chalk):
+def test_syft_binary(copy_files: list[Path], chalk_copy: Chalk, use_docker: bool):
     bin_path = copy_files[0]
 
     # we need to enable sboms + embed sboms so load test config
@@ -872,26 +874,33 @@ def test_syft_binary(copy_files: list[Path], chalk_copy: Chalk):
 
     artifact = ArtifactInfo.one_elf(bin_path, chalk_info=sbom_data)
 
-    insert = chalk.insert(bin_path)
+    insert = chalk.insert(bin_path, env={"EXTERNAL_TOOL_USE_DOCKER": str(use_docker)})
     validate_chalk_report(
         chalk_report=insert.report,
         artifact_map=artifact,
         virtual=False,
         chalk_action="insert",
     )
+    if use_docker:
+        assert "ghcr.io/anchore/syft" in insert.logs
+    else:
+        assert "ghcr.io/anchore/syft" not in insert.logs
 
     # check that sbom has been embedded into the artifact
     chalk_mark = ChalkMark.from_binary(bin_path)
     assert chalk_mark.contains(sbom_data)
 
 
+@pytest.mark.parametrize("use_docker", [True, False])
 @pytest.mark.parametrize(
     "test_file",
     [
         "sample_1",
     ],
 )
-def test_semgrep(tmp_data_dir: Path, test_file: str, chalk_copy: Chalk):
+def test_semgrep(
+    tmp_data_dir: Path, test_file: str, chalk_copy: Chalk, use_docker: bool
+):
     shutil.copytree(PYS / test_file, tmp_data_dir, dirs_exist_ok=True)
     # copy rule.yaml also
     shutil.copy(DATA / "semgrep" / "rule.yaml", tmp_data_dir)
@@ -964,13 +973,19 @@ def test_semgrep(tmp_data_dir: Path, test_file: str, chalk_copy: Chalk):
         tmp_data_dir / "helloworld.py", chalk_info=sast_data
     )
 
-    insert = chalk.insert(artifact=tmp_data_dir)
+    insert = chalk.insert(
+        artifact=tmp_data_dir, env={"EXTERNAL_TOOL_USE_DOCKER": str(use_docker)}
+    )
     validate_chalk_report(
         chalk_report=insert.report,
         artifact_map=artifact,
         virtual=False,
         chalk_action="insert",
     )
+    if use_docker:
+        assert "semgrep/semgrep" in insert.logs
+    else:
+        assert "semgrep/semgrep" not in insert.logs
 
     # check that sbom has been embedded into the artifact
     chalk_mark = ChalkMark.from_binary(tmp_data_dir / "helloworld.py")

--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -8,3 +8,8 @@ custom_report.terminal_other_op.enabled: false
 if not env_exists("VENDOR") {
   cloud_provider.cloud_instance_hw_identifiers.sys_vendor_path: "/tmp/nonexisting"
 }
+
+# to avoid rate throttling in CI
+tool.syft.syft_container = "ghcr.io/anchore/syft"
+# unfortunately semgrep does not publish to ghcr
+# https://github.com/semgrep/semgrep/issues/9169


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary



## Description

previously chalk would always try to install the external tool on the host system which in some cases required some system dependencies like `pipx` or `python3` to be available for `semgrep`. Right now the precedence is:

1. use installed tool
2. use docker (if present)
3. install tool

This should minimize any external system dependencies and should allow to bundle any tool configs in a container which can be customized via the config:

```
tool.syft.syft_container = "mysyft:latest"
```

In addition some logging was improved in tool runtime to help in debugging what tool ran and what keys it generated.

Also `semgrep ci` does not allow to specify target for scanning which means that it was always scanning `cwd()` which is incorrect for example in case of docker builds when context is outside of `cwd()`. Now `semgrep scan` is used which allows to specify target for scanning.

## Testing

```
➜ make tests args="test_plugins.py::test_semgrep test_plugins.py::test_syft_docker  -x --logs"
```
