### PR TITLE
fix: support git empty tag messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
   ([#351](https://github.com/crashappsec/chalk/pull/351))
 
+- Chalk did not correctly handle git annotated tags with an
+  empty message.
+  ([#354](https://github.com/crashappsec/chalk/pull/354))
+
 ## 0.4.5
 
 ### Fixes

--- a/tests/functional/utils/git.py
+++ b/tests/functional/utils/git.py
@@ -64,13 +64,17 @@ class Git:
         return self
 
     def commit(self, message="dummy"):
-        self.run(["git", "commit", "--allow-empty", "-m", message])
+        args = ["git", "commit", "--allow-empty"]
+        if message == "":
+            args += ["--allow-empty-message"]
+        args += ["-m", message]
+        self.run(args)
         return self
 
-    def tag(self, tag: str, message=""):
+    def tag(self, tag: str, message: Optional[str] = None):
         args = ["git", "tag", tag]
-        if message or self.sign:
-            args += ["-a", "-m", message or "dummy"]
+        if message is not None or self.sign:
+            args += ["-a", "-m", message if message is not None else "dummy"]
         self.run(args)
         return self
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

fixes https://github.com/crashappsec/chalk/issues/353

## Testing

```
➜ make tests args="test_git.py::test_repo -x --logs"
```
