### PR TITLE
feat: reporting all base images within Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
   in the chalk mark (e.g. `/chalk.json`) such as the
   repository origin and commit id.
   ([#380](https://github.com/crashappsec/chalk/pull/380))
+- New chalk keys:
+
+  - `DOCKER_TARGET` - name of the target being built in `Dockerfile`
+  - `DOCKER_BASE_IMAGES` - breakdown of all base images across
+    all sections of `Dockerfile`
+  - `DOCKER_COPY_IMAGES` - breakdown of all external `COPY --from`
+    across all sections of `Dockerfile`
+
+  ([#382](https://github.com/crashappsec/chalk/pull/382))
 
 ## 0.4.8
 

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -251,6 +251,7 @@ type
 
   CopyInfo* = ref object of InfoBase
     flags*:  Table[string, DfFlag]
+    frm*:    string
     rawSrc*: seq[string]
     rawDst*: string
 
@@ -266,6 +267,7 @@ type
     platform*:    DockerPlatform
     image*:       DockerImage
     alias*:       string
+    copies*:      seq[CopyInfo]
     entrypoint*:  EntryPointInfo
     cmd*:         CmdInfo
     shell*:       ShellInfo

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1726,6 +1726,10 @@ keyspec DOCKER_TARGET {
     doc: """
 Name of the Dockerfile target being built.
 Empty string is used for alias-less target.
+
+For example `docker build --target=foo` this key will report `"foo"`.
+Also note that when `--target` is not specified, this key will report the
+alias of the last target/section within the Dockerfile.
 """
 }
 
@@ -1895,7 +1899,7 @@ COPY --from=one /bin/sh /sh
       "from": "docker",
       "name": "docker",
       "repo": "docker",
-      "src": ["/bin/docker"],
+      "src": ["/usr/local/bin/docker"],
       "dest": "/docker",
     },
     {

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1717,6 +1717,18 @@ Additional instructions added to the passed dockerfile.
 """
 }
 
+keyspec DOCKER_TARGET {
+    kind:             ChalkTimeArtifact
+    type:             string
+    standard:         true
+    system:           false
+    since:            "0.4.9"
+    doc: """
+Name of the Dockerfile target being built.
+Empty string is used for alias-less target.
+"""
+}
+
 keyspec DOCKER_BASE_IMAGE {
     kind:             ChalkTimeArtifact
     type:             string

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1765,6 +1765,159 @@ Note this only specifies the base image of the final build target.
 """
 }
 
+keyspec DOCKER_BASE_IMAGES {
+    kind:             ChalkTimeArtifact
+    type:             dict[string, `x]
+    standard:         true
+    system:           false
+    since:            "0.4.9"
+    doc: """
+All base images via `FROM` statements used in the Dockerfile for all its sections.
+Each base image will break it into its individual components of:
+
+* from - name as `FROM` references image. Can be either base image or Dockerfile target/section name
+* name - full name as its referenced in Dockerfile
+* repo - only the repo of the image
+* tag - only the tag of the image (if `:<tag>` is provided)
+* digest - only the digest of the image (if `@sha256:<digest>` is provided)
+
+Some special cases:
+
+* if the final target/section doesnt have an alias,
+  it will be under empty string key
+* any transient targets/sections which reference another target/section
+  via `FROM <alias>` the root base image is going to be reported
+
+```
+FROM alpine as one
+FROM ubuntu:latest as two
+FROM busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7 as three
+FROM nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe as four
+FROM one as five
+FROM two
+```
+
+`DOCKER_BASE_IMAGES` is going to be:
+
+```
+{
+  "one": {
+    "from": "alpine",
+    "name": "alpine",
+    "repo": "alpine"
+  },
+  "two": {
+    "from": "ubuntu:latest",
+    "name": "ubuntu:latest",
+    "repo": "ubuntu",
+    "tag": "latest"
+  },
+  "three": {
+    "from": "busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7",
+    "name": "busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7",
+    "repo": "busybox",
+    "digest": "9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7"
+  },
+  "four": {
+    "from": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+    "name": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+    "repo": "nginx",
+    "tag": "1.27.0",
+    "digest": "97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe"
+  }
+  "five": {
+    "from": "one",
+    "name": "alpine",
+    "repo": "alpine"
+  },
+  "": {
+    "from": "two",
+    "name": "ubuntu:latest",
+    "repo": "ubuntu",
+    "tag": "latest"
+  }
+}
+```
+"""
+}
+
+keyspec DOCKER_COPY_IMAGES {
+    kind:             ChalkTimeArtifact
+    type:             dict[string, `x]
+    standard:         true
+    system:           false
+    since:            "0.4.9"
+    doc: """
+All images used in the Dockerfile `COPY --from` directives for all its sections.
+All `COPY` statements are grouped by the Dockerfile target/section.
+
+* from - name as `COPY` references image. Can be either base image or Dockerfile target/section name
+* name - full name as its referenced in Dockerfile
+* repo - only the repo of the image
+* tag - only the tag of the image (if `:<tag>` is provided)
+* digest - only the digest of the image (if `@sha256:<digest>` is provided)
+* src - what COPY copies from image
+* dest - where COPY copies to in the target/section
+
+Special cases:
+
+* If the `COPY` references another target/section within the Dockerfile, its
+  base image is reported.
+
+```
+FROM alpine as one
+FROM ubuntu as two
+COPY --from=docker /usr/local/bin/docker /docker
+COPY --from=busybox:latest /bin/busybox /busybox
+FROM scratch
+COPY --from=nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe /bin/nginx /nginx
+COPY --from=one /bin/sh /sh
+```
+
+`DOCKER_COPY_IMAGES` is going to be:
+
+```
+{
+  "two": [
+    {
+      "from": "docker",
+      "name": "docker",
+      "repo": "docker",
+      "src": ["/bin/docker"],
+      "dest": "/docker",
+    },
+    {
+      "from": "busybox:latest",
+      "name": "busybox:latest",
+      "repo": "busybox",
+      "tag": "latest",
+      "src": ["/bin/busybox"],
+      "dest": "/busybox",
+    }
+  ],
+  "": [
+    {
+      "from": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+      "name": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+      "repo": "nginx",
+      "tag": "1.27.0"
+      "digest": "97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe"
+      "src": ["/bin/nginx"],
+      "dest": "/nginx",
+    },
+    {
+      "from": "one",
+      "name": "alpine",
+      "repo": "alpine",
+      "src": ["/bin/sh"],
+      "dest": "/sh"
+    }
+  ]
+}
+```
+"""
+}
+
 keyspec _DOCKER_CLIENT_VERSION {
     kind:             RunTimeHost
     type:             string

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -120,6 +120,7 @@ report and subtract from it.
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true
   key.DOCKER_TAGS.use                         = true
+  key.DOCKER_TARGET.use                       = true
   key.DOCKER_CONTEXT.use                      = true
   key.DOCKER_ADDITIONAL_CONTEXTS.use          = true
   key.DOCKER_CHALK_ADDED_LABELS.use           = true
@@ -128,6 +129,8 @@ report and subtract from it.
   key.DOCKER_BASE_IMAGE_REPO.use              = true
   key.DOCKER_BASE_IMAGE_TAG.use               = true
   key.DOCKER_BASE_IMAGE_DIGEST.use            = true
+  key.DOCKER_BASE_IMAGES.use                  = true
+  key.DOCKER_COPY_IMAGES.use                  = true
   key._OP_ARTIFACT_TYPE.use                   = true
   key._OP_ARTIFACT_PATH.use                   = true
   key._CURRENT_HASH.use                       = true
@@ -686,6 +689,7 @@ doc: """
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true
   key.DOCKER_TAGS.use                         = true
+  key.DOCKER_TARGET.use                       = true
   key.DOCKER_CONTEXT.use                      = true
   key.DOCKER_ADDITIONAL_CONTEXTS.use          = true
   key.DOCKER_CHALK_ADDED_LABELS.use           = true
@@ -694,6 +698,8 @@ doc: """
   key.DOCKER_BASE_IMAGE_REPO.use              = true
   key.DOCKER_BASE_IMAGE_TAG.use               = true
   key.DOCKER_BASE_IMAGE_DIGEST.use            = true
+  key.DOCKER_BASE_IMAGES.use                  = true
+  key.DOCKER_COPY_IMAGES.use                  = true
   key._OP_ARTIFACT_TYPE.use                   = true
   key._OP_ARTIFACT_PATH.use                   = true
   key._CURRENT_HASH.use                       = true
@@ -1143,6 +1149,7 @@ container.
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true
   key.DOCKER_TAGS.use                         = true
+  key.DOCKER_TARGET.use                       = true
   key.DOCKER_CONTEXT.use                      = true
   key.DOCKER_ADDITIONAL_CONTEXTS.use          = true
   key.DOCKER_CHALK_ADDED_LABELS.use           = true
@@ -1151,6 +1158,8 @@ container.
   key.DOCKER_BASE_IMAGE_REPO.use              = true
   key.DOCKER_BASE_IMAGE_TAG.use               = true
   key.DOCKER_BASE_IMAGE_DIGEST.use            = true
+  key.DOCKER_BASE_IMAGES.use                  = true
+  key.DOCKER_COPY_IMAGES.use                  = true
   key._OP_ARTIFACT_TYPE.use                   = true
   key._OP_ARTIFACT_PATH.use                   = true
   key._CURRENT_HASH.use                       = true
@@ -1601,6 +1610,7 @@ and keep the run-time key.
   key.DOCKER_LABELS.use                       = true
   key.DOCKER_TAGS.use                         = true
   key.DOCKER_CONTEXT.use                      = true
+  key.DOCKER_TARGET.use                       = true
   key.DOCKER_ADDITIONAL_CONTEXTS.use          = true
   key.DOCKER_CHALK_ADDED_LABELS.use           = true
   key.DOCKER_CHALK_ADDED_TO_DOCKERFILE.use    = true
@@ -1608,6 +1618,8 @@ and keep the run-time key.
   key.DOCKER_BASE_IMAGE_REPO.use              = true
   key.DOCKER_BASE_IMAGE_TAG.use               = true
   key.DOCKER_BASE_IMAGE_DIGEST.use            = true
+  key.DOCKER_BASE_IMAGES.use                  = true
+  key.DOCKER_COPY_IMAGES.use                  = true
   key._OP_ARTIFACT_TYPE.use                   = true
   key._OP_ARTIFACT_PATH.use                   = true
   key._CURRENT_HASH.use                       = true
@@ -1941,6 +1953,8 @@ running insert commands.
   key.DOCKER_BASE_IMAGE_REPO.use              = false
   key.DOCKER_BASE_IMAGE_TAG.use               = false
   key.DOCKER_BASE_IMAGE_DIGEST.use            = false
+  key.DOCKER_BASE_IMAGES.use                  = false
+  key.DOCKER_COPY_IMAGES.use                  = false
   key.INFERRED_TECH_STACKS.use                = true
   key._INFERRED_TECH_STACKS_HOST.use          = true
   key.METADATA_ID.use                         = true
@@ -2023,6 +2037,8 @@ running commands that do NOT insert chalk marks.
   key.DOCKER_BASE_IMAGE_REPO.use              = true
   key.DOCKER_BASE_IMAGE_TAG.use               = true
   key.DOCKER_BASE_IMAGE_DIGEST.use            = true
+  key.DOCKER_BASE_IMAGES.use                  = true
+  key.DOCKER_COPY_IMAGES.use                  = true
   key.METADATA_ID.use                         = true
   key.SIGNATURE.use                           = true
   key._SIGNATURES.use                         = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -229,6 +229,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.DOCKER_PLATFORMS.use                    = true
   ~key.DOCKER_LABELS.use                       = true
   ~key.DOCKER_TAGS.use                         = true
+  ~key.DOCKER_TARGET.use                       = true
   ~key.DOCKER_CONTEXT.use                      = true
   ~key.DOCKER_ADDITIONAL_CONTEXTS.use          = true
   ~key.DOCKER_CHALK_ADDED_LABELS.use           = true
@@ -237,6 +238,8 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.DOCKER_BASE_IMAGE_REPO.use              = true
   ~key.DOCKER_BASE_IMAGE_TAG.use               = true
   ~key.DOCKER_BASE_IMAGE_DIGEST.use            = true
+  ~key.DOCKER_BASE_IMAGES.use                  = true
+  ~key.DOCKER_COPY_IMAGES.use                  = true
   ~key._OP_ARTIFACT_TYPE.use                   = true
   ~key._OP_ARTIFACT_PATH.use                   = true
   ~key._CURRENT_HASH.use                       = true

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -171,7 +171,7 @@ template isSubscribedKey*(key: string): bool =
   else:
     false
 
-template setIfSubscribed[T](d: ChalkDict, k: string, v: T) =
+template setIfSubscribed*[T](d: ChalkDict, k: string, v: T) =
   if isSubscribedKey(k):
     when T is Box:
       d[k] = v

--- a/tests/functional/data/dockerfiles/valid/bases/Dockerfile
+++ b/tests/functional/data/dockerfiles/valid/bases/Dockerfile
@@ -1,0 +1,18 @@
+  ARG BASE=two
+
+  FROM alpine as one
+
+  FROM ubuntu:24.04 as two
+  COPY --from=docker /usr/local/bin/docker /docker
+  COPY --from=busybox:latest /bin/busybox /busybox
+
+  FROM busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7 as three
+
+  FROM nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe as four
+
+  FROM one as five
+  COPY --from=nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe /usr/sbin/nginx /nginx
+  COPY --from=one /bin/sh /sh
+
+  FROM $BASE
+  COPY --from=four /usr/sbin/nginx /nginx

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -318,6 +318,103 @@ def test_base_image(chalk: Chalk, random_hex: str):
     assert Docker.run(image_id)
 
 
+def test_base_images(chalk: Chalk):
+    _, result = chalk.docker_build(
+        dockerfile=DOCKERFILES / "valid" / "bases" / "Dockerfile",
+    )
+    assert result.mark.has(
+        DOCKER_TARGET="",
+        DOCKER_BASE_IMAGE="ubuntu:24.04",
+        DOCKER_BASE_IMAGE_REPO="ubuntu",
+        DOCKER_BASE_IMAGE_TAG="24.04",
+        DOCKER_BASE_IMAGES={
+            "one": {
+                "from": "alpine",
+                "name": "alpine",
+                "repo": "alpine",
+            },
+            "two": {
+                "from": "ubuntu:24.04",
+                "name": "ubuntu:24.04",
+                "repo": "ubuntu",
+                "tag": "24.04",
+            },
+            "three": {
+                "from": "busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7",
+                "name": "busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7",
+                "repo": "busybox",
+                "digest": "9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7",
+            },
+            "four": {
+                "from": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+                "name": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+                "repo": "nginx",
+                "tag": "1.27.0",
+                "digest": "97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+            },
+            "five": {
+                "from": "one",
+                "name": "alpine",
+                "repo": "alpine",
+            },
+            "": {
+                "from": "two",
+                "name": "ubuntu:24.04",
+                "repo": "ubuntu",
+                "tag": "24.04",
+            },
+        },
+        DOCKER_COPY_IMAGES={
+            "two": [
+                {
+                    "from": "docker",
+                    "name": "docker",
+                    "repo": "docker",
+                    "src": ["/usr/local/bin/docker"],
+                    "dest": "/docker",
+                },
+                {
+                    "from": "busybox:latest",
+                    "name": "busybox:latest",
+                    "repo": "busybox",
+                    "tag": "latest",
+                    "src": ["/bin/busybox"],
+                    "dest": "/busybox",
+                },
+            ],
+            "five": [
+                {
+                    "from": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+                    "name": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+                    "repo": "nginx",
+                    "tag": "1.27.0",
+                    "digest": "97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+                    "src": ["/usr/sbin/nginx"],
+                    "dest": "/nginx",
+                },
+                {
+                    "from": "one",
+                    "name": "alpine",
+                    "repo": "alpine",
+                    "src": ["/bin/sh"],
+                    "dest": "/sh",
+                },
+            ],
+            "": [
+                {
+                    "from": "four",
+                    "name": "nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+                    "repo": "nginx",
+                    "tag": "1.27.0",
+                    "digest": "97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe",
+                    "src": ["/usr/sbin/nginx"],
+                    "dest": "/nginx",
+                }
+            ],
+        },
+    )
+
+
 @pytest.mark.parametrize(
     "test_file, entrypoint, cmd",
     [


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

currently chalk only reports a single base image

fixes https://github.com/crashappsec/chalk/issues/375

## Description

chalk can report all images used across all of the dockerfile across all of the targets/sections including `COPY` directives

## Testing

```
➜ make tests args="test_docker.py::test_base_images --logs"
```
