### PR TITLE
fix(docker): generic git refspec in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
   regular tags (not annotated) from origin. To customize
   this behavior use `git.refetch_lightweight_tags` config.
   ([#349](https://github.com/crashappsec/chalk/pull/349))
+- Chalk docker build did not support remote git context
+  which was neither a tag or a branch.
+  For example:
+
+  ```
+  docker build https://github.com/user/repo.git#refs/pull/1/merge
+  ```
+
+  ([#351](https://github.com/crashappsec/chalk/pull/351))
 
 ## 0.4.5
 

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -282,7 +282,7 @@ type
     digest: string
 
   GitHeadType* = enum
-    commit, branch, tag
+    commit, branch, tag, other
 
   GitHead* = ref object
     gitRef*:       string
@@ -291,6 +291,7 @@ type
     # first matching branch for commit ref, if any
     branches*:     seq[string]
     tags*:         seq[string]
+    refs*:         seq[string]
 
   DigestedJson* = ref object
     json*:   JsonNode

--- a/src/util.nim
+++ b/src/util.nim
@@ -608,3 +608,8 @@ proc makeExecutable*(path: string) =
     wanted   = existing + {fpUserExec, fpGroupExec, fpOthersExec}
   if existing != wanted:
     path.setFilePermissions(wanted)
+
+proc getOrDefault*[T](self: openArray[T], i: int, default: T): T =
+  if len(self) > i:
+    return self[i]
+  return default

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -798,9 +798,30 @@ def test_multiplatform_build(
             False,
             True,
         ),
+        # with tag
+        (
+            "https://github.com/crashappsec/chalk-docker-git-context.git#1-annotated",
+            None,
+            False,
+            True,
+        ),
         # with branch and nested folder for context
         (
             "https://github.com/crashappsec/chalk-docker-git-context.git#main:nested",
+            None,
+            False,
+            True,
+        ),
+        # with PR ref
+        (
+            "https://github.com/crashappsec/chalk-docker-git-context.git#refs/pull/1/merge",
+            None,
+            False,
+            True,
+        ),
+        # with tag ref
+        (
+            "https://github.com/crashappsec/chalk-docker-git-context.git#refs/tags/1-annotated",
             None,
             False,
             True,


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

fixes https://github.com/crashappsec/chalk/issues/350

## Description

Docker supports providing full refspec as the context.
For example:

```
docker build https://github.com/user/repo.git#refs/pull/1/merge
```

Previously chalk only supported tags and branches:

```
docker build https://github.com/user/repo.git#<branch>
docker build https://github.com/user/repo.git#<tag>
```

Now chalk also fetches any other explicit refs passed to it.


## Testing

```
➜ make tests args="test_docker.py::test_git_context --slow -x --logs"
```

tests:--slow
