### PR TITLE
build(nimble): pin viega/zippy to SHA, not unclear tag

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -12,7 +12,7 @@ bin           = @["chalk"]
 # Dependencies
 requires "nim >= 2.0.0"
 requires "https://github.com/crashappsec/con4m#70680c397c82e779a0099f78b1604f065ed666d0"
-requires "https://github.com/viega/zippy == 0.10.7" # MIT
+requires "https://github.com/viega/zippy#b9fab3deb93f5c0b5a643d489adb2d13355d784a" # MIT
 
 # this allows us to get version externally
 task version, "Show current version":


### PR DESCRIPTION
### Description

Previously, the pinning of this dependency was potentially confusing because:

- The upstream repo, guzba/zippy, has a `v0.10.7` tag for a different state.

- One repo's tag includes the `v` prefix, and the other doesn't.

Pin to a SHA, like we do for con4m.

See:

- https://github.com/guzba/zippy/releases/tag/0.10.7
- https://github.com/viega/zippy/releases/tag/v0.10.7
- https://github.com/guzba/zippy/compare/0.10.7...viega:zippy:v0.10.7

Follow-up from https://github.com/crashappsec/chalk/issues/142#issuecomment-2029893033

### Testing

Verify that this PR produces no functional change.