### PR TITLE
fix: docker push generated wrong METADATA_* keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - `_REPO_DIGESTS` was reported even when image digest was
   not known during buildx-enabled docker builds.
   ([#402](https://github.com/crashappsec/chalk/pull/402))
+- `METADATA_ID` and `METADATA_HASH` were incorrectly
+  computed for all `docker push` operations.
+  ([#403](https://github.com/crashappsec/chalk/pull/403))
 
 ## 0.4.10
 

--- a/src/docker/push.nim
+++ b/src/docker/push.nim
@@ -19,6 +19,10 @@ proc dockerPush*(ctx: DockerInvocation): int =
     error("docker: " & ctx.foundImage & " is not found. pushing without chalk")
     return ctx.runMungedDockerInvocation()
 
+  # force DOCKER_PLATFORM to be included in chalk normalization
+  # which is required to compute unique METADATA_* keys
+  forceChalkKeys(["DOCKER_PLATFORM"])
+
   let chalk = chalkOpt.get()
   if not chalk.isChalked():
     warn("docker: " & chalk.name & " is not chalked. reporting will be limited")

--- a/src/plugins/system.nim
+++ b/src/plugins/system.nim
@@ -77,7 +77,12 @@ proc sysGetChalkTimeArtifactInfo*(self: Plugin, obj: ChalkObj):
                                                         ChalkDict {.cdecl.} =
   result                           = ChalkDict()
   result["MAGIC"]                  = pack(magicUTF8)
-  result["TIMESTAMP_WHEN_CHALKED"] = pack(unixTimeInMS())
+  if ResourceImage in obj.resourceType:
+    if "TIMESTAMP_WHEN_CHALKED" notin obj.collectedData:
+      # image is immutable so cannot overwrite timestamp from original build
+      result["TIMESTAMP_WHEN_CHALKED"] = pack(unixTimeInMS())
+  else:
+    result["TIMESTAMP_WHEN_CHALKED"] = pack(unixTimeInMS())
 
   if isSubscribedKey("PRE_CHALK_HASH") and obj.fsRef != "":
     withFilesTream(obj.fsRef, mode = fmRead, strict = true):

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -918,6 +918,7 @@ def test_build_and_push(
         CHALK_ID=ANY,
         # primary key needed to associate build+push
         METADATA_ID=ANY,
+        METADATA_HASH=ANY,
         _CURRENT_HASH=image_id,
         _IMAGE_ID=image_id,
         _IMAGE_DIGEST=image_digest if push else MISSING,
@@ -932,7 +933,8 @@ def test_build_and_push(
 
     assert push_result.mark.has(
         CHALK_ID=build_result.mark["CHALK_ID"],
-        METADATA_ID=ANY,  # build_result.mark["METADATA_ID"],
+        METADATA_ID=build_result.mark["METADATA_ID"],
+        METADATA_HASH=build_result.mark["METADATA_HASH"],
         _CURRENT_HASH=image_id,
         _IMAGE_ID=image_id,
         _IMAGE_DIGEST=image_digest,
@@ -954,7 +956,7 @@ def test_push_without_buildx(
     tag_base = f"{REGISTRY}/{test_file}_{random_hex}"
     tag = f"{tag_base}:latest"
 
-    image_id, _ = chalk.docker_build(
+    image_id, build = chalk.docker_build(
         dockerfile=DOCKERFILES / test_file / "Dockerfile",
         buildkit=False,
         tag=tag,
@@ -980,9 +982,10 @@ def test_push_without_buildx(
         ":", maxsplit=1
     )[-1]
     assert push.mark.has(
-        CHALK_ID=ANY,
+        CHALK_ID=build.mark["CHALK_ID"],
         # primary key needed to associate build+push
-        METADATA_ID=ANY,
+        METADATA_ID=build.mark["METADATA_ID"],
+        METADATA_HASH=build.mark["METADATA_HASH"],
         _CURRENT_HASH=image_id,
         _IMAGE_ID=image_id,
         _IMAGE_DIGEST=image_digest,


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

wrong fields were sent in the report

## Description

these 2 fields were different:

* `TIMESTAMP_WHEN_CHALKED` was being overwritten hence changing the hash
* `DOCKER_PLATFORM` was not forced during `docker push` as in `docker build` which meant that it was ignored in computing the hash


## Testing

```
➜ make tests args="test_docker.py::test_build_and_push --logs --pdb"
```
