### PR TITLE
feat: setting chalk_log_level to trace in connect.c4m

### DIFF
--- a/configs/connect.c4m
+++ b/configs/connect.c4m
@@ -47,6 +47,7 @@ custom_report crashoverride {
   ~use_when:        ["insert", "build", "push", "exec"]
 }
 
+chalk_log_level                      = "trace"
 attestation.key_provider             = "get"
 docker.wrap_entrypoint               = true
 run_sbom_tools                       = true

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -5458,7 +5458,6 @@ Calculates the amount of time between the start of a chalk executable
 and when a report is generated. It's an integer with resolution of
 1/1000000th of a second.
 """
-
 }
 
 keyspec $CHALK_CONFIG {

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2811,11 +2811,11 @@ everything, use 'trace' or 'verbose' (they are aliases).
     shortdoc: "Reporting Log Level"
     doc:      """
 Determines what kind of logging messages will be added to metadata via the
-ERR_INFO or `_ERR_INFO` keys. During the chalk phase of chalking ops only,
+ERR_INFO or `_OP_ERRORS` keys. During the chalk phase of chalking ops only,
 per-object errors that are at least as severe as specified will be added to
 the object's  `ERR_INFO` field.
 
-Everything else will go to `_ERR_INFO`.
+Everything else will go to `_OP_ERRORS`.
 
 Generally, we recommend setting this to `warn` for docker, and `error`
 for everything else, as docker only reports errors when there is a


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [ ] ~Updated `CHANGELOG.md` if necessary~ (not updating as this is only change part of `connect.c4m` and not the default chalk config

## Issue

If the chalk has an error its hard to debug now as you have to hunt down execution logs, if chalk is running with trace log level. Otherwise you are out of 

## Description

This will help with debugging as chalk report will include all trace logs as part of the report in `_OP_ERRORS` field. In the future might be worth renaming the field as `ERRORS` sounds dangerous even when it contains trace-level logs...

We should do a pass on anything potentially sensitive we might be logging to ensure the field does not leak anything security-sensitive.

## Testing

```
➜ cat /etc/chalk.c4m | grep log_level
chalk_log_level = "trace"
```

then run a few commands such as `chalk insert ls` to see log output being part of the report
