### PR TITLE
WIP feat: docker registry http wrappers

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -13,6 +13,7 @@ bin           = @["chalk"]
 requires "nim >= 2.0.8"
 requires "https://github.com/crashappsec/con4m#c6e22293abf0d0eabd44b012b5deb5e8c9ed5bac"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
+requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 
 # this allows us to get version externally
 task version, "Show current version":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       context: ./tests/functional
       args:
         BASE: ${BASE:-ubuntu}
-    entrypoint: ./entrypoint.sh
+    entrypoint: $PWD/tests/functional/entrypoint.sh
     cap_add:
       - SYS_PTRACE # for gdb
     security_opt:

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -222,9 +222,7 @@ type
 
   FromInfo* = ref object of InfoBase
     flags*:  Table[string, DfFlag]
-    repo*:   Option[LineToken]
-    tag*:    Option[LineToken]
-    digest*: Option[LineToken]
+    image*:  Option[seq[LineToken]]
     asArg*:  Option[LineToken]
 
   ShellInfo* = ref object of InfoBase
@@ -294,10 +292,14 @@ type
     tags*:         seq[string]
     refs*:         seq[string]
 
-  DigestedJson* = ref object
+  DigestedJson* = ref object of RootObj
     json*:   JsonNode
     digest*: string
     size*:   int
+
+  DockerDigestedJson* = ref object of DigestedJson
+    mediaType*: string
+    kind*:      DockerManifestType
 
   DockerManifestType* = enum
     list, image, config, layer

--- a/src/docker/exe.nim
+++ b/src/docker/exe.nim
@@ -5,7 +5,8 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
-import std/[os]
+import std/[os, sets]
+import pkg/[parsetoml]
 import ".."/[config, util, semver]
 
 var
@@ -27,15 +28,23 @@ proc getDockerExeLocation*(): string =
       warn("docker: no command found in PATH. `chalk docker` not available.")
   return dockerExeLocation
 
-proc runDockerGetEverything*(args: seq[string], stdin = "", silent = true): ExecOutput =
-  let exe = getDockerExeLocation()
+proc runDockerGetEverything*(args: seq[string],
+                             stdin = "",
+                             silent = true,
+                             raiseOnError = false): ExecOutput =
+  let
+    exe = getDockerExeLocation()
+    msg = exe & " " & args.join(" ")
   if not silent:
-    trace("docker: " & exe & " " & args.join(" "))
+    trace("docker: " & msg)
     if stdin != "":
       trace("docker: stdin: \n" & stdin)
   result = runCmdGetEverything(exe, args, stdin)
   if not silent and result.exitCode > 0:
     trace(strutils.strip(result.stderr & result.stdout))
+  if result.exitCode > 0 and raiseOnError:
+    error("docker: " & msg & "\n" & result.stderr)
+    raise newException(ValueError, msg & " - exited with non-zero " & $result.exitCode)
   return result
 
 proc getBuildXVersion*(): Version =
@@ -100,6 +109,55 @@ proc getDockerInfo*(): string =
       dockerInfo = output.getStdOut()
   return dockerInfo
 
+proc getDockerInfoSubList*(key: string): seq[string] =
+  let lower = key.toLower()
+  result = @[]
+  var found = false
+  for line in getDockerInfo().splitLines():
+    if line.strip().toLower() == lower:
+      found = true
+      continue
+    if not found:
+      continue
+    # all list entries are indented
+    # so if a line doesnt have indent we exhaused relevant lines
+    if line.strip() == line:
+      break
+    result.add(line.strip())
+
+proc readDockerHostFile*(path: string): string =
+  # note that the docker socket can be mounted to a container where
+  # chalk is running from hence we attempt to get the file content
+  # via a docker run and mounting source path which will allow
+  # us to get the content of file of the docker daemon host,
+  # not where chalk is running
+  let
+    inner  = "/mnt" & path
+    output = runDockerGetEverything(
+      @[
+        "run",
+        "--entrypoint=cat",
+        # note that --mount does not create the source path if one doesnt exist already
+        # unlike --volume which creates a folder if one is not present already
+        "--mount", "type=bind,source=" & path & ",target=" & inner,
+        "busybox",
+        inner,
+      ],
+      silent = false,
+    )
+  if output.exitCode != 0:
+    raise newException(ValueError, "could not read " & path)
+  trace("docker: read docker host's " & path)
+  return output.stdOut
+
+proc readFirstDockerHostFile*(paths: seq[string]): tuple[path: string, content: string] =
+  for path in paths.toSet():
+    try:
+      return (path, readDockerHostFile(path))
+    except:
+      continue
+  raise newException(ValueError, "could not read any of " & $paths)
+
 var contextName = "default"
 proc getContextName(): string =
   once:
