### PR TITLE
style(cloudMetadata): fix unclear indentation

### DIFF
--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -88,9 +88,9 @@ template jsonKey(keyname: string, url: string) =
           let jsonValue = parseJson(value)
           # redact some keys as they contain sensitive api keys
           case keyname
-            of AWS_IDENTITY_CREDENTIALS_SECURITY_CREDS:
-              jsonValue["SecretAccessKey"] = newJString("<<redacted>>")
-              jsonValue["Token"] = newJString("<<redacted>>")
+          of AWS_IDENTITY_CREDENTIALS_SECURITY_CREDS:
+            jsonValue["SecretAccessKey"] = newJString("<<redacted>>")
+            jsonValue["Token"] = newJString("<<redacted>>")
           setIfNeeded(result, keyname, jsonValue.nimJsonToBox())
         except:
           trace("IMDSv2 responded with invalid json for URL: " & url)


### PR DESCRIPTION
This file previously used a mixture of two spaces and four spaces for indentation. This was particularly unclear when inconsistent between branches:

https://github.com/crashappsec/chalk/blob/0e4c382e245cc9d17dec1361ec6ae5abc4552aa8/src/plugins/cloudMetadata.nim#L213-L221

Use two spaces consistently, like the rest of the codebase.

Also with https://github.com/crashappsec/chalk/commit/0d4743d3579075d264efbea91f908c32f44b4393, re-style two unclear areas. Previously it was harder to see that lines 209–274 were inside the condition at line 208:

https://github.com/crashappsec/chalk/blob/0e4c382e245cc9d17dec1361ec6ae5abc4552aa8/src/plugins/cloudMetadata.nim#L200-L274