### PR TITLE
fix: docker non-buildx file copy ensure name is unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
   scans when the Docker context was outside that
   directory.
   ([#314](https://github.com/crashappsec/chalk/pull/314))
+- Docker wrapping `ENTRYPOINT` without `buildx` was failing
+  when docker context folder already had either `chalk`
+  or `docker` file/folder.
+  ([#315](https://github.com/crashappsec/chalk/pull/315))
+- Docker wrapping `ENTRYPOINT` with buildx was failing
+  when chalk binary was located next to `.dockerignore`
+  (e.g. in chalk repo itself) hence chalk could not be
+  copied during the build.
+  ([#315](https://github.com/crashappsec/chalk/pull/315))
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,14 @@
   scans when the Docker context was outside that
   directory.
   ([#314](https://github.com/crashappsec/chalk/pull/314))
-- Docker wrapping `ENTRYPOINT` without `buildx` was failing
-  when docker context folder already had either `chalk`
-  or `docker` file/folder.
+- Without Buildx, Docker failed to wrap `ENTRYPOINT` when
+  the Docker context folder already had a file/directory named
+  `chalk` or `docker`.
   ([#315](https://github.com/crashappsec/chalk/pull/315))
-- Docker wrapping `ENTRYPOINT` with buildx was failing
-  when chalk binary was located next to `.dockerignore`
-  (e.g. in chalk repo itself) hence chalk could not be
-  copied during the build.
+- With Buildx, Docker failed to wrap `ENTRYPOINT` when
+  a `chalk` binary was located next to `.dockerignore`
+  (e.g. in the Chalk repo itself) because `chalk` could
+  not be copied during the build.
   ([#315](https://github.com/crashappsec/chalk/pull/315))
 
 ### New Features

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -408,7 +408,6 @@ proc dockerBuild*(ctx: DockerInvocation): int =
               text       = chalk.getChalkMarkAsStr(),
               newPath    = "/chalk.json",
               user       = user,
-              move       = true,
               chmod      = "0444",
               byPlatform = ctx.isMultiPlatform(),
               platform   = platform,

--- a/src/docker/entrypoint.nim
+++ b/src/docker/entrypoint.nim
@@ -106,7 +106,7 @@ proc rewriteEntryPoint*(ctx:        DockerInvocation,
       binaries = binaries,
       newPath  = "/chalk",
       user     = user,
-      move     = false,
+      move     = false, # preserve original file
       chmod    = "0755",
   )
 

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -102,7 +102,7 @@ def test_no_docker(chalk: Chalk):
     ],
 )
 def test_build(
-    chalk: Chalk,
+    chalk_copy: Chalk,
     dockerfile: Optional[Path],
     cwd: Optional[Path],
     tag: Optional[bool],
@@ -112,7 +112,8 @@ def test_build(
     """
     Test various variants of docker build command
     """
-    image_id, build = chalk.docker_build(
+    chalk_copy.binary.rename("chalk")
+    image_id, build = chalk_copy.docker_build(
         dockerfile=dockerfile,
         cwd=cwd,
         tag=random_hex if tag else None,


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

When docker context contained `docker` or `chalk` folders, entrypoint wrapping would fail

## Description

For non-buildx build, as the file needed to be copied into the context to be copied in Dockerfile, the name needs to be unique as if the same filename/folder already exist in the context folder, the copy/move will fail which in turn would bail out of ENTRYPOINT wrapping. Now chalk ensures that filename is unique for both copy/move modes.

In addition when using buildx, whenever chalk binary was located in a folder which contained .dockerignore which ignored the `chalk` binary (e.g. in chalk repo itself), the wrapping would fail as the binary could not be copied into the build. Now this edge case is detected and the file is copied into a temporary directory hence guaranteeing there is no .dockerignore there.

## Testing

<!-- What are the steps needed to test this PR? -->
