### PR TITLE
test: sending usage reports to test env in tests

### DIFF
--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -3,6 +3,10 @@ custom_report.github_group_chalk_time.enabled: false
 custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false
 
+if not env_exists("CHALK_USAGE_URL") {
+  crashoverride_usage_reporting_url: "https://chalk-test.crashoverride.run/v0.1/usage"
+}
+
 # ignore any cloud metadata by default
 # as github actions use azure runners
 if not env_exists("VENDOR") {


### PR DESCRIPTION
small test improvement. saw in one of the test runs that usage metrics were being sent to prod env:

```
error: Call to 'connect' timed out.: [ { "_OPERATION" : "build", "_TIMESTAMP" : 1720570114938, "_OP_CHALKER_COMMIT_ID" : "5c50ce0ea987b025645658c18da18f508388737a", "_OP_CHALKER_VERSION" : "0.4.8-dev", "_OP_PLATFORM" : "GNU/Linux x86_64", "_OP_CHALK_COUNT" : 1 } ]
 (sink conf='usage_stats_conf')
	uri          = https://chalk.crashoverride.run/v0.1/usage
	content_type = application/json
	timeout      = none
	headers      = none```

https://github.com/crashappsec/chalk/actions/runs/9865853999/job/27243572497?pr=365