### PR TITLE
build(Dockerfile, nimble): bump Nim from 2.0.0 to 2.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/crashappsec/nim:ubuntu-2.0.0 as nim
+FROM ghcr.io/crashappsec/nim:ubuntu-2.0.8 as nim
 FROM gcr.io/projectsigstore/cosign:v2.2.3 as cosign
 
 # -------------------------------------------------------------------

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -10,7 +10,7 @@ srcDir        = "src"
 bin           = @["chalk"]
 
 # Dependencies
-requires "nim >= 2.0.0"
+requires "nim >= 2.0.8"
 requires "https://github.com/crashappsec/con4m#435f230db9cc51beade76427297c206b91e91a70"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 


### PR DESCRIPTION
Bump Nim from 2.0.0 (released 2023-08-01) to 2.0.8 (released 2024-07-03), to guarantee that there's no unexpected behavior in Chalk that's due to upstream Nim bugs that were fixed on the v2 branch over the last year. This bump brings [about 300 commits of mostly small fixes](https://github.com/nim-lang/Nim/compare/v2.0.0...v2.0.8), but notably:

- Nim could previously generate C code that could no longer be compiled with default options by recent stable releases of GCC and Clang. See e.g. [Gentoo's wiki on Modern C porting](https://wiki.gentoo.org/wiki/Modern_C_porting) for constructs that are now errors by default rather than warnings. This could prevent a Chalk developer from building Chalk outside a container, or from bumping Clang/GCC in the image.
- Nim's default allocator had significant bugs.

Nowadays, I usually have the latest stable Nim release as my system-wide default, and I want to be able to build Chalk outside of a container locally during development without:

- Any possibility of different behavior inside the container (due to a one-year-outdated Nim version).
- Doing something special to switch to Nim 2.0.0 when building Chalk.

Compared to the previous Docker Nim image, this PR also:

- Fixes an incorrect Nimble version. The Nimble version used is now correctly the one that's bundled with the Nim release, rather than an older one (see https://github.com/crashappsec/docker-nim/commit/7dd6e383d319182be978e7f4d0319a054a58745c).
- Bumps Ubuntu from 22.04 to 24.04.
- Bumps GCC from 11 to 13.
- Gives us a newly rebuilt image with up-to-date packages across the board.
- Decreases the Nim image size by 4.5x, from 1.8 GB to 0.4 GB (see https://github.com/crashappsec/docker-nim/commit/7fa48407ee3168577d4dfd70a10537d2757f3efa).

This PR is also good for preparing for Nim 2.2.0, which is in the pipeline, and will have a larger number of fixes.

Closes: https://github.com/crashappsec/chalk/issues/152

---

To-do:

- [x] Merge https://github.com/crashappsec/nimutils/pull/70
- [x] Bump nimutils in con4m
- [x] Bump con4m in chalk
- [x] Rebase this PR on top of `main`