### PR TITLE
test: fixing flaky test

### DIFF
--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -454,38 +454,38 @@ class Chalk:
                 sbom=sbom,
             )
 
-        image_hash, result = Docker.with_image_id(
-            self.run(
-                # TODO remove log level but there are error bugs due to --debug
-                # which fail the command validation
-                log_level=log_level,
-                debug=True,
-                virtual=virtual,
-                config=config,
-                params=Docker.build_cmd(
-                    tag=tag,
-                    tags=tags,
-                    context=context,
-                    dockerfile=dockerfile,
-                    content=content,
-                    args=args,
-                    push=push,
-                    platforms=platforms,
-                    buildx=buildx,
-                    secrets=secrets,
-                    buildkit=buildkit,
-                    provenance=provenance,
-                    sbom=sbom,
-                ),
-                expected_success=expected_success,
-                ignore_errors=not expecting_report,
-                cwd=cwd,
-                env={
-                    **Docker.build_env(buildkit=buildkit),
-                    **(env or {}),
-                },
+        with Docker.build_cmd(
+            tag=tag,
+            tags=tags,
+            context=context,
+            dockerfile=dockerfile,
+            content=content,
+            args=args,
+            push=push,
+            platforms=platforms,
+            buildx=buildx,
+            secrets=secrets,
+            buildkit=buildkit,
+            provenance=provenance,
+            sbom=sbom,
+        ) as (params, stdin):
+            image_hash, result = Docker.with_image_id(
+                self.run(
+                    log_level=log_level,
+                    debug=True,
+                    virtual=virtual,
+                    config=config,
+                    params=params,
+                    stdin=stdin,
+                    expected_success=expected_success,
+                    ignore_errors=not expecting_report,
+                    cwd=cwd,
+                    env={
+                        **Docker.build_env(buildkit=buildkit),
+                        **(env or {}),
+                    },
+                )
             )
-        )
         if expecting_report and expected_success and image_hash:
             if platforms:
                 assert len(result.marks) == len(platforms)

--- a/tests/functional/utils/os.py
+++ b/tests/functional/utils/os.py
@@ -57,11 +57,7 @@ class Program:
                 self.logger.error(f"{self.bin} failed")
 
     def __eq__(self, other: "Program") -> bool:
-        return (
-            self.exit_code == other.exit_code
-            and self.stdout == other.stdout
-            and self.stderr == other.stderr
-        )
+        return self.exit_code == other.exit_code and self.stdout == other.stdout
 
     def __bool__(self) -> bool:
         """
@@ -80,6 +76,7 @@ class Program:
             exit_code=self.exit_code,
             expected_status_code=self.expected_exit_code,
             duration=self.duration,
+            stdin=self.input,
             stdout=self.text,
             stderr=self.logs,
             cwd=self.cwd,
@@ -109,6 +106,10 @@ class Program:
     @property
     def logs(self) -> str:
         return self._strip_ansi(self.stderr.decode().strip())
+
+    @property
+    def input(self) -> str:
+        return (self.stdin or b"").decode()
 
     @property
     def error(self) -> CalledProcessError:


### PR DESCRIPTION
looks like in some cases tmp file was garbage collected earlier than the process exit which resulted in :

```
ERROR: failed to solve: failed to read dockerfile: open tmp_76z0fet: no such file or directory
```

passing content as stdin should make that irrelevant however if well need to do any contextual cleanup as part of cmd handling also moved it as a context manager which will allow us to cleanup anything necessary after the full command is finished executing

also in some cases stderr did not match between the commands as it included the failure timestamp so no longer comparing it as part of the program equality logic

example failures:

https://github.com/crashappsec/chalk/actions/runs/10356433406/job/28667491174?pr=403
https://github.com/crashappsec/chalk/actions/runs/10356433406/job/28667154589?pr=403
