### PR TITLE
refactor: moving out www-authenticate handling to authSafeRequest 

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#435f230db9cc51beade76427297c206b91e91a70"
+requires "https://github.com/crashappsec/con4m#520e144555abefd7de2cce2b3383e6b872109687"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally

--- a/src/www_authenticate.nim
+++ b/src/www_authenticate.nim
@@ -139,7 +139,8 @@ proc authSafeRequest*(url: Uri | string,
                       pinnedCert: string = "",
                       maxRedirects: int = 3,
                       disallowHttp: bool = false,
-                      raiseOnStatus: bool = true,
+                      only2xx: bool = false,
+                      raiseWhenAbove: int = 0,
                       ): Response =
   let uri =
     when url is string:
@@ -163,7 +164,9 @@ proc authSafeRequest*(url: Uri | string,
                        timeout           = timeout,
                        pinnedCert        = pinnedCert,
                        maxRedirects      = maxRedirects,
-                       disallowHttp      = disallowHttp)
+                       disallowHttp      = disallowHttp,
+                       only2xx           = false,
+                       raiseWhenAbove    = 0)
 
   if (
     result.code() == Http401 and
@@ -189,7 +192,10 @@ proc authSafeRequest*(url: Uri | string,
                          timeout           = timeout,
                          pinnedCert        = pinnedCert,
                          maxRedirects      = maxRedirects,
-                         disallowHttp      = disallowHttp)
+                         disallowHttp      = disallowHttp,
+                         only2xx           = false,
+                         raiseWhenAbove    = 0)
 
-  if not result.code().is2xx():
-    raise newException(ValueError, $uri & " failed with " & result.status)
+  discard result.check(url            = url,
+                       only2xx        = only2xx,
+                       raiseWhenAbove = raiseWhenAbove)


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Description

authSafeRequest will be used by registry SDK as www-authenticate
is a common auth mechanism in registries including docker hub:

```
➜ curl https://registry-1.docker.io/v2/ -Is | grep authenticate
www-authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io"
```

In addition the token headers are cached by hostname so that only first
failure needs to elicit the auth after which same token is reused
multiple times

## Testing

```
➜ make tests args="test_docker.py::test_base_ecr --logs"
```
