### PR TITLE
fix: cloud metadata timeout handing and guaranteeing _OP_CLOUD_* keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@
 ### Fixes
 
 - A chalk report would previously omit the `_OP_CLOUD_PROVIDER`
-  key when:
+  and `_OP_CLOUD_PROVIDER_SERVICE_TYPE` keys when:
 
   - No other instance metadata key (e.g. `_GCP_INSTANCE_METADATA`
     or `_OP_CLOUD_PROVIDER_IP`) was subscribed.
   - The instance metadata service couldn't be reached, or
     returned invalid data.
 
-  ([#362](https://github.com/crashappsec/chalk/pull/362))
+  ([#362](https://github.com/crashappsec/chalk/pull/362)
+  [#370](https://github.com/crashappsec/chalk/pull/370))
 
 - `_OP_ERRORS` was missing any logs/errors from plugins.
   The key was collected by the `system` plugin which

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -67,7 +67,6 @@ proc getAzureMetadata(): ChalkDict =
       isSubscribedKey("_OP_CLOUD_PROVIDER_REGION") or
       isSubscribedKey("_OP_CLOUD_PROVIDER_TAGS") or
       isSubscribedKey("_OP_CLOUD_PROVIDER_ACCOUNT_INFO") or
-      isSubscribedKey("_OP_CLOUD_PROVIDER_SERVICE_TYPE") or
       isSubscribedKey("_OP_CLOUD_PROVIDER_INSTANCE_TYPE"):
     let resultOpt = hitProviderEndpoint(
       "http://169.254.169.254/metadata/instance?api-version=2021-02-01",
@@ -84,10 +83,6 @@ proc getAzureMetadata(): ChalkDict =
       let jsonValue = parseJson(value)
       result.setIfNeeded("_AZURE_INSTANCE_METADATA", jsonValue.nimJsonToBox())
       try:
-        result.setIfNeeded("_OP_CLOUD_PROVIDER_TAGS", jsonValue["compute"]["tagsList"].nimJsonToBox())
-      except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_TAGS for azure")
-      try:
         for iface in jsonValue["network"]["interface"]:
           var found = false
           for address in iface["ipv4"]["ipAddress"]:
@@ -100,25 +95,24 @@ proc getAzureMetadata(): ChalkDict =
           if found:
             break
       except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_IP for azure")
-      try:
-        result.setIfNeeded("_OP_CLOUD_PROVIDER_ACCOUNT_INFO", jsonValue["compute"]["subscriptionId"].getStr())
-      except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_ACCOUNT_INFO for azure")
-      try:
-        result.setIfNeeded("_OP_CLOUD_PROVIDER_REGION", jsonValue["compute"]["location"].getStr())
-      except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_REGION for azure")
-      try:
-        result.setIfNeeded("_OP_CLOUD_PROVIDER_INSTANCE_TYPE", jsonValue["compute"]["vmSize"].getStr())
-      except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_INSTANCE_TYPE for azure")
+        trace("Could not set _OP_CLOUD_PROVIDER_IP for azure: " & getCurrentExceptionMsg())
+      result.trySetIfNeeded("_OP_CLOUD_PROVIDER_TAGS"):
+        jsonValue["compute"]["tagsList"].nimJsonToBox()
+      result.trySetIfNeeded("_OP_CLOUD_PROVIDER_ACCOUNT_INFO"):
+        jsonValue["compute"]["subscriptionId"].getStr()
+      result.trySetIfNeeded("_OP_CLOUD_PROVIDER_REGION"):
+        jsonValue["compute"]["location"].getStr()
+      result.trySetIfNeeded("_OP_CLOUD_PROVIDER_INSTANCE_TYPE"):
+        jsonValue["compute"]["vmSize"].getStr()
     except:
-      trace("Azure metadata responded with invalid json")
+      trace("Azure metadata responded with invalid json: " & getCurrentExceptionMsg())
 
 proc getGcpMetadata(): ChalkDict =
   result = ChalkDict()
   result.setIfNeeded("_OP_CLOUD_PROVIDER", $hkGcp)
+
+  if getEnv(K_SERVICE) != "" and getEnv(CLOUD_RUN_TIMEOUT_SECONDS) != "":
+    result.setIfNeeded("_OP_CLOUD_PROVIDER_SERVICE_TYPE", "gcp_cloud_run_service")
 
   if isSubscribedKey("_GCP_INSTANCE_METADATA") or
       isSubscribedKey("_GCP_PROJECT_METADATA") or
@@ -126,7 +120,6 @@ proc getGcpMetadata(): ChalkDict =
       isSubscribedKey("_OP_CLOUD_PROVIDER_REGION") or
       isSubscribedKey("_OP_CLOUD_PROVIDER_TAGS") or
       isSubscribedKey("_OP_CLOUD_PROVIDER_ACCOUNT_INFO") or
-      isSubscribedKey("_OP_CLOUD_PROVIDER_SERVICE_TYPE") or
       isSubscribedKey("_OP_CLOUD_PROVIDER_INSTANCE_TYPE"):
     trace("Querying for GCP metadata")
     if isSubscribedKey("_GCP_PROJECT_METADATA"):
@@ -143,7 +136,7 @@ proc getGcpMetadata(): ChalkDict =
           else:
             trace("GCP project metadata didnt respond with json object. Ignoring it")
         except:
-          trace("Could not insert _GCP_PROJECT_METADATA")
+          trace("Could not set _GCP_PROJECT_METADATA: " & getCurrentExceptionMsg())
 
     let resultOpt = hitProviderEndpoint(
       "http://169.254.169.254/computeMetadata/v1/instance/?recursive=true",
@@ -159,18 +152,6 @@ proc getGcpMetadata(): ChalkDict =
     try:
       let jsonValue = parseJson(value)
       try:
-        result.setIfNeeded("_GCP_INSTANCE_METADATA", jsonValue.nimJsonToBox())
-      except:
-        trace("Could not insert _GCP_INSTANCE_METADATA")
-      try:
-        result.setIfNeeded("_OP_CLOUD_PROVIDER_TAGS", jsonValue["tags"].nimJsonToBox())
-      except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_TAGS for gcp")
-      try:
-        result.setIfNeeded("_OP_CLOUD_PROVIDER_ACCOUNT_INFO", jsonValue["serviceAccounts"].nimJsonToBox())
-      except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_TAGS for gcp")
-      try:
         for iface in jsonValue["networkInterfaces"]:
           var found = false
           for config in iface["accessConfigs"]:
@@ -183,20 +164,19 @@ proc getGcpMetadata(): ChalkDict =
           if found:
             break
       except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_IP for gcp")
-      try:
-        result.setIfNeeded("_OP_CLOUD_PROVIDER_REGION", jsonValue["zone"].getStr().split("/")[^1])
-      except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_REGION for gcp")
-      try:
-        result.setIfNeeded("_OP_CLOUD_PROVIDER_INSTANCE_TYPE", jsonValue["machineType"].getStr().split("/")[^1])
-      except:
-        trace("Could not insert _OP_CLOUD_PROVIDER_INSTANCE_TYPE for gcp")
+        trace("Could not insert _OP_CLOUD_PROVIDER_IP for gcp: " & getCurrentExceptionMsg())
+      result.trySetIfNeeded("_GCP_INSTANCE_METADATA"):
+        jsonValue.nimJsonToBox()
+      result.trySetIfNeeded("_OP_CLOUD_PROVIDER_TAGS"):
+        jsonValue["tags"].nimJsonToBox()
+      result.trySetIfNeeded("_OP_CLOUD_PROVIDER_ACCOUNT_INFO"):
+        jsonValue["serviceAccounts"].nimJsonToBox()
+      result.trySetIfNeeded("_OP_CLOUD_PROVIDER_REGION"):
+        jsonValue["zone"].getStr().split("/")[^1]
+      result.trySetIfNeeded("_OP_CLOUD_PROVIDER_INSTANCE_TYPE"):
+        jsonValue["machineType"].getStr().split("/")[^1]
     except:
-      trace("GCP metadata responded with invalid json")
-
-    if getEnv(K_SERVICE) != "" and getEnv(CLOUD_RUN_TIMEOUT_SECONDS) != "":
-      result["_OP_CLOUD_PROVIDER_SERVICE_TYPE"] = pack("gcp_cloud_run_service")
+      trace("GCP metadata responded with invalid json: " & getCurrentExceptionMsg())
 
 proc getAwsToken(): Option[string] =
   let url      = awsBaseUri & "api/token"
@@ -227,7 +207,7 @@ proc oneItem(chalkDict: ChalkDict, token: string, keyname: string, url: string) 
       hdrs      = newHttpHeaders([("X-aws-ec2-metadata-token", token)])
       resultOpt = hitProviderEndpoint(url, hdrs)
     if resultOpt.isSome():
-      setIfNotEmpty(chalkDict, keyname, resultOpt.get())
+      chalkDict.setIfNotEmpty(keyname, resultOpt.get())
 
 proc listKey(chalkDict: ChalkDict, token: string, keyname: string, url: string) =
   ## If `keyname` is subscribed, hits the given `url` and sets the `keyname` key
@@ -266,7 +246,7 @@ proc jsonKey(chalkDict: ChalkDict, token: string, keyname: string, url: string) 
             jsonValue["Token"] = newJString("<<redacted>>")
           chalkDict.setIfNeeded(keyname, jsonValue.nimJsonToBox())
         except:
-          trace("IMDSv2 responded with invalid json for URL: " & url)
+          trace("IMDSv2 responded with invalid json from " & url & ": " & getCurrentExceptionMsg())
 
 proc extractJsonKey(chalkDict: ChalkDict, token: string, keyname: string,
                     url: string, subkey: string) =
@@ -283,11 +263,8 @@ proc extractJsonKey(chalkDict: ChalkDict, token: string, keyname: string,
       if not value.startswith("{"):
         trace("Provider Didn't respond with json object. Ignoring it. URL: " & url)
       else:
-        try:
-          let jsonValue = parseJson(value)
-          setIfNotEmpty(chalkDict, keyname, jsonValue[subkey].getStr())
-        except:
-          trace("Could not set " & keyname & " with subkey " & subkey & " from " & url)
+        chalkDict.trySetIfNeeded(keyname):
+          parseJson(value)[subkey].getStr()
 
 proc getTags(chalkDict: ChalkDict, token: string, keyname: string, url: string) =
   ## If `keyname` is subscribed, hits the given `url` and sets the `keyname` key
@@ -310,53 +287,40 @@ proc getTags(chalkDict: ChalkDict, token: string, keyname: string, url: string) 
           continue
         let tagOpt = hitProviderEndpoint(url & "/" & name, hdrs)
         if tagOpt.isSome():
-          tags[name] = pack(tagOpt.get())
+          tags.setIfNotEmpty(name, tagOpt.get())
         chalkDict.setIfNeeded(keyname, tags)
 
 proc getAwsMetadata(): ChalkDict =
   result = ChalkDict()
   result.setIfNeeded("_OP_CLOUD_PROVIDER", $hkAws)
 
-  var tokenOpt: Option[string]
-
-  try:
-    tokenOpt = getAwsToken()
-    if tokenOpt.isNone():
-      trace("IMDSv2 token not available.")
-      return
-  except:
-    trace("IMDSv2 metadata not available.")
-    # if we do not find imdsv2 but we have a kubernetes cluster and running
-    # in AWS EC2, most likely we are running in an eks fargate cluster.
-    # https://docs.aws.amazon.com/eks/latest/userguide/fargate.html
-    let k8sPort = getEnv("KUBERNETES_PORT")
-    let k8sServiceHost = getEnv("KUBERNETES_SERVICE_HOST")
-    if k8sPort != "" or k8sServiceHost != "":
-      # this is most definitely fargate at this point, but might have FP, so
-      # leaving EKS to be on the safe side
-      result["_OP_CLOUD_PROVIDER_SERVICE_TYPE"] = pack("aws_eks")
-    return
-
-  let
-    token = tokenOpt.get()
-
-  # at this point we have metadata, differentiate between eks, ec2, ecs
+  # fetching token can fail due to timeout however as hardware vendor indicated
+  # we are running in AWS and so we should report what type of the service
+  # we are running in AWS (eks, ec2, ecs, etc)
   if isSubscribedKey("_OP_CLOUD_PROVIDER_SERVICE_TYPE"):
     # XXX ignoring task metadata v2 which is no longer actively maintained
     let ecsv3 = getEnv("ECS_CONTAINER_METADATA_URI")
     let ecsv4 = getEnv("ECS_CONTAINER_METADATA_URI_V4")
     if ecsv3 != "" or ecsv4 != "":
-      result["_OP_CLOUD_PROVIDER_SERVICE_TYPE"] = pack("aws_ecs")
+      result.setIfNotEmpty("_OP_CLOUD_PROVIDER_SERVICE_TYPE", "aws_ecs")
     else:
       let k8sPort = getEnv("KUBERNETES_PORT")
       let k8sServiceHost = getEnv("KUBERNETES_SERVICE_HOST")
+      # https://docs.aws.amazon.com/eks/latest/userguide/fargate.html
       if k8sPort != "" or k8sServiceHost != "":
         # XXX this might have FP in case of a user that has deployed k8s within
         # a single EC2 instance, so should differentiate from the rest of the
         # IMDS metadata versions
-        result["_OP_CLOUD_PROVIDER_SERVICE_TYPE"] = pack("aws_eks")
+        result.setIfNotEmpty("_OP_CLOUD_PROVIDER_SERVICE_TYPE", "aws_eks")
       else:
-        result["_OP_CLOUD_PROVIDER_SERVICE_TYPE"] = pack("aws_ec2")
+        result.setIfNotEmpty("_OP_CLOUD_PROVIDER_SERVICE_TYPE", "aws_ec2")
+
+  let tokenOpt = getAwsToken()
+  if tokenOpt.isNone():
+    trace("IMDSv2 token not available.")
+    return
+
+  let token = tokenOpt.get()
 
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
   # dynamic entries

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -194,6 +194,12 @@ template setIfNeeded*[T](o: ChalkDict, k: string, v: T) =
 template setIfNeeded*[T](o: ChalkObj, k: string, v: T) =
   setIfNeeded(o.collectedData, k, v)
 
+template trySetIfNeeded*(o: ChalkDict, k: string, code: untyped) =
+  try:
+    o.setIfNeeded(k, code)
+  except:
+    trace("Could not set chalk key " & k & " due to: " & getCurrentExceptionMsg())
+
 proc isChalkingOp*(): bool =
   return commandName in get[seq[string]](getChalkScope(), "valid_chalk_command_names")
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

some keys were not guaranteed to be present and timeout errors were not handled in the plugin

## Description

When making HTTP calls the plugin did not handle timeout exceptions and
as such on any exception complete plugin will bail and none of its keys
were populated such as `_OP_CLOUD_METADATA`. We were observing a bunch
of logs:

```
warn:  When collecting run-time host info, plugin implementation cloud_metadata threw an exception it didn't handle: Call to 'connect' timed out.
```

Looks like 250ms wasnt enough in AWS for metadata plugin to reliably hit
metadata endpoint so bumping it to 500ms.

---


metadata endpoint can fail due to timeout however in most cases we can
still determine service type by the presence of env vars plus the
hardware vendor file already told us the cloud provider so we can set
the key regardless of the output of metadata endpoint response.

---


in addition ensuring all exception handling provides useful trace log
message as otherwise debugging any of the errors is not-trivial

## Testing

hard to test with test suite some of these. mostly manual testing
