### PR TITLE
fix: fixing docker plugin run-time collection for non-build cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- `docker` run-time host metadata collection was failing
+  for non-build commands such as `docker push`.
+  ([#399](https://github.com/crashappsec/chalk/pull/399))
+
 ## 0.4.10
 
 **Aug 5, 2024**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `docker` run-time host metadata collection was failing
   for non-build commands such as `docker push`.
   ([#399](https://github.com/crashappsec/chalk/pull/399))
+- `procfs` plugin was throwing an exception while parsing
+  `/proc/net/dev` to populate `_OP_IPV[4/6]_INTERFACES` keys.
+  ([#399](https://github.com/crashappsec/chalk/pull/399))
 
 ## 0.4.10
 

--- a/src/collect.nim
+++ b/src/collect.nim
@@ -108,8 +108,8 @@ proc collectChalkTimeHostInfo*() =
             plugin.isSystem():
           hostInfo[k] = v
     except:
-      warn("When collecting chalk-time host info, plugin implementation " &
-           plugin.name & " threw an exception it didn't handle: " & getCurrentExceptionMsg())
+      error("When collecting chalk-time host info, plugin implementation " &
+            plugin.name & " threw an exception it didn't handle: " & getCurrentExceptionMsg())
       dumpExOnDebug()
 
 proc initCollection*() =
@@ -166,9 +166,9 @@ proc collectRunTimeArtifactInfo*(artifact: ChalkObj) =
           artifact.collectedData[k] = v
       trace(plugin.name & ": Plugin called.")
     except:
-      warn("When collecting run-time artifact data, plugin implementation " &
-           plugin.name & " threw an exception it didn't handle (artifact = " &
-           artifact.name & "): " & getCurrentExceptionMsg())
+      error("When collecting run-time artifact data, plugin implementation " &
+            plugin.name & " threw an exception it didn't handle (artifact = " &
+            artifact.name & "): " & getCurrentExceptionMsg())
       dumpExOnDebug()
 
   let hashOpt = artifact.callGetEndingHash()
@@ -224,9 +224,9 @@ proc collectChalkTimeArtifactInfo*(obj: ChalkObj, override = false) =
           obj.collectedData[k] = v
       trace(plugin.name & ": Plugin called.")
     except:
-      warn("When collecting chalk-time artifact data, plugin implementation " &
-           plugin.name & " threw an exception it didn't handle (artifact = " &
-           obj.name & "): " & getCurrentExceptionMsg())
+      error("When collecting chalk-time artifact data, plugin implementation " &
+            plugin.name & " threw an exception it didn't handle (artifact = " &
+            obj.name & "): " & getCurrentExceptionMsg())
       dumpExOnDebug()
 
 proc collectRunTimeHostInfo*() =
@@ -251,9 +251,9 @@ proc collectRunTimeHostInfo*() =
             plugin.isSystem():
           hostInfo[k] = v
     except:
-      warn("When collecting run-time host info, plugin implementation " &
-           plugin.name & " threw an exception it didn't handle: " &
-           getCurrentExceptionMsg())
+      error("When collecting run-time host info, plugin implementation " &
+            plugin.name & " threw an exception it didn't handle: " &
+            getCurrentExceptionMsg())
       dumpExOnDebug()
 
 

--- a/src/docker/collect.nim
+++ b/src/docker/collect.nim
@@ -233,7 +233,7 @@ proc collectImageFrom(chalk: ChalkObj, contents: JsonNode, name: string, digest 
   chalk.setIfNeeded("_OP_ALL_IMAGE_METADATA", contents.nimJsonToBox())
   chalk.setIfNeeded("DOCKER_PLATFORM", $platform)
 
-proc normalizeDigestsFromManifest(chalk: ChalkObj, manifest: Dockermanifest) =
+proc normalizeDigestsFromManifest(chalk: ChalkObj, manifest: DockerManifest) =
   chalk.imageDigest = manifest.digest.extractDockerHash()
   chalk.setIfNeeded("_IMAGE_DIGEST", chalk.imageDigest)
   if manifest.list != nil:

--- a/src/docker/exe.nim
+++ b/src/docker/exe.nim
@@ -120,10 +120,11 @@ proc getContextName(): string =
   return contextName
 
 proc getBuilderName(ctx: DockerInvocation): string =
-  if not ctx.foundBuildx:
-    return getContextName()
-  if ctx.foundBuilder != "":
-    return ctx.foundBuilder
+  if ctx != nil and ctx.cmd == DockerCmd.build:
+    if not ctx.foundBuildx:
+      return getContextName()
+    if ctx.foundBuilder != "":
+      return ctx.foundBuilder
   return getEnv("BUILDX_BUILDER")
 
 var builderInfo = ""


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

some metadata is missing

## Description

Internally to get buildx builder info, it needs to find out the builder name which was referencing an attribute only accessible for docker build command

To catch plugin errors in the future switching that log to `error` level which automatically fails tests if the plugin fails.


## Testing

```
➜ make tests args="test_docker.py::test_build_and_push --logs"
```