@@ -120,10 +178,11 @@ proc getContextName(): string =
   return contextName
 
 proc getBuilderName(ctx: DockerInvocation): string =
-  if not ctx.foundBuildx:
-    return getContextName()
-  if ctx.foundBuilder != "":
-    return ctx.foundBuilder
+  if ctx != nil and ctx.cmd == DockerCmd.build:
+    if not ctx.foundBuildx:
+      return getContextName()
+    if ctx.foundBuilder != "":
+      return ctx.foundBuilder
   return getEnv("BUILDX_BUILDER")
 
 var builderInfo = ""
@@ -134,11 +193,64 @@ proc getBuilderInfo*(ctx: DockerInvocation): string =
       var args = @["buildx", "inspect", "--bootstrap"]
       if name != "":
         args.add(name)
-      let output = runDockerGetEverything(args)
+      let output = runDockerGetEverything(args, silent = false)
       if output.exitCode != 0:
         trace("docker: could not get buildx builder information: " & output.getStdErr())
       builderInfo = output.getStdOut()
   return builderInfo
+
+proc getBuilderNodesInfo*(ctx: DockerInvocation): Table[string, string] =
+  result = initTable[string, string]()
+  var
+    foundNodes = false
+    name       = ""
+  for line in ctx.getBuilderInfo().splitLines():
+    let lower = line.toLower()
+    if lower.startsWith("driver:"):
+      let driver = line.splitWhitespace()[^1]
+      if driver != "docker-container":
+        trace("docker: unsupported buildx builder driver: " & driver)
+        return
+    if lower.startsWith("nodes:"):
+      foundNodes = true
+      continue
+    if not foundNodes:
+      continue
+    if lower.startsWith("name:"):
+      name = line.splitWhitespace()[^1]
+      result[name] = ""
+    result[name] &= line & "\n"
+
+proc readBuilderNodeFile*(ctx: DockerInvocation, node: string, path: string): string =
+  let
+    # ideally we can query the namespaces however they are not exposed
+    # via docker info output and are only stored in the buildx config files
+    # which we cant read until we know the namespaces
+    # TODO search through all running containers if the default namespace is not found
+    container = "buildx_buildkit_" & node
+    output    = runDockerGetEverything(
+      @[
+        "exec",
+        container,
+        "cat",
+        path,
+      ],
+      silent = false,
+    )
+  if output.exitCode != 0:
+    raise newException(ValueError, "could not read buildx node's " & container & " " & path)
+  return output.stdOut
+
+iterator iterBuilderNodesConfigs*(ctx: DockerInvocation): tuple[name: string, config: JsonNode] =
+  for name, _ in ctx.getBuilderNodesInfo():
+    try:
+      let
+        toml   = ctx.readBuilderNodeFile(name, "/etc/buildkit/buildkitd.toml")
+        config = parsetoml.parseString(toml).toJson()
+      yield (name, config)
+    except:
+      trace("docker: could not load toml for buildx node " & name & " due to: " & getCurrentExceptionMsg())
+      continue
 
 proc getBuildKitVersion*(ctx: DockerInvocation): Version =
   once:
@@ -152,6 +264,20 @@ proc getBuildKitVersion*(ctx: DockerInvocation): Version =
     except:
       dumpExOnDebug()
   return buildKitVersion
+
+var dockerAuth = newJObject()
+proc getDockerAuthConfig*(): JsonNode =
+  once:
+    let path = "~/.docker/config.json"
+    try:
+      let data = tryToLoadFile(path.resolvePath())
+      if data != "":
+        dockerAuth = parseJson(data)
+      else:
+        trace("docker: no auth config file " & path)
+    except:
+      trace("docker: could not read docker auth config file " & path & " due to: " & getCurrentExceptionMsg())
+  return dockerAuth
 
 proc supportsBuildContextFlag*(ctx: DockerInvocation): bool =
   # https://github.com/docker/buildx/releases/tag/v0.8.0

