### PR TITLE
test: fixing integration tests

### DIFF
--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -410,6 +410,7 @@ class Chalk:
         self,
         *,
         dockerfile: Optional[Path | str] = None,
+        content: Optional[str] = None,
         tag: Optional[str] = None,
         tags: Optional[list[str]] = None,
         context: Optional[Path | str] = None,
@@ -440,6 +441,7 @@ class Chalk:
                 tags=tags,
                 context=context,
                 dockerfile=dockerfile,
+                content=content,
                 args=args,
                 cwd=cwd,
                 push=push,
@@ -465,6 +467,7 @@ class Chalk:
                     tags=tags,
                     context=context,
                     dockerfile=dockerfile,
+                    content=content,
                     args=args,
                     push=push,
                     platforms=platforms,
@@ -491,12 +494,11 @@ class Chalk:
             # sanity check that chalk mark includes basic chalk keys
             assert image_hash in [i["_CURRENT_HASH"] for i in result.marks]
             assert image_hash in [i["_IMAGE_ID"] for i in result.marks]
-            if isinstance(dockerfile, Path) or dockerfile is None:
-                if isinstance(context, Path):
-                    dockerfile = dockerfile or (
-                        (cwd or context or Path(os.getcwd())) / "Dockerfile"
-                    )
-                    assert str(dockerfile) == result.marks[-1]["DOCKERFILE_PATH"]
+            if isinstance(context, Path) and not content:
+                dockerfile = dockerfile or (
+                    (cwd or context or Path(os.getcwd())) / "Dockerfile"
+                )
+                assert str(dockerfile) == result.marks[-1]["DOCKERFILE_PATH"]
         elif not expecting_report:
             try:
                 assert not result.reports

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -594,7 +594,7 @@ def test_wrap_entrypoint(
     runnable: bool,
 ):
     docker_id, _ = Docker.build(
-        dockerfile=test_file,
+        content=test_file,
         buildkit=buildkit,
         buildx=buildx,
     )
@@ -607,7 +607,7 @@ def test_wrap_entrypoint(
     _, docker_output = Docker.run(docker_id, expected_success=runnable)
 
     image_id, result = chalk.docker_build(
-        dockerfile=test_file,
+        content=test_file,
         config=CONFIGS / "docker_wrap.c4m",
         buildkit=buildkit,
         buildx=buildx,

--- a/tests/functional/utils/docker.py
+++ b/tests/functional/utils/docker.py
@@ -33,6 +33,7 @@ class Docker:
         tags: Optional[list[str]] = None,
         context: Optional[Path | str] = None,
         dockerfile: Optional[Path | str] = None,
+        content: Optional[str] = None,
         args: Optional[dict[str, str]] = None,
         push: bool = False,
         platforms: Optional[list[str]] = None,
@@ -53,15 +54,14 @@ class Docker:
             cmd += ["--load"]
         for t in tags:
             cmd += ["-t", t]
-        if dockerfile:
-            if isinstance(dockerfile, Path):
-                cmd += ["-f", str(dockerfile)]
-            else:
-                tmp = NamedTemporaryFile(delete_on_close=False)
-                tmp.file.write(dockerfile.encode())
-                tmp.file.close()
-                dockerfiles.append(tmp)
-                cmd += ["-f", tmp.name]
+        if content:
+            tmp = NamedTemporaryFile(delete_on_close=False)
+            tmp.file.write(content.encode())
+            tmp.file.close()
+            dockerfiles.append(tmp)
+            cmd += ["-f", tmp.name]
+        elif dockerfile:
+            cmd += ["-f", str(dockerfile)]
         for name, value in (args or {}).items():
             cmd += [f"--build-arg={name}={value}"]
         if platforms:
@@ -87,6 +87,7 @@ class Docker:
         tags: Optional[list[str]] = None,
         context: Optional[Path | str] = None,
         dockerfile: Optional[Path | str] = None,
+        content: Optional[str] = None,
         args: Optional[dict[str, str]] = None,
         cwd: Optional[Path] = None,
         push: bool = False,
@@ -109,6 +110,7 @@ class Docker:
                     tags=tags,
                     context=context,
                     dockerfile=dockerfile,
+                    content=content,
                     args=args,
                     push=push,
                     platforms=platforms,


### PR DESCRIPTION
changed semantic of dockerfile param in docker build wrappers which broke some --slow tests so adding new param content now. In theory we could rename dockerfile to dockerfile_path and dockerfile params but that would require changing all existing callers which is bigger refactor we can opt in to do in the future. For now content param should suffice.

tests:--slow
