### PR TITLE
fix: _IMAGE_ONBUILD is a list, not a string

### DIFF
--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -2661,7 +2661,7 @@ The set MAC address for a container
 
 keyspec _IMAGE_ONBUILD {
     kind:     RunTimeArtifact
-    type:     string
+    type:     list[string]
     standard: true
     doc: """
 The ONBUILD instruction which adds to the image a trigger instruction to be executed at a later time, when the image is used as the base for another build.


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [ ] ~~Updated `CHANGELOG.md` if necessary~~

## Issue

no impact to anything. chalk was still reporting it correctly. just a warning message

## Description

there are warnings:

> warn: docker: JSON key Config.OnBuild associated with chalk key
> '_IMAGE_ONBUILD' is not of the expected type. Using it anyway.

the key has an incorrect type. ONBUILD must be an array but chalk was defining it as a string
