### PR TITLE
fix(docker): fixing --metadata-file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- Docker build `--metadata-file` flag is only added when
+  using `buildx >= 0.6.0`. In addition the flag is only added
+  when using `docker >= 22` as docker aliased `docker build`
+  to `docker buildx build` which allows to use buildx flags
+  in normal build command.
+  ([#357](https://github.com/crashappsec/chalk/pull/357))
+
 ## 0.4.6
 
 **June 20, 2024**

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -217,7 +217,7 @@ proc setIidFile(ctx: DockerInvocation) =
     ctx.iidFilePath = ctx.foundIidFile
 
 proc setMetadataFile(ctx: DockerInvocation) =
-  if ctx.foundMetadataFile == "" and hasBuildx():
+  if ctx.foundMetadataFile == "" and ctx.supportsMetadataFile():
     trace("docker: adding --metadata-file flag")
     # ensure file is closed so docker can overwrite it
     ctx.metadataFilePath = writeNewTempFile("", suffix = ".metatadata-file")

--- a/src/docker/exe.nim
+++ b/src/docker/exe.nim
@@ -180,6 +180,21 @@ proc supportsMultiStageBuilds*(): bool =
   # https://docs.docker.com/engine/release-notes/17.05/
   return getDockerServerVersion() >= parseVersion("17.05")
 
+proc supportsMetadataFile*(ctx: DockerInvocation): bool =
+  # docker buildx build
+  if ctx.foundBuildx:
+    # https://github.com/docker/buildx/releases/tag/v0.6.0
+    return getBuildXVersion() >= parseVersion("0.6")
+  else:
+    # docker>=23 (technically was changed in 22-rc)
+    # docker build is an alias to docker buildx build therefore
+    # any buildx flags are also added to build command
+    # https://docs.docker.com/engine/release-notes/23.0/#2300
+    return (
+      getBuildXVersion() >= parseVersion("0.6") and
+      getDockerClientVersion() >= parseVersion("22")
+    )
+
 proc installBinFmt*() =
   once:
     # https://docs.docker.com/build/building/multi-platform/#qemu-without-docker-desktop


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

chalk build fails due to invalid `--metadata-file` flag.

## Description

In older docker versions, as `docker build` is not an alias to `docker buildx build`, `--metadata-file` flag is not supported. It only works when explicitly using `docker buildx build` in which case 0.6.0 is required which added that flag. Otherwise docker version needs to be >=22 which aliased `build` to `buildx build` as well as have supported buildx version.

No easy way of testing it in CI but tested locally various combination of versions.

## Testing

Was running something like:

```
➜ echo '
  FROM docker:22.06-rc
  COPY --from=docker/buildx-bin:0.6.0 /buildx /usr/lib/docker/cli-plugins/docker-buildx
  COPY --from=docker/buildx-bin:0.6.0 /buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
  ' | docker build -f - . -t dockerbuildx
  and docker run -it --rm dockerbuildx docker --version
  and docker run -it --rm dockerbuildx buildx version
  and docker run -it --rm dockerbuildx build --help
  and docker run -it --rm dockerbuildx buildx build --help
```
