### PR TITLE
refactor(cloudMetadata): turn templates into procs

### DIFF
--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -224,7 +224,7 @@ proc listKey(chalkDict: ChalkDict, token: string, keyname: string, url: string) 
       hdrs      = newHttpHeaders([("X-aws-ec2-metadata-token", token)])
       resultOpt = hitProviderEndpoint(url, hdrs)
     if resultOpt.isSome():
-      setIfNeeded(chalkDict, keyname, resultOpt.get().splitLines())
+      chalkDict.setIfNeeded(keyname, resultOpt.get().splitLines())
 
 proc jsonKey(chalkDict: ChalkDict, token: string, keyname: string, url: string) =
   ## If `keyname` is subscribed, hits the given `url` and sets the `keyname` key
@@ -251,7 +251,7 @@ proc jsonKey(chalkDict: ChalkDict, token: string, keyname: string, url: string) 
           of AWS_IDENTITY_CREDENTIALS_SECURITY_CREDS:
             jsonValue["SecretAccessKey"] = newJString("<<redacted>>")
             jsonValue["Token"] = newJString("<<redacted>>")
-          setIfNeeded(chalkDict, keyname, jsonValue.nimJsonToBox())
+          chalkDict.setIfNeeded(keyname, jsonValue.nimJsonToBox())
         except:
           trace("IMDSv2 responded with invalid json for URL: " & url)
 
@@ -298,7 +298,7 @@ proc getTags(chalkDict: ChalkDict, token: string, keyname: string, url: string) 
         let tagOpt = hitProviderEndpoint(url & "/" & name, hdrs)
         if tagOpt.isSome():
           tags[name] = pack(tagOpt.get())
-        setIfNeeded(chalkDict, keyname, tags)
+        chalkDict.setIfNeeded(keyname, tags)
 
 proc getAwsMetadata(): ChalkDict =
   result = ChalkDict()


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Description

Implementing commit 55cd0d520352 reminded me that we'd benefit from tidying up in this file. We've been having some issues with `_OP_CLOUD_PROVIDER`, and it'd help if this file was easier to reason about. Here's a few quick improvements while I was in the area.

Previously, at a call site for e.g. `oneItem` it was not obvious that:

- It mutates `result`.
- It uses `token`.

Replace the templates with procs to make that clearer, and add doc comments. This also removes the excessive inlining.

From the [Nim Manual][1]:

>Style note: For code readability, it is best to use the least powerful programming construct that remains expressive. So the "check list" is:
>
>1. Use an ordinary proc/iterator, if possible.
>2. Else: Use a generic proc/iterator, if possible.
>3. Else: Use a template, if possible.
>4. Else: Use a macro.

Also make a few minor formatting changes (see the individual commits).

Renaming the procs would help clarify further (`setKey`?), but I don't think we need to bikeshed that now. If you want to do that, please suggest the full set of renames.

As an aside, it turns out that this PR reduces the chalk executable size by 0.2%, which illustrates the amount of inlining here.

[1]: https://nim-lang.org/2.0.0/manual.html#macros

## Testing

Verify this is refactoring-only.