### PR TITLE
fix: increasing cloud metadata timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## On the `main` branch
 
+### Other
+
+- Increasing cloud metadata endpoint collection timeout
+  from 500ms to 1sec as in some cases it takes longer than
+  500ms to get a response.
+  ([#388](https://github.com/crashappsec/chalk/pull/388))
+
 ## 0.4.9
 
 **July 30, 2024**

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -28,7 +28,7 @@ proc hitProviderEndpoint(path: string, hdrs: HttpHeaders): Option[string] =
     let
       response = safeRequest(url        = path,
                              httpMethod = HttpGet,
-                             timeout    = 500, # 1/2 of a second
+                             timeout    = 1000, # 1 of a second
                              headers    = hdrs)
       body     = response.body().strip()
 
@@ -186,7 +186,7 @@ proc getAwsToken(): Option[string] =
       hdrs     = newHttpHeaders([("X-aws-ec2-metadata-token-ttl-seconds", "10")])
       response = safeRequest(url        = url,
                              httpMethod = HttpPut,
-                             timeout    = 500, # 1/2 of a second
+                             timeout    = 1000, # 1 of a second
                              headers    = hdrs)
       body     = response.body().strip()
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

we are still seeing some connect timeouts with 500ms
