### PR TITLE
fix: recursively wrapping docker ENTRYPOINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- When base image is already wrapped by chalk, `ENTRYPOINT`
+  was recursively wrapped which broke image runtime
+  as it was always exiting with non-zero code.
+  ([#385](https://github.com/crashappsec/chalk/pull/385))
+
 ### New Features
 
 - `docker build` and `docker push` now use `mark_default`

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -318,6 +318,24 @@ def test_base_image(chalk: Chalk, random_hex: str):
     assert Docker.run(image_id)
 
 
+def test_recursion_wrapping(chalk: Chalk, random_hex: str):
+    base_id, _ = chalk.docker_build(
+        dockerfile=DOCKERFILES / "valid" / "base" / "Dockerfile.base",
+        context=DOCKERFILES / "valid" / "base",
+        tag=random_hex,
+        config=CONFIGS / "docker_wrap.c4m",
+    )
+    assert base_id
+
+    image_id, result = chalk.docker_build(
+        dockerfile=DOCKERFILES / "valid" / "base" / "Dockerfile",
+        context=DOCKERFILES / "valid" / "base",
+        args={"BASE": random_hex},
+        config=CONFIGS / "docker_wrap.c4m",
+    )
+    assert Docker.run(image_id)
+
+
 def test_base_images(chalk: Chalk):
     _, result = chalk.docker_build(
         dockerfile=DOCKERFILES / "valid" / "bases" / "Dockerfile",


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

building image on top of another chalk image breaks its runtime

## Description

base image ENTRYPOINT wrapping was always wrapping it regardless of its existing value which meant that chalk can recursively wrap itself which would always fail at run-time.

now we check if the entrypoint is already wrapped with chalk and if so skip wrapping ENTRYPOINT again

## Testing

```
➜ make tests args="test_docker.py::test_recursion_wrapping --logs"
```
