### PR TITLE
fix: _REPO_DIGESTS misreported for buildx builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   the pushed image can only be image manifest as only buildx
   supports list manifests.
   ([#401](https://github.com/crashappsec/chalk/pull/401))
+- `_REPO_DIGESTS` was reported even when image digest was
+  not known during buildx-enabled docker builds.
+  ([#402](https://github.com/crashappsec/chalk/pull/402))
 
 ## 0.4.10
 

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -297,7 +297,13 @@ proc collectAfterBuild(ctx: DockerInvocation, chalksByPlatform: TableRef[DockerP
     trace("docker: built image is loaded locally")
     # in some cases even with --push, repo digests show up as blank in docker inspect
     # but we might know the digest from the --metadata-file so we normalize to that
-    let digest = ctx.metadataFile{"containerimage.digest"}.getStr()
+    let
+      config = ctx.metadataFile{"containerimage.config.digest"}.getStr()
+      maybe  = ctx.metadataFile{"containerimage.digest"}.getStr()
+      # if the digest matches config digest we know this is config digest (image id)
+      # and not image digest most likely because there was no --push
+      # and therefore digest is unknown at this time
+      digest = if config == maybe: "" else: maybe
     # image was loaded to docker cache
     for platform, chalk in chalksByPlatform:
       chalk.collectImage(ctx.iidFile, digest = digest)

--- a/src/docker/inspect.nim
+++ b/src/docker/inspect.nim
@@ -53,6 +53,8 @@ proc inspectJson(name: string, what: string): JsonNode =
       stdout & " " & stderr,
     )
   let json = parseJson(stdout)
+  when defined(debug):
+    trace(json.pretty())
   if len(json) != 1:
     raise newException(
       ValueError,


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

`_REPO_DIGESTS` does not match between `docker build && docker push`

## Description

metadata file misreports image config digest as image digest which is not valid but oh well. As chalk was using that value to normalize digest value for `_REPO_DIGESTS` it was then misreporting image id as the digest.

## Testing

```
➜ make tests args="test_docker.py::test_build_and_push --logs --pdb"
```