--- a/src/docker/json.nim
+++ b/src/docker/json.nim
@@ -9,12 +9,25 @@
 
 import std/[json]
 import ".."/[config, chalkjson, util]
+import "."/[ids]
 
 proc parseAndDigestJson*(data: string): DigestedJson =
   return DigestedJson(
     json:   parseJson(data),
     digest: "sha256:" & sha256(data).hex(),
     size:   len(data),
+  )
+
+proc newDockerDigestedJson*(data: string,
+                            digest: string,
+                            mediaType: string,
+                            kind: DockerManifestType): DockerDigestedJson =
+  return DockerDigestedJson(
+    json:      parseJson(data),
+    digest:    "sha256:" & extractDockerhash(digest),
+    size:      len(data),
+    mediaType: mediaType,
+    kind:      kind,
   )
 
 type

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -1,0 +1,276 @@
+##
+## Copyright (c) 2024, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Docker registry v2 wrapper
+## https://docker-docs.uclv.cu/registry/spec/api/
+## https://docker-docs.uclv.cu/registry/spec/manifest-v2-2/
+## https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file
+## https://docs.docker.com/build/buildkit/toml-configuration/
+
+import std/[net, uri, httpclient, nativesockets]
+import ".."/[config, ip, util, www_authenticate]
+import "."/[exe, json, ids]
+
+type RegistryConfig = ref object
+  scheme*:     string
+  certPath*:   string
+  pinnedCert*: string
+  verifyMode*: SslCVerifyMode
+  auth*:       HttpHeaders
+
+const
+  TIMEOUT = 3000 # sec
+  CONTENT_TYPE_MAPPING = {
+    "application/vnd.docker.distribution.manifest.list.v2+json": DockerManifestType.list,
+    "application/vnd.docker.distribution.manifest.v2+json": DockerManifestType.image,
+    "application/vnd.docker.container.image.v1+json": DockerManifestType.config,
+    "application/vnd.docker.image.rootfs.diff.tar.gzip": DockerManifestType.layer,
+
+    "application/vnd.oci.image.index.v1+json": DockerManifestType.list,
+    "application/vnd.oci.image.manifest.v1+json": DockerManifestType.image,
+    "application/vnd.oci.image.config.v1+json": DockerManifestType.config,
+  }.toTable()
+
+proc withBasicAuth(self: RegistryConfig, token: string): RegistryConfig =
+  if token != "":
+    self.auth = newHttpHeaders(@[
+      ("Authorization", "Basic " & token),
+    ])
+  else:
+    self.auth = newHttpHeaders()
+  return self
+
+iterator iterDaemonRegistryHttpsConfigs(self: DockerImage): RegistryConfig =
+  var (path, cert) =
+    try:
+      readFirstDockerHostFile(@[
+        "/etc/docker/certs.d/" & self.registry & "/ca.crt",
+        "/etc/docker/certs.d/" & self.domain   & "/ca.crt",
+      ])
+    except:
+      ("", "")
+  if cert != "":
+    trace("docker: found CA certificate for " & self.registry & " at " & path & " in docker daemon")
+    yield RegistryConfig(
+      scheme:     "https://",
+      certPath:   path,
+      pinnedCert: writeNewTempFile(
+        cert,
+        prefix = self.domain,
+        suffix = ".crt",
+      ),
+    )
+  trace("docker: " & self.registry & " will attempt TLS without verifying server cert")
+  yield RegistryConfig(scheme: "https://", verifyMode: CVerifyNone)
+
+iterator iterDaemonRegistryConfigs(self: DockerImage): RegistryConfig =
+  template insecure() =
+    for i in self.iterDaemonRegistryHttpsConfigs():
+      yield i
+    yield RegistryConfig(scheme: "http://", verifyMode: CVerifyNone)
+  for i in getDockerInfoSubList("insecure registries:"):
+    if self.registry == i or self.domain == i:
+      trace("docker: " & i & " is configured as an insecure registry in docker daemon")
+      insecure()
+    # docker does not support port numbers along with cidr blocks
+    # so 127.0.0.0/8 cannot be combined with a port number
+    # like 127.0.0.0/8:1234
+    if ":" in i:
+      continue
+    try:
+      let
+        # if the domain is not an ip address, it raises an excpetion
+        # and which we ignore which is fine
+        (ip, ipRange)   = parseIpCidr(i)
+        # when the insecure registry is a cidr block
+        # any domain resolved to that block is insecure
+        selfIp =
+          try:
+            parseIpAddress(self.domain)
+          except:
+            parseIpAddress(getHostByName(self.domain).addrList[0])
+      if selfIp.family != ip.family:
+        continue
+      if selfIp in ipRange:
+        trace("docker: " & self.domain & " (" & $selfIp & ") is an insecure registry via IP address match for " & i)
+        insecure()
+    except:
+      continue
+
+iterator iterBuildxRegistryConfigs(self: DockerImage): RegistryConfig =
+  # TODO this should be compatible outside of build commands
+  # where docker daemon takes precedence
+  if hasBuildx():
+    for node, config in dockerInvocation.iterBuilderNodesConfigs():
+      if self.registry notin config{"registry"}:
+        continue
+      try:
+        let
+          registry = config["registry"][self.registry]
+          http     = registry{"http"}{"value"}.getStr()
+          insecure = registry{"insecure"}{"value"}.getStr()
+          certs    = registry{"ca"}{"value"}
+        if certs != nil and certs.kind == JArray:
+          for cert in certs:
+            let path = cert{"value"}.getStr()
+            try:
+              let data = dockerInvocation.readBuilderNodeFile(node, path)
+              trace("docker: found CA certificate for " & self.registry & " at " & path & " in buildx node " & node)
+              yield RegistryConfig(
+                scheme:     "https://",
+                verifyMode: CVerifyPeer,
+                pinnedCert: data,
+                certPath:   path,
+              )
+            except:
+              trace("docker: cannot read buildx registry CA from " & path & " in buildx node " & node)
+              continue
+        if insecure == "true":
+          trace("docker: " & self.registry & " is configured as an insecure registry in docker buildx node " & node)
+          yield RegistryConfig(scheme: "https://", verifyMode: CVerifyNone)
+        if http == "true":
+          trace("docker: " & self.registry & " is configured as an http registry in docker buildx node " & node)
+          yield RegistryConfig(scheme: "http://", verifyMode: CVerifyNone)
+      except:
+        trace("docker: cannot inspect buildx config due to: " & getCurrentExceptionMsg())
+        continue
+
+proc getBasicAuth(self: DockerImage): string =
+  try:
+    let config = getDockerAuthConfig()
+    result = config{"auths"}{self.registry}{"auth"}.getStr()
+    if result != "":
+      trace("docker: using basic auth creds from docker config for " & self.registry)
+  except:
+    trace("docker: invalid auth config: " & getCurrentExceptionMsg())
+    return ""
+
+var configByRegistry = initTable[string, RegistryConfig]()
+iterator getConfigs(self: DockerImage): RegistryConfig =
+  ## get all plausible configs for iteracting with the registry
+  ## note this is explicitly implemented as an iterator
+  ## as getting specific config can be more expensive as it might
+  ## need to get docker daemon/buildx configs/etc
+  ## and iterators allow to make that lazy where if a config attempt
+  ## fails, only then next config is fetched until a working config
+  ## is found
+  if self.registry in configByRegistry:
+    yield configByRegistry[self.registry]
+
+  # find basic auth from docker config file
+  let token = self.getBasicAuth()
+
+  # some configs could be duplicates such as if there are multiple buildx
+  # nodex they might all have equivalent configs
+  var checkedConfigs = newSeq[RegistryConfig]()
+
+  # always attempt to talk to registry via https first
+  # which will bypass parsing all daemon/buildx configs/etc
+  # plus in most production flows this should be most common case
+  trace("docker: attempting secure registry config for " & self.registry)
+  let https = RegistryConfig(scheme: "https://", verifyMode: CVerifyPeer).withBasicAuth(token)
+  checkedConfigs.add(https)
+  yield https
+
+  let isBuildx = (
+    dockerInvocation != nil and
+    dockerInvocation.cmd == build and
+    dockerInvocation.foundBuildx
+  )
+  template buildx() =
+    for i in self.iterBuildxRegistryConfigs():
+      if i notin checkedConfigs:
+        let i = i.withBasicAuth(token)
+        checkedConfigs.add(i)
+        yield i
+  # when running buildx, buildx nodes configs should take precedence
+  # over daemon configs but we still scan both just in case
+  if isBuildx:
+    buildx()
+  for i in self.iterDaemonRegistryConfigs():
+    if i notin checkedConfigs:
+      let i = i.withBasicAuth(token)
+      checkedConfigs.add(i)
+      yield i
+  if not isBuildx:
+    buildx()
+
+proc request(self: DockerImage,
+             httpMethod: HttpMethod,
+             path: string,
+             accept: string): (string, Response) =
+  for config in self.getConfigs():
+    let uri = self.uri(scheme = config.scheme, path = path)
+    var msg = $httpMethod & " " & $uri
+    if uri.scheme == "https":
+      msg &= " " & $config.verifyMode
+      if config.certPath != "":
+        msg &= "@" & config.certPath
+    trace("docker: " & msg)
+    try:
+      result = (msg, authSafeRequest(
+        uri,
+        httpMethod,
+        headers    = newHttpHeaders(
+          @[("Accept", accept)],
+        ).update(config.auth),
+        pinnedCert = config.pinnedCert,
+        verifyMode = config.verifyMode,
+        timeout    = TIMEOUT,
+        retries    = 2,
+        only2xx    = true,
+      ))
+      configByRegistry[self.registry] = config
+      return
+    except:
+      discard
+  quit(1) # TODO obviously remove but useful for testing
+  raise newException(ValueError, "could not find working registry configuration for " & $self)
+
+proc manifestHead*(image: DockerImage): DockerDigestedJson =
+  let
+    (msg, response) = image.request(
+      httpMethod = HttpHead,
+      path       = "/manifests/" & image.imageRef,
+      accept     = (
+        "application/vnd.docker.distribution.manifest.v2+json, " &
+        "application/vnd.docker.distribution.manifest.list.v2+json, " &
+        "application/vnd.oci.image.manifest.v1+json, " &
+        "application/vnd.oci.image.index.v1+json, " &
+        "*/*"
+      ),
+    )
+    contentType = response.headers["Content-Type"]
+    digest      = response.headers["Docker-Content-Digest"]
+  if contentType notin CONTENT_TYPE_MAPPING:
+    # TODO do heuristics on response payload as there are bound to be new mime types
+    raise newException(
+      ValueError,
+      "docker: " & msg & " returned unsupported registry content type: " & contentType
+    )
+  let kind = CONTENT_TYPE_MAPPING[contentType]
+  return newDockerDigestedJson("{}", digest, contentType, kind)
+
+proc manifestGet*(image: DockerImage, accept: string): DockerDigestedJson =
+  let
+    kind          = CONTENT_TYPE_MAPPING[accept]
+    (_, response) = image.request(
+      httpMethod = HttpGet,
+      path       = "/manifests/" & image.imageRef,
+      accept     = accept,
+    )
+  return newDockerDigestedJson(response.body(), image.imageRef, accept, kind)
+
+proc layerGet*(image: DockerImage, accept: string): DockerDigestedJson =
+  let
+    kind          = CONTENT_TYPE_MAPPING[accept]
+    (_, response) = image.request(
+      httpMethod = HttpGet,
+      path       = "/blobs/" & image.imageRef,
+      accept     = accept,
+    )
+  return newDockerDigestedJson(response.body(), image.imageRef, accept, kind)

