### PR TITLE
fix: conffile plugin was sending empty keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   of other attestation providers.
   ([#411](https://github.com/crashappsec/chalk/pull/411))
 
+### Fixes
+
+- `conffile` plugin was sending some empty keys vs skipping
+  them during reporting. Now it has matching behavior to
+  other plugins which ignores empty keys.
+  ([#412](https://github.com/crashappsec/chalk/pull/412))
+
 ## 0.4.11
 
 **Aug 13, 2024**

--- a/src/plugins/conffile.nim
+++ b/src/plugins/conffile.nim
@@ -17,14 +17,16 @@ proc scanForWork(kt: auto, opt: Option[ChalkObj], args: seq[Box]): ChalkDict =
     if opt.isNone() and k in hostInfo:                continue
     if opt.isSome() and k in opt.get().collectedData: continue
     if attrGet[int](v & ".kind") != int(kt): continue
-    if k notin subscribedKeys: continue
+    if not isSubscribedKey(k):
+      continue
     let valueOpt = attrGetOpt[Box](v & ".value")
     let callbackOpt = attrGetOpt[CallbackObj](v & ".callback")
     if valueOpt.isSome():
-      result[k] = valueOpt.get()
+      result.setIfNeeded(k, valueOpt.get())
     elif callbackOpt.isSome():
       let cbOpt = runCallback(callbackOpt.get(), args)
-      if cbOpt.isSome(): result[k] = cbOpt.get()
+      if cbOpt.isSome():
+        result.setIfNeeded(k, cbOpt.get())
 
 proc confGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
   return scanForWork(KtChalkableHost, none(ChalkObj),


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

empty keys were sent from conffile plugin

## Description

this did not match other plugins


