### PR TITLE
fix(git): commit id is correctly determined for annotated symbolic ref tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- Chalk did not extract correct commit ID for git repos
+  with `HEAD` being symbolic reference to an annotated tag.
+  This usually happens via `git symbolic-ref HEAD`.
+  ([#347](https://github.com/crashappsec/chalk/pull/347))
+
 ## 0.4.5
 
 ### Fixes

--- a/tests/functional/utils/git.py
+++ b/tests/functional/utils/git.py
@@ -69,10 +69,18 @@ class Git:
         self.run(args)
         return self
 
+    def checkout(self, spec: str):
+        self.run(["git", "checkout", spec])
+        return self
+
+    def symbolic_ref(self, ref: str):
+        self.run(["git", "symbolic-ref", "HEAD", ref])
+        return self
+
     def pack(self):
         self.run(["git", "gc"])
         return self
 
     @property
     def latest_commit(self) -> str:
-        return self.run(["git", "rev-parse", "HEAD"]).text
+        return self.run(["git", "log", "-n1", "--pretty=format:%H"]).text


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

wrong commit id is reported

## Description


`.git/HEAD` can be a symbolic ref to a branch/tag or directly pointer to a commit. When doing `git checkout <branch>` it normally sets it to symbolic ref however when doing `git checkout <tag>` it usually sets it directly to the tag's commit. However it is possible to update it via `git symbolic-ref HEAD <tag>`. In that case `HEAD` will point to annotated tag and as such we chalk simply opens the ref of that symbolic ref it is not guaranteed to be for a commit id. Now chalk loads the tag object and if it is an annotated tag, resolves commit id to be from the tags object pointer.

## Testing

```
➜ make tests args="test_git.py::test_repo[False-copy_files0-True-None-True-True] --logs -x"
```
