### PR TITLE
fix: sending _IMAGE_DIGEST for push without buildx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 - `procfs` plugin was throwing an exception while parsing
   `/proc/net/dev` to populate `_OP_IPV[4/6]_INTERFACES` keys.
   ([#399](https://github.com/crashappsec/chalk/pull/399))
+- `_IMAGE_DIGEST` is sent when for `docker push` when
+  buildx is not available. Normally chalk needs to validate
+  type of the manifest in the registry (image or list)
+  which is currently done via `buildx imagetools`.
+  When buildx is missing and the operation was `docker push`
+  the pushed image can only be image manifest as only buildx
+  supports list manifests.
+  ([#401](https://github.com/crashappsec/chalk/pull/401))
 
 ## 0.4.10
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

`_IMAGE_DIGEST` is missing for `docker push` without buildx

## Description

this will be handled better when registry SDK is merged/fully used everywhere however for now this specifically addresses `_IMAGE_DIGEST` field when buildx is missing

## Testing

```
➜ make tests args="test_docker.py::test_push_without_buildx --logs --pdb"
```