--- a/src/ip.nim
+++ b/src/ip.nim
@@ -1,0 +1,75 @@
+##
+## Copyright (c) 2024, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## utils for working with ip addresses,
+## specifically parse and compare ip ranges from cidr notation
+##
+## as nim does not support uint128 each ip address is broken down
+## into a 2-tuple of (uint64, uint64) which then allows
+## to compare whether its within a range of other ip tuples
+## by using normal nim tuple operators
+## which means all this module needs to implement is:
+## * ipaddress to int-tuple conversion
+## * cidr to ip range (tuple of ip-tuples)
+
+import std/[algorithm, bitops, enumerate, net, strutils]
+import "."/[util]
+
+type
+  IpInt   = (uint64, uint64)
+  IpRange = (IpInt, IpInt)
+
+proc toInt(self: openArray[uint8]): uint64 =
+  result = 0
+  for i, n in enumerate(self.reversed()):
+    result = bitor(result, rotateLeftBits(uint64(n), 8 * i))
+
+proc toInt(self: IpAddress): IpInt =
+  if self.family == IPv6:
+    result = (self.address_v6[0..7].toInt(), self.address_v6[8..15].toInt())
+  else:
+    result = (0, self.address_v4.toInt())
+
+proc ipRange*(self: IpAddress, bits: int): IpRange =
+  if bits < 0:
+    raise newException(ValueError, "invalid IP range with negative bit range " & $bits)
+  if bits == 0:
+    return ((0, 0), (high(uint64), high(uint64)))
+  let
+    diff = (if self.family == IPv6: 128 else: 32) - bits
+    ip   = self.toInt()
+    a, b = ip
+    ma   = if diff >  64: toMask[uint64](0 .. diff - 64 - 1) else: 0
+    mb   = if diff <= 64: toMask[uint64](0 .. diff      - 1) else: high(uint64)
+  result = (
+    (a[0].clearMasked(ma), b[1].clearMasked(mb)),
+    (a[0].setMasked(ma),   b[1].setMasked(mb)),
+  )
+  # echo($self)
+  # echo("bits: ", bits, " diff: ", diff)
+  # echo("mask: ", ma.toHex(), " ", mb.toHex())
+  # echo("low:  ", result[0][0].toHex(), " ", result[0][1].toHex())
+  # echo("high: ", result[1][0].toHex(), " ", result[1][1].toHex())
+
+proc parseIpCidr*(self: string): tuple[ip: IpAddress, range: IpRange] =
+  let (maybeIp, suffix) = self.splitBy("/")
+  if suffix == "":
+    raise newException(ValueError, "Invalid IP CIDR " & self)
+  let
+    ip   = parseIpAddress(maybeIp)
+    bits = parseInt(suffix)
+  return (ip, ip.ipRange(bits))
+
+proc parseIpCidrRange*(self: string): IpRange =
+  let (_, range) = self.parseIpCidr()
+  return range
+
+proc contains*(ipRange: IpRange, self: IpAddress): bool =
+  let
+    n           = self.toInt()
+    (low, high) = ipRange
+  return n >= low and n <= high

