### PR TITLE
refactor(cloudMetadata): refactor metadata collection

### DIFF
--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -152,8 +152,8 @@ proc isAwsEc2Host(vendor: string): bool =
 
   # this will only work if we have root, normally sudo dmidecode  --string system-uuid
   # gives the same output
-  let product_uuid = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_product_path"))
-  if product_uuid.toLowerAscii().startsWith("ec2"):
+  let productUuid = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_product_path"))
+  if productUuid.toLowerAscii().startsWith("ec2"):
     return true
 
   return false

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -143,7 +143,7 @@ proc isAwsEc2Host(vendor: string): bool =
 
   # older Xen instances
   let uuid = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_hypervisor_path"))
-  if uuid.toLowerAscii().startswith("ec2"):
+  if uuid.toLowerAscii().startsWith("ec2"):
     return true
 
   # nitro instances

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -143,24 +143,24 @@ proc isAwsEc2Host(vendor: string): bool =
 
   # older Xen instances
   let uuid = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_hypervisor_path"))
-  if strutils.toLowerAscii(uuid).startswith("ec2"):
+  if uuid.toLowerAscii().startswith("ec2"):
     return true
 
   # nitro instances
-  if contains(strutils.toLowerAscii(vendor), "amazon"):
+  if vendor.toLowerAscii().contains("amazon"):
     return true
 
   # this will only work if we have root, normally sudo dmidecode  --string system-uuid
   # gives the same output
   let product_uuid = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_product_path"))
-  if strutils.toLowerAscii(product_uuid).startsWith("ec2"):
+  if product_uuid.toLowerAscii().startsWith("ec2"):
     return true
 
   return false
 
 proc isGoogleHost(vendor: string, resolvContents: string): bool =
   # vendor is present
-  if contains(strutils.toLowerAscii(vendor), "google"):
+  if vendor.toLowerAscii().contains("google"):
     return true
 
   # vendor information should be present in most services, but its not present
@@ -189,7 +189,7 @@ proc isGoogleHost(vendor: string, resolvContents: string): bool =
 
 
 proc isAzureHost(vendor: string): bool =
-  return contains(strutils.toLowerAscii(vendor), "microsoft")
+  return vendor.toLowerAscii().contains("microsoft")
 
 proc cloudMetadataGetrunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
                                ChalkDict {.cdecl.} =

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -456,17 +456,17 @@ proc cloudMetadataGetrunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
     vendor = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_vendor_path"))
     resolv = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_resolv_path"))
 
-  let hostKind = getHostKind(vendor, resolv)
-  result = case hostKind
-  of hkUnknown:
-    trace("Unknown cloud host: does not seem to be AWS, Azure, or Google")
-    ChalkDict()
-  of hkAws:
-    getAwsMetadata()
-  of hkAzure:
-    getAzureMetadata()
-  of hkGcp:
-    getGcpMetadata()
+  result =
+    case getHostKind(vendor, resolv)
+    of hkUnknown:
+      trace("Unknown cloud host: does not seem to be AWS, Azure, or Google")
+      ChalkDict()
+    of hkAws:
+      getAwsMetadata()
+    of hkAzure:
+      getAzureMetadata()
+    of hkGcp:
+      getGcpMetadata()
 
 proc loadCloudMetadata*() =
   newPlugin("cloud_metadata", rtHostCallback = RunTimeHostCb(cloudMetadataGetrunTimeHostInfo))

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -186,8 +186,6 @@ proc isGoogleHost(vendor: string, resolvContents: string): bool =
           getEnv(CLOUD_RUN_TIMEOUT_SECONDS) != "" and
           getEnv(K_SERVICE) != "")
 
-
-
 proc isAzureHost(vendor: string): bool =
   return vendor.toLowerAscii().contains("microsoft")
 

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -452,8 +452,9 @@ proc getHostKind(vendor: string, resolvContents: string): HostKind =
 
 proc cloudMetadataGetrunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
                                ChalkDict {.cdecl.} =
-  let vendor = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_vendor_path"))
-  let resolv = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_resolv_path"))
+  let
+    vendor = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_vendor_path"))
+    resolv = tryToLoadFile(get[string](getChalkScope(), "cloud_provider.cloud_instance_hw_identifiers.sys_resolv_path"))
 
   let hostKind = getHostKind(vendor, resolv)
   result = case hostKind


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Description

Implementing https://github.com/crashappsec/chalk/commit/55cd0d52035251de461abb1599821ceb2200f374 reminded me that we'd benefit from tidying up this file. We've been having some issues with `_OP_CLOUD_PROVIDER`, and it'd help if this file was easier to reason about.

There was previously one long function that handled collecting metadata for AWS, Azure, and GCP, which had to return after setting metadata for one platform. Split into separate functions, and add an enum to resolve the `FIXME`s.

We can refactor further later - this PR is just an attempt at a quick step in the right direction.

Also resolve some nits. See individual commits.

## Testing

Verify that this is refactoring-only. I might have missed something with how the AWS metadata collection worked.