### PR TITLE
fix: refetching lightweight tags from origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   with `HEAD` being symbolic reference to an annotated tag.
   This usually happens via `git symbolic-ref HEAD`.
   ([#347](https://github.com/crashappsec/chalk/pull/347))
+- Chalk misreported annotated git tag as not annotated.
+  To ensure tag is up-to-date with origin, chalk refetches
+  regular tags (not annotated) from origin. To customize
+  this behavior use `git.refetch_lightweight_tags` config.
+  ([#349](https://github.com/crashappsec/chalk/pull/349))
 
 ## 0.4.5
 

--- a/src/configs/base_init.c4m
+++ b/src/configs/base_init.c4m
@@ -25,6 +25,8 @@ docker { }
 
 load { }
 
+git {}
+
 cloud_provider {
   cloud_instance_hw_identifiers { }
 }

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -85,7 +85,6 @@ object key {
   gen_typename:  "KeyConfig"
   gen_setters:   false
   doc:           """
-
 These objects are used in reporting templates and chalking templates
 to help determine what to produce. The two fields in this object are:
 
@@ -124,7 +123,6 @@ object mark_template {
   gen_typename:  "MarkTemplate"
   gen_setters:   false
   doc: """
-
 # Chalk Mark Templates
 
 Chalk decides what metadata keys should be added to a chalk mark based
@@ -266,7 +264,6 @@ object report_template {
   gen_typename:  "ReportTemplate"
   gen_setters:   false
   doc: """
-
 # Report Templates
 
 Report templates specify what metadata gets added into reports. You
@@ -326,7 +323,6 @@ object tool {
    gen_typename:  "ToolInfo"
    gen_setters:   false
    doc:           """
-
 Tool sections allow you to automatically run external tools for
 collecting metadata, for tool types that are known to chalk (This
 doesn't preclude chalk from providing its own collection for these
@@ -409,7 +405,6 @@ be used directly, or can be called if you want to do something fancier.
      type:     func (string) -> bool
      require:  true
      doc:      """
-
 A callback used when implementing tools.  You must implement this for
 any new tool you add, even if you have no intention of ever attempting
 an actual installation (in which case, it can simply return false).
@@ -982,7 +977,6 @@ object sink {
   user_def_ok:   true
   validator:     func sink_object_check
   doc:           """
-
 This object type is needed to add new data sinks to chalk. If you're
 not a Chalk developer, this probably isn't going to be particularly
 useful; Instead, use `sink_config` to configure a sink, and then
@@ -1410,7 +1404,6 @@ object outconf {
   gen_setters:   false
   user_def_ok:   false
   doc:           """
-
 ## Changing reports for operations
 
 Each chalk operation that reports metadata will have one or more
@@ -1665,7 +1658,6 @@ singleton extract {
   gen_setters: false
   user_def_ok: false
   doc: """
-
 These are configuration options specific to how container extraction
 works for containers (plenty of the global options apply to
 extraction). Currently, the only options involve how we handle looking
@@ -1977,6 +1969,39 @@ ENV ARTIFACT_IDENTIFIER="X6VRPZ-C828-KDNS-QDXRT0"
   }
 }
 
+singleton git {
+  gen_fieldname: "gitConfig"
+  gen_typename:  "GitConfig"
+  gen_setters:   false
+  user_def_ok:   false
+  doc: """
+Options how chalk interacts with git.
+"""
+
+  field refetch_lightweight_tags {
+    type:     bool
+    default:  true
+    shortdoc: "Refetch latest tag from origin"
+    doc:      """
+During chalk insertion, when chalk encounters a git tag,
+there is a possibility the tag might not be up to date.
+For example if repo is fetched via:
+
+```
+git fetch origin --force <ref> +<commit>:refs/tags/<tag>
+```
+
+Git will explicitly create tag locally which will point to the commit.
+This might not be accurate as the tag might be annotated in origin.
+As such chalk will not be able to report accurately metadata about the tag
+such as date tagged, tagger, etc.
+
+When this config is true, chalk will refetch lightweight tags (not annotated)
+from the origin to ensure its local definition is up to date.
+"""
+  }
+}
+
 singleton load {
   gen_fieldname: "loadConfig"
   gen_typename:  "LoadConfig"
@@ -1993,7 +2018,6 @@ configuration being loaded.
     default:  false
     shortdoc: "Replace on load"
     doc: """
-
 When this value is true, the entire stored configuration file will be
 REPLACED with the specified configuration, as long as that
 configuration loads successfully.
@@ -2255,7 +2279,6 @@ singleton env_config {
   gen_setters:   false
   user_def_ok:   false
   doc: """
-
 This section is for internal configuration information gathering
 runtime environment information when running with the 'env' command,
 which is similar to the exec command, but where the exec command
@@ -2343,7 +2366,6 @@ unless you provide a custom callback.
     default: false
     shortdoc: "Marking requires +x"
     doc: """
-
 When this is true, Chalk will not attempt to mark source code *unless*
 the executable bit is set. However, the execute bit can get added later;
 it's a trade-off!
@@ -2669,6 +2691,7 @@ root {
   allow cloud_provider
   allow tech_stack_rule
   allow linguist_language
+  allow git
 
   shortdoc: "Chalk Configuration Options"
 
@@ -2750,7 +2773,6 @@ then chalk will produce a help message.
     write_lock: false
     shortdoc:   "The currently running command"
     doc:        """
-
 Once the command line is fully parsed, this will get the value of the
 selected command.  If the command is ambiguous, fill it in with the
 value 'default_commmand'.
@@ -2936,7 +2958,6 @@ Set the default path to search for artifacts, unless overridden by command-line 
     require: false
     shortdoc: "Specify a default place for /tmp files if needed"
     doc: """
-
 Generally, systems use `/tmp` for temporary files, and most modern API
 interfaces to using `/tmp` take mitigation against file-based race
 conditions, for instance, by leveraging per-app directories and

--- a/src/docker/git.nim
+++ b/src/docker/git.nim
@@ -5,7 +5,7 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 import std/[base64, strutils, uri]
-import ".."/[config, util]
+import ".."/[config, git, util]
 import "."/[base]
 
 const
@@ -14,13 +14,6 @@ const
   ANNOTATED_TAG  = "^{}"
   GIT_USER       = "x-access-token"
   DEFAULT_BRANCH = "main"
-
-proc setGitExeLocation() =
-  once:
-    gitExeLocation = util.findExePath("git").get("")
-    if gitExeLocation == "":
-      error("No git command found in PATH")
-      raise newException(ValueError, "No git")
 
 proc setSshKeyscanExeLocation() =
   once:
@@ -152,7 +145,7 @@ proc run(git:    DockerGitContext,
     # therefore the cd here is required so that git operations
     # are isolated in their own directory
     withWorkingDir(git.tmpGitDir):
-      result = runCmdGetEverything(gitExeLocation, allArgs.raw())
+      result = runCmdGetEverything(getGitExeLocation(), allArgs.raw())
   if strict and result.exitCode != 0:
     error("Failed to run git " & allArgs.redacted().join(" "))
     error(strip(result.stdOut & result.stdErr))

--- a/src/git.nim
+++ b/src/git.nim
@@ -1,0 +1,23 @@
+##
+## Copyright (c) 2024, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+import "."/[config, util]
+
+proc setGitExeLocation*() =
+  once:
+    gitExeLocation = util.findExePath("git").get("")
+    if gitExeLocation == "":
+      error("No git command found in PATH")
+      raise newException(ValueError, "No git")
+
+proc getGitExeLocation*(): string =
+  once:
+    try:
+      setGitExeLocation()
+    except:
+      discard
+  return gitExeLocation

--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -605,7 +605,7 @@ proc refetchTags(info: RepoInfo) =
     return
   var args = @[
     "fetch",
-    "origin",
+    info.origin,
     "--force",                 # allow to update the tag
     "--no-tags",               # dont fetch everything
     "--no-recurse-submodules", # ignore submodules

--- a/tests/functional/test_git.py
+++ b/tests/functional/test_git.py
@@ -111,3 +111,26 @@ def test_empty_repo(
         ORIGIN_URI=MISSING,
         VCS_DIR_WHEN_CHALKED=MISSING,
     )
+
+
+@pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
+def test_refetch_tag(
+    tmp_data_dir: Path,
+    chalk_copy: Chalk,
+    copy_files: list[Path],
+):
+    repo = Git(tmp_data_dir).clone(
+        "https://github.com/crashappsec/chalk-docker-git-context.git"
+    )
+    # replicate what github checkout action does
+    # https://github.com/crashappsec/chalk/issues/345
+    repo.fetch(
+        ref="1-signed",
+        refs={repo.latest_commit: "refs/tags/1-signed"},
+    )
+    artifact = copy_files[0]
+    result = chalk_copy.insert(artifact)
+    assert result.mark.has(
+        TAG="1-signed",
+        TAG_SIGNED=True,
+    )

--- a/tests/functional/utils/git.py
+++ b/tests/functional/utils/git.py
@@ -31,7 +31,6 @@ class Git:
         self,
         *,
         first_commit: bool = True,
-        add: bool = True,
         remote: Optional[str] = None,
         branch: str = "main",
     ):
@@ -49,6 +48,12 @@ class Git:
             self.config("user.signingkey", os.environ.get("GPG_KEY", ""))
         if remote:
             self.run(["git", "remote", "add", "origin", remote])
+        return self
+
+    def clone(self, origin: str, ref: str = "main"):
+        self.init(first_commit=False, remote=origin)
+        self.fetch()
+        self.checkout(ref)
         return self
 
     def config(self, key: str, value: str):
@@ -71,6 +76,21 @@ class Git:
 
     def checkout(self, spec: str):
         self.run(["git", "checkout", spec])
+        return self
+
+    def fetch(
+        self,
+        remote: str = "origin",
+        *,
+        ref: Optional[str] = None,
+        refs: Optional[dict[str, str]] = None,
+    ):
+        args = ["git", "fetch", "--force", remote]
+        if refs:
+            assert ref
+            args.append(ref)
+            args += [f"{k}:{v}" for k, v in (refs or {}).items()]
+        self.run(args)
         return self
 
     def symbolic_ref(self, ref: str):


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

fixes https://github.com/crashappsec/chalk/issues/345

## Description

If repo is checked out incorrectly locally, a tag can be lightweight but annotated in origin. To guarantee chalk sees up-to-date tags, chalk refetches lightweight tags to ensure it reports correct metadata about the "latest" tag.

This was noticed via checkout github action which if triggered from a tag build it looses any tag annotations.

## Testing

```
➜ make tests args="test_git.py::test_refetch_tag --logs --pdb"
```