--- a/src/util.nim
+++ b/src/util.nim
@@ -8,7 +8,7 @@
 ## This is for any common code for system stuff, such as executing
 ## code.
 
-import std/[tempfiles, posix, monotimes, parseutils, exitprocs]
+import std/[httpcore, tempfiles, posix, monotimes, parseutils, exitprocs]
 import pkg/[nimutils/managedtmp]
 import "."/[config, subscan, fd_cache]
 export fd_cache
@@ -613,3 +613,8 @@ proc getOrDefault*[T](self: openArray[T], i: int, default: T): T =
   if len(self) > i:
     return self[i]
   return default
+
+proc update*(self: HttpHeaders, with: HttpHeaders): HttpHeaders =
+  for k, v in with.pairs():
+    self[k] = v
+  return self

--- a/tests/functional/entrypoint.sh
+++ b/tests/functional/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+FILEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [ -z "${SSH_AUTH_SOCK:-}" ] && [ -n "${SSH_KEY}" ]; then
     eval "$(ssh-agent)"
     ssh-add <(echo "$SSH_KEY")
@@ -44,13 +46,13 @@ name=insecure_builder
 if ! docker buildx inspect $name &> /dev/null; then
     docker buildx create \
         --use \
-        --config=<(cat ./data/templates/docker/buildkitd.toml | envsubst | tee /dev/stderr) \
+        --config=<(cat $FILEDIR/data/templates/docker/buildkitd.toml | envsubst | tee /dev/stderr) \
         --name $name \
         node-amd64 \
         > /dev/null
     docker buildx create \
         --append \
-        --config=<(cat ./data/templates/docker/buildkitd.toml | envsubst) \
+        --config=<(cat $FILEDIR/data/templates/docker/buildkitd.toml | envsubst) \
         --name $name \
         node-arm64 \
         > /dev/null

--- a/tests/unit/test_docker_ids.nim
+++ b/tests/unit/test_docker_ids.nim
@@ -1,0 +1,35 @@
+import std/uri
+import ../../src/docker/ids
+
+proc main() =
+  doAssert parseImage("foo") == ("foo", "latest", "")
+  doAssert parseImage("foo/bar") == ("foo/bar", "latest", "")
+  doAssert parseImage("foo:tag") == ("foo", "tag", "")
+  doAssert parseImage("foo/bar:tag") == ("foo/bar", "tag", "")
+  doAssert parseImage("foo@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("foo", "latest", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
+  doAssert parseImage("foo/bar@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("foo/bar", "latest", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
+  doAssert parseImage("foo:tag@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("foo", "tag", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
+  doAssert parseImage("foo/bar:tag@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("foo/bar", "tag", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
+  doAssert parseImage("foo.com/test") == ("foo.com/test", "latest", "")
+  doAssert parseImage("foo.com/test:tag") == ("foo.com/test", "tag", "")
+  doAssert parseImage("foo.com:1234/test") == ("foo.com:1234/test", "latest", "")
+  doAssert parseImage("foo.com:1234/test:tag") == ("foo.com:1234/test", "tag", "")
+  doAssert parseImage("127.0.0.1/test:tag") == ("127.0.0.1/test", "tag", "")
+  doAssert parseImage("127.0.0.1:1234/test:tag") == ("127.0.0.1:1234/test", "tag", "")
+  doAssert parseImage("sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("", "", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
+
+  doAssert $(parseImage("foo").uri) == "https://registry-1.docker.io/v2/library/foo"
+  doAssert $(parseImage("foo/bar").uri) == "https://registry-1.docker.io/v2/foo/bar"
+  doAssert $(parseImage("Foo/bar").uri) == "https://Foo/v2/bar"
+  doAssert $(parseImage("foo.com/bar").uri) == "https://foo.com/v2/bar"
+  doAssert $(parseImage("foo:1234/bar").uri) == "https://foo:1234/v2/bar"
+  doAssert $(parseImage("localhost/bar").uri) == "http://localhost/v2/bar"
+  doAssert $(parseImage("localhost:1234/bar").uri) == "http://localhost:1234/v2/bar"
+  doAssert $(parseImage("127.0.0.1/bar").uri) == "http://127.0.0.1/v2/bar"
+  doAssert $(parseImage("127.0.0.1/bar").uri) == "http://127.0.0.1/v2/bar"
+  doAssert $(parseImage("127.0.0.1:1234/bar").uri) == "http://127.0.0.1:1234/v2/bar"
+  doAssert $(parseImage("localhost/bar").uri(scheme="https://")) == "https://localhost/v2/bar"
+
+  doAssert $(parseImage("foo").uri(path = "/manifests/latest")) == "https://registry-1.docker.io/v2/library/foo/manifests/latest"
+
+main()

--- a/tests/unit/test_ip.nim
+++ b/tests/unit/test_ip.nim
@@ -1,0 +1,13 @@
+import std/net
+import ../../src/ip
+
+proc main() =
+  doAssert parseIpAddress("10.10.10.10") notin parseIpCidrRange("10.11.12.13/24")
+  doAssert parseIpAddress("10.10.10.10") notin parseIpCidrRange("10.11.12.13/16")
+  doAssert parseIpAddress("10.10.10.10") in    parseIpCidrRange("10.11.12.13/8")
+  doAssert parseIpAddress("10.10.10.10") in    parseIpCidrRange("1.2.3.4/0")
+
+  doAssert parseIpAddress("2001:db8:0:0:0:ab1:0:0") in    parseIpCidrRange("2001:db8::/48")
+  doAssert parseIpAddress("2001:df8:0:0:0:ab1:0:0") notin parseIpCidrRange("2001:db8::/48")
+
+main()


### PR DESCRIPTION
mini-sdk for interacting with the registry

the sdk bit is primarily:

* mapping image to to an url

* figuring out how to connect to it (insecure, http, etc)
  * this is slightly complicated due to docker daemon, buildx runners having different configs

* getting basic auth tokens from docker config file

* attempting multiple connection configs. for example an insecure registry can mean:

  * TLS connection without validating certs
  * http connection

  as such whenever there are multiple methods, they are all tried until
  a successful registry config is found

  note that each connection config is lazy loaded as loading additional
  configs can be expensive

<!-- Please ensure you have done the following steps: -->

- [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ ] Filled out the template to a useful degree
- [ ] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

## Testing

<!-- What are the steps needed to test this PR? -->
