### PR TITLE
feat: BUILD_COMMIT_ID key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   not extract chalk mark from the image.
   ([#338](https://github.com/crashappsec/chalk/pull/338))
 
+### New Features
+
+- Added `BUILD_COMMIT_ID` key. This reports the commit ID
+  which triggered the build in CI/CD.
+  ([#339](https://github.com/crashappsec/chalk/pull/339))
+
 ## 0.4.4
 
 **June 12, 2024**

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -75,6 +75,7 @@ or vice versa.
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.BUILD_ID.use                            = true
+  key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
@@ -174,6 +175,7 @@ mark_template mark_large {
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.BUILD_ID.use                            = true
+  key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
@@ -271,6 +273,7 @@ use the mark template named `reproducable`.
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.BUILD_ID.use                            = true
+  key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
@@ -335,6 +338,7 @@ the time and the nonce removed.
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.BUILD_ID.use                            = true
+  key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1216,6 +1216,17 @@ key's documentation for more detail).
 """
 }
 
+keyspec BUILD_COMMIT_ID {
+  kind:     ChalkTimeHost
+  type:     string
+  standard: true
+  since:    "0.4.5"
+  shortdoc: "Commit ID which triggered the build"
+  doc:      """
+Commit ID which triggered the build in CI/CD at chalk time.
+"""
+}
+
 keyspec BUILD_TRIGGER {
     kind:             ChalkTimeHost
     type:             string

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -111,7 +111,8 @@ artifacts will be attached to that info.
 
 plugin ci_github {
     enabled:         true
-    pre_run_keys:    ["BUILD_ID", "BUILD_URI", "BUILD_API_URI",
+    pre_run_keys:    ["BUILD_ID", "BUILD_COMMIT_ID",
+                      "BUILD_URI", "BUILD_API_URI",
                       "BUILD_TRIGGER", "BUILD_CONTACT",
                       "BUILD_ORIGIN_ID", "BUILD_ORIGIN_OWNER_ID",
                       "BUILD_ORIGIN_KEY", "BUILD_ORIGIN_OWNER_KEY"]
@@ -134,7 +135,8 @@ This only collects data when adding chalk marks.
 
 plugin ci_gitlab {
     enabled:         true
-    pre_run_keys:    ["BUILD_ID", "BUILD_URI", "BUILD_API_URI",
+    pre_run_keys:    ["BUILD_ID",  "BUILD_COMMIT_ID",
+                      "BUILD_URI", "BUILD_API_URI",
                       "BUILD_TRIGGER", "BUILD_CONTACT",
                       "BUILD_ORIGIN_ID", "BUILD_ORIGIN_OWNER_ID"]
     doc: """

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -85,6 +85,7 @@ report and subtract from it.
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.BUILD_ID.use                            = true
+  key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
@@ -650,6 +651,7 @@ doc: """
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.BUILD_ID.use                            = true
+  key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
@@ -1106,6 +1108,7 @@ container.
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.BUILD_ID.use                            = true
+  key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true
@@ -1562,6 +1565,7 @@ and keep the run-time key.
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.BUILD_ID.use                            = true
+  key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
   key.BUILD_TRIGGER.use                       = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -194,6 +194,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.CODE_OWNERS.use                         = true
   ~key.VCS_DIR_WHEN_CHALKED.use                = true
   ~key.BUILD_ID.use                            = true
+  ~key.BUILD_COMMIT_ID.use                     = true
   ~key.BUILD_URI.use                           = true
   ~key.BUILD_API_URI.use                       = true
   ~key.BUILD_TRIGGER.use                       = true

--- a/src/plugins/ciGithub.nim
+++ b/src/plugins/ciGithub.nim
@@ -55,6 +55,7 @@ proc githubGetChalkTimeHostInfo(self: Plugin): ChalkDict {.cdecl.} =
   if CI == "" and GITHUB_SHA == "": return
 
   result.setIfNeeded("BUILD_ID",              GITHUB_RUN_ID)
+  result.setIfNeeded("BUILD_COMMIT_ID",       GITHUB_SHA)
   result.setIfNeeded("BUILD_ORIGIN_ID",       GITHUB_REPOSITORY_ID)
   result.setIfNeeded("BUILD_ORIGIN_OWNER_ID", GITHUB_REPOSITORY_OWNER_ID)
   result.setIfNeeded("BUILD_API_URI",         GITHUB_API_URL)

--- a/src/plugins/ciGitlab.nim
+++ b/src/plugins/ciGitlab.nim
@@ -18,6 +18,7 @@ proc gitlabGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.}  =
   let
     CI                  = getEnv("CI")
     GITLAB_CI           = getEnv("GITLAB_CI")
+    GITLAB_COMMIT_SHA   = getEnv("CI_COMMIT_SHA")
     GITLAB_JOB_URL      = getEnv("CI_JOB_URL")
     GITLAB_JOB_ID       = getEnv("CI_JOB_ID")
     GITLAB_API_URL      = getEnv("CI_API_V4_URL")
@@ -30,6 +31,7 @@ proc gitlabGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.}  =
   if CI == "" and GITLAB_CI == "": return
 
   result.setIfNeeded("BUILD_ID",              GITLAB_JOB_ID)
+  result.setIfNeeded("BUILD_COMMIT_ID",       GITLAB_COMMIT_SHA)
   result.setIfNeeded("BUILD_URI",             GITLAB_JOB_URL)
   result.setIfNeeded("BUILD_API_URI",         GITLAB_API_URL)
   result.setIfNeeded("BUILD_ORIGIN_ID",       GITLAB_PROJECT_ID)

--- a/src/plugins/ciJenkins.nim
+++ b/src/plugins/ciJenkins.nim
@@ -14,8 +14,7 @@ import ".."/[config, plugin_api]
 proc jenkinsGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
   result = ChalkDict()
 
-  # https://www.jenkins.io/doc/book/pipeline/
-  #                        jenkinsfile/#using-environment-variables
+  # https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
   let
     CI = getEnv("CI")
 

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -61,6 +61,7 @@ def test_github(copy_files: list[Path], chalk: Chalk, server_imds: str):
         bin_path,
         host_info={
             "BUILD_ID": "1658821493",
+            "BUILD_COMMIT_ID": "ffac537e6cbbf934b08745a378932722df287a53",
             "BUILD_TRIGGER": "tag",
             "BUILD_CONTACT": ["octocat"],
             "BUILD_URI": "https://github.com/octocat/Hello-World/actions/runs/1658821493/attempts/5",
@@ -107,6 +108,7 @@ def test_gitlab(copy_files: list[Path], chalk: Chalk):
         bin_path,
         host_info={
             "BUILD_ID": "4999820578",
+            "BUILD_COMMIT_ID": "ffac537e6cbbf934b08745a378932722df287a53",
             "BUILD_TRIGGER": "push",
             "BUILD_CONTACT": ["user"],
             "BUILD_URI": "https://gitlab.com/gitlab-org/gitlab/-/jobs/4999820578",
@@ -121,6 +123,7 @@ def test_gitlab(copy_files: list[Path], chalk: Chalk):
             # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
             "CI": "true",
             "GITLAB_CI": "true",
+            "CI_COMMIT_SHA": "ffac537e6cbbf934b08745a378932722df287a53",
             "CI_JOB_URL": "https://gitlab.com/gitlab-org/gitlab/-/jobs/4999820578",
             "CI_JOB_ID": "4999820578",
             "CI_API_V4_URL": "https://gitlab.com/api/v4",


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Description

this should allow to at find the commit id of the build in case chalk could not interact with the .git folder.

## Testing

```
➜ make tests args="test_plugins.py::test_github test_plugins.py::test_gitlab"
```
