### PR TITLE
fix(git): handle branch names with /

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Docker push of distroless image built without `buildx` could
   not extract chalk mark from the image.
   ([#338](https://github.com/crashappsec/chalk/pull/338))
+- Chalk did not handle git branch names with `/` in them
+  and therefore could not report correct
+  branch name/commit id.
+  ([#340](https://github.com/crashappsec/chalk/pull/340))
 
 ### New Features
 

--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -521,7 +521,7 @@ proc loadCommit(info: RepoInfo, commitId: string) =
 proc loadSymref(info: RepoInfo, gitRef: string) =
   let
     fname = gitRef[4 .. ^1].strip()
-    parts = fname.split({ DirSep, '/'}, maxsplit = 3)
+    parts = fname.split({ DirSep, '/'}, maxsplit = 2)
 
   if parts.len() < 3:
     error(fNameHead & ": Git HEAD file couldn't be loaded")

--- a/tests/functional/test_git.py
+++ b/tests/functional/test_git.py
@@ -53,7 +53,7 @@ def test_repo(
     tag_message = "Changes since the previous tag:\n\n- Fix widget\n- Improve performance of bar by 42%"
     git = (
         Git(tmp_data_dir, sign=sign)
-        .init(remote=remote)
+        .init(remote=remote, branch="foo/bar")
         .add()
         .commit(commit_message)
         .tag(f"{random_hex}-1")
@@ -64,7 +64,7 @@ def test_repo(
     author = re.compile(rf"^{git.author} \d+ [+-]\d+$")
     committer = re.compile(rf"^{git.committer} \d+ [+-]\d+$")
     assert result.mark.has(
-        BRANCH="main",
+        BRANCH="foo/bar",
         COMMIT_ID=ANY,
         COMMIT_SIGNED=sign,
         AUTHOR=author,

--- a/tests/functional/utils/git.py
+++ b/tests/functional/utils/git.py
@@ -34,11 +34,12 @@ class Git:
         first_commit: bool = True,
         add: bool = True,
         remote: Optional[str] = None,
+        branch: str = "main",
     ):
         author_name, author_email = self.author.split()
         committer_name, committer_email = self.committer.split()
         self.run(["git", "init"])
-        self.run(["git", "branch", "-m", "main"])
+        self.run(["git", "branch", "-m", branch])
         self.config("author.name", author_name)
         self.config("author.email", author_email)
         self.config("committer.name", committer_name)


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

chalk does not report `COMMIT_ID` for branches with `/` in them

## Description

If the branch is "foo/bar", chalk incorrectly split the branch name and therefore was only attempting to find commit id for branch "foo" which is incorrect.

## Testing

```
➜ make tests args="test_git.py::test_repo --logs -x"
```
