### PR TITLE
build(nimble): bump con4m to make nimutils support Nim 2.0.8

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "https://github.com/crashappsec/con4m#70680c397c82e779a0099f78b1604f065ed666d0"
+requires "https://github.com/crashappsec/con4m#435f230db9cc51beade76427297c206b91e91a70"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally


### PR DESCRIPTION
Bump con4m for this change: https://github.com/crashappsec/con4m/compare/70680c397c82e779a0099f78b1604f065ed666d0...435f230db9cc51beade76427297c206b91e91a70.