### PR TITLE
feat: retrying all aws requests even on connect timeout

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#31823fae883f663ae542e7d8b46348d8b45e2945"
+requires "https://github.com/crashappsec/con4m#5d58901a470c38ab0a242f0806d1ad08436a2fc7"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally

--- a/src/plugins/awsEcs.nim
+++ b/src/plugins/awsEcs.nim
@@ -27,7 +27,7 @@ proc requestECSMetadata(path: string): Option[Box] =
   var body = ""
   try:
     var
-      resp   = safeRequest(url)
+      resp   = safeRequest(url, retries=2, connectRetries=2)
     if resp.code != Http200:
       error("ecs: " & url & " returned " & resp.status)
       return none(Box)

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -26,10 +26,12 @@ const
 proc hitProviderEndpoint(path: string, hdrs: HttpHeaders): Option[string] =
   try:
     let
-      response = safeRequest(url        = path,
-                             httpMethod = HttpGet,
-                             timeout    = 1000, # 1 of a second
-                             headers    = hdrs)
+      response = safeRequest(url            = path,
+                             httpMethod     = HttpGet,
+                             timeout        = 1000, # 1 of a second
+                             connectRetries = 2,
+                             retries        = 2,
+                             headers        = hdrs)
       body     = response.body().strip()
 
     if not response.code.is2xx():
@@ -184,10 +186,12 @@ proc getAwsToken(): Option[string] =
   try:
     let
       hdrs     = newHttpHeaders([("X-aws-ec2-metadata-token-ttl-seconds", "10")])
-      response = safeRequest(url        = url,
-                             httpMethod = HttpPut,
-                             timeout    = 1000, # 1 of a second
-                             headers    = hdrs)
+      response = safeRequest(url            = url,
+                             httpMethod     = HttpPut,
+                             timeout        = 1000, # 1 of a second
+                             connectRetries = 2,
+                             retries        = 2,
+                             headers        = hdrs)
       body     = response.body().strip()
 
     if not response.code.is2xx():


### PR DESCRIPTION
by the time we attempt any request to AWS, we already know we are running in instance which should respond successfully so multiple retries should help with unstable network conditions which we see in some reports
