### PR TITLE
fix: hiding chalk exec report in interactive shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   from 500ms to 1sec as in some cases it takes longer than
   500ms to get a response.
   ([#388](https://github.com/crashappsec/chalk/pull/388))
+- Not showing `exec` report when chalk is running in
+  interactive shell.
+  ([#390](https://github.com/crashappsec/chalk/pull/390))
 
 ## 0.4.9
 

--- a/src/configs/ioconfig.c4m
+++ b/src/configs/ioconfig.c4m
@@ -19,7 +19,7 @@ custom_report terminal_other_op {
   enabled:         true
   report_template: "terminal_rest"
   sink_configs:    ["json_console_out"]
-  use_when:        ["extract", "delete", "exec", "env", "heartbeat"]
+  use_when:        ["extract", "delete", "env", "heartbeat"]
 }
 
 custom_report github_group_chalk_time {

--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -2,6 +2,7 @@ subscribe("report", "json_console_out")
 custom_report.github_group_chalk_time.enabled: false
 custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false
+custom_report.terminal_other_op.use_when: ["extract", "delete", "exec", "env", "heartbeat"]
 
 if not env_exists("CHALK_USAGE_URL") {
   crashoverride_usage_reporting_url: "https://chalk-test.crashoverride.run/v0.1/usage"


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

`./chalk exec` shows report in stdout for interactive shell

## Description

`./chalk exec` .. should preserve original command output

for example running docker wrapped container:

```
docker run --rm -it python-wrapped-with-chalk
```

would show full chalk exec report which would be unexpected
