### PR TITLE
fix(docker): extracting chalk mark from distroless non-buildx images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- Docker push of distroless image built without `buildx` could
+  not extract chalk mark from the image.
+  ([#338](https://github.com/crashappsec/chalk/pull/338))
+
 ## 0.4.4
 
 **June 12, 2024**

--- a/src/docker/extract.nim
+++ b/src/docker/extract.nim
@@ -15,8 +15,7 @@ proc hasChalkLayer(self: ChalkObj): bool =
   result = false
   let layers = inspectHistoryCommands(self.imageId)
   for layer in layers:
-    let withoutComment = layer.split("#")[0].strip()
-    if layer.startsWith("COPY ") and layer.endsWith(" /chalk.json"):
+    if "COPY " in layer and " /chalk.json" in layer:
       return true
 
 proc extractMarkFromStdOut(s: string): string =

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -505,9 +505,10 @@ class Chalk:
                 pass
         return image_hash, result
 
-    def docker_push(self, image: str):
+    def docker_push(self, image: str, buildkit: bool = True):
         return self.run(
             params=["docker", "push", image],
+            env=Docker.build_env(buildkit=buildkit),
         )
 
     def docker_pull(self, image: str):


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Image build without buildx on `docker push` its chalk mark was not reported

## Description


The format of `docker history` is different between buildx and non-buildx images. For non-buildx:

```
/bin/sh -c #(nop) COPY file:283b357328fb308cf6cfe240564dab744e8547f48c8626f11c1926ce41df45ef in /chalk.json
```

For buildx:

```
COPY --chmod=0444 chalk-XP9wJMFN-file.tmp /chalk.json # buildkit
```

To try to accomodate both chalk now simply checks for substring match whether `"COPY "` and `" /chalk.json"` was present in the layer spec and if so it attempts to extract chalk mark from the image tar file.


## Testing

```
➜ make tests args="test_docker.py::test_build_and_push[valid/empty-False-False] --logs"
```
