### PR TITLE
fix(docker): build without buildx with non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   `/chalk.json` which was from the base image which is
   not expected.
   ([#322](https://github.com/crashappsec/chalk/pull/322))
+- Docker build without `buildx` was failing for distroless
+  images with non-root `USER`.
+  ([#323](https://github.com/crashappsec/chalk/pull/323))
 
 ## 0.4.2
 

--- a/src/docker/exe.nim
+++ b/src/docker/exe.nim
@@ -176,6 +176,10 @@ proc supportsInspectJsonFlag*(): bool =
   # https://github.com/docker/cli/pull/2936
   return getDockerClientVersion() >= parseVersion("22")
 
+proc supportsMultiStageBuilds*(): bool =
+  # https://docs.docker.com/engine/release-notes/17.05/
+  return getDockerServerVersion() >= parseVersion("17.05")
+
 proc installBinFmt*() =
   once:
     # https://docs.docker.com/build/building/multi-platform/#qemu-without-docker-desktop

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -129,7 +129,7 @@ def test_scratch(chalk: Chalk, buildkit: bool):
     _, build = chalk.docker_build(
         dockerfile=DOCKERFILES / "valid" / "empty" / "Dockerfile",
         buildkit=buildkit,
-        expected_success=buildkit,
+        run_docker=buildkit,  # non-buildx doesnt allow empty image
         config=CONFIGS / "docker_wrap.c4m",
     )
     if buildkit:

--- a/tests/unit/test_semver.nim
+++ b/tests/unit/test_semver.nim
@@ -8,6 +8,7 @@ proc main() =
 
   doAssert parseVersion("0.1") == parseVersion("0.1.0")
   doAssert parseVersion("0.1.0") == parseVersion("0.1.0")
+  doAssert parseVersion("0.1.05") == parseVersion("0.1.5")
   doAssert not (parseVersion("0.1") == parseVersion("0.1.5"))
   doAssert not (parseVersion("0.1") == parseVersion("0.1-dev"))
   doAssert not (parseVersion("0.1.0") == parseVersion("0.1.5"))
@@ -33,12 +34,14 @@ proc main() =
   doAssert parseVersion("0.1") > parseVersion("0.1-dev")
   doAssert parseVersion("0.1.5") > parseVersion("0.1")
   doAssert parseVersion("0.1.5") > parseVersion("0.1.0")
+  doAssert parseVersion("0.1.05") > parseVersion("0.1.0")
   doAssert not (parseVersion("0.1") > parseVersion("0.1"))
   doAssert not (parseVersion("0.1.0") > parseVersion("0.1"))
 
   doAssert parseVersion("0.1") >= parseVersion("0.1-dev")
   doAssert parseVersion("0.1.5") >= parseVersion("0.1")
   doAssert parseVersion("0.1.5") >= parseVersion("0.1.0")
+  doAssert parseVersion("0.1.05") >= parseVersion("0.1.0")
   doAssert parseVersion("0.1") >= parseVersion("0.1")
   doAssert parseVersion("0.1.0") >= parseVersion("0.1")
 


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

when using distroless image without buildx, some builds can fail

## Description

When chalk needs to copy both `/chalk.json` and `/chalk` in the build, it needs to set correct permissions on the file. Without buildx, as it cannot leverage `COPY --chmod`, Chalk needs to manually adjust permissions by:

```
COPY chalk.json /chalk.json
RUN chmod 0444 /chalk.json
```

However for distroless images `RUN` cannot work as there is no `chmod` executable and so the build will fail.

Now for this case we attempt to use multi-stage builds if possible as we can use `busybox` image which has the capability to run `chmod` and then we copy that into the final image. Something like:

```
FROM busybox AS chalk_json
COPY chalk.json /chalk.json
RUN chmod 0444 /chalk.json

FROM scratch
COPY --from=chalk_json /chalk.json /chalk.json
```

There is still an edge case where this will fail when docker doesnt support multi-stage builds but at that point we have no other options so wrapping will fail without any other recourse.


## Testing

```
➜ make tests args="test_docker.py::test_scratch --logs"
```
