### PR TITLE
feat: adding _CHALK_RUN_TIME to crashoverride report template

### DIFF
--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -83,7 +83,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key._OP_CLOUD_PROVIDER_IP.use                      = true
   ~key._OP_CLOUD_PROVIDER_TAGS.use                    = true
   ~key._OP_CLOUD_PROVIDER_INSTANCE_TYPE.use           = true
-
+  ~key._CHALK_RUN_TIME.use                            = true
 
   # IMDS keys
   # dynamic


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

no issue

## Description

will help in the backend to link how long chalk execution took

## Testing

<!-- What are the steps needed to test this PR? -->
