### PR TITLE
fix(git): git packed objects/refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   and therefore could not report correct
   branch name/commit id.
   ([#340](https://github.com/crashappsec/chalk/pull/340))
+- For packed repos (e.g. via `git gc`), chalk could not
+  report all git-related keys like `COMMIT_ID`, `TAG`, etc.
+  ([#341](https://github.com/crashappsec/chalk/pull/341))
 
 ### New Features
 

--- a/tests/functional/test_git.py
+++ b/tests/functional/test_git.py
@@ -30,6 +30,7 @@ from .utils.git import DATE_FORMAT, Git
         ),
     ],
 )
+@pytest.mark.parametrize("pack", [True, False])
 @pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
 @pytest.mark.parametrize(
     "set_tag_message",
@@ -46,6 +47,7 @@ def test_repo(
     sign: bool,
     random_hex: str,
     set_tag_message: bool,
+    pack: bool,
 ):
     commit_message = (
         "fix widget\n\nBefore this commit, the widget behaved incorrectly when foo."
@@ -56,9 +58,11 @@ def test_repo(
         .init(remote=remote, branch="foo/bar")
         .add()
         .commit(commit_message)
-        .tag(f"{random_hex}-1")
-        .tag(f"{random_hex}-2", tag_message if set_tag_message else None)
+        .tag(f"foo/{random_hex}-1")
+        .tag(f"foo/{random_hex}-2", tag_message if set_tag_message else None)
     )
+    if pack:
+        git.pack()
     artifact = copy_files[0]
     result = chalk_copy.insert(artifact)
     author = re.compile(rf"^{git.author} \d+ [+-]\d+$")
@@ -72,7 +76,7 @@ def test_repo(
         COMMITTER=committer,
         DATE_COMMITTED=DATE_FORMAT,
         COMMIT_MESSAGE=commit_message,
-        TAG=f"{random_hex}-2",
+        TAG=f"foo/{random_hex}-2",
         TAG_SIGNED=sign,
         TAGGER=committer if (sign or set_tag_message) else MISSING,
         DATE_TAGGED=DATE_FORMAT if (sign or set_tag_message) else MISSING,

--- a/tests/functional/utils/git.py
+++ b/tests/functional/utils/git.py
@@ -5,7 +5,6 @@
 import functools
 import re
 from pathlib import Path
-from time import sleep
 from typing import Optional
 
 import os
@@ -68,6 +67,10 @@ class Git:
         if message or self.sign:
             args += ["-a", "-m", message or "dummy"]
         self.run(args)
+        return self
+
+    def pack(self):
+        self.run(["git", "gc"])
         return self
 
     @property


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

annotated tags are not reported when cloning repo in CI (github)

fixes https://github.com/crashappsec/chalk/issues/332
fixes https://github.com/crashappsec/chalk/issues/342

## Description

    Packed git object does not store normal object header.
    When reading file from the pack, chalk now adds back normal object
    header for consistent parsing so its irrelevant where the object
    content was grabbed from.

    In addition `git pack-refs` packs all refs in .git/refs/ into
    .git/packed-refs which chalk now honors as well.
    Otherwise chalk would presume it was an empty git repo.


## Testing

```
✗ make tests args="test_git.py::test_repo --logs -x"
```
