### PR TITLE
feat: using mark_default for docker chalk templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## On the `main` branch
 
+### New Features
+
+- `docker build` and `docker push` now use `mark_default`
+  chalk template instead of `minimal`. As such basic
+  metadata about the repository is now included by default
+  in the chalk mark (e.g. `/chalk.json`) such as the
+  repository origin and commit id.
+
 ## 0.4.8
 
 **July 12, 2024**

--- a/src/configs/base_outconf.c4m
+++ b/src/configs/base_outconf.c4m
@@ -18,12 +18,12 @@ outconf extract {
 }
 
 outconf build {
-  mark_template:          "minimal"
+  mark_template:          "mark_default"
   report_template:        "insertion_default"
 }
 
 outconf push {
-  mark_template:          "minimal"
+  mark_template:          "mark_default"
   report_template:        "insertion_default"
 }
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

currently default docker chalk template is `minimal` which does not include any information about the repository, etc. That makes it harder to process any out of order events such as `exec` coming in before `build` for whatever reason (network latency, etc). By bundling the repo information into the chalkmark itself it makes `exec` reports a lot less dependant on the `build` report. Also makes for more pleasant experience manually pulling the image and inspecting its `/chalk.json`.
