### PR TITLE
fix: looking up ec2 instance id from board_asset_tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   them during reporting. Now it has matching behavior to
   other plugins which ignores empty keys.
   ([#412](https://github.com/crashappsec/chalk/pull/412))
+- AWS instance is determined from board_asset_tag file when
+  present. This allows to report `_AWS_INSTANCE_ID` even
+  when cloud metadata endpoint is not reachable.
+  ([#413](https://github.com/crashappsec/chalk/pull/413))
 
 ## 0.4.11
 

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2569,6 +2569,14 @@ end users.
     hidden:  true
     doc:     "Path where to check product uuid for cloud nodes"
   }
+
+  field sys_board_asset_tag_path {
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+    type:    string
+    default: "/sys/devices/virtual/dmi/id/board_asset_tag"
+    hidden:  true
+    doc:     "Path where to check the system VM tag (instance ID for AWS)"
+  }
 }
 
 singleton cloud_provider {
@@ -2580,6 +2588,13 @@ singleton cloud_provider {
 Configuration information for the different Cloud Provider
 """
   allow cloud_instance_hw_identifiers { }
+
+  field metadata_ip {
+    type:    string
+    default: "169.254.169.254"
+    hidden:  true
+    doc:     "Default cloud metadata IP"
+  }
 }
 
 root {

--- a/tests/functional/conf.py
+++ b/tests/functional/conf.py
@@ -2,9 +2,10 @@
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
-import os
 import shutil
 from pathlib import Path
+
+import os
 
 
 DOCKER_SSH_REPO = (

--- a/tests/functional/data/configs/imds.c4m
+++ b/tests/functional/data/configs/imds.c4m
@@ -1,3 +1,9 @@
 if env_exists("VENDOR") {
   cloud_provider.cloud_instance_hw_identifiers.sys_vendor_path: env("VENDOR")
 }
+if env_exists("INSTANCE") {
+  cloud_provider.cloud_instance_hw_identifiers.sys_board_asset_tag_path: env("INSTANCE")
+}
+if env_exists("METADATA_IP") {
+  cloud_provider.metadata_ip: env("METADATA_IP")
+}

--- a/tests/functional/imds/app.py
+++ b/tests/functional/imds/app.py
@@ -7,6 +7,7 @@ import json
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 
+
 PREFIX = "/latest"
 TOKEN = "token"
 TAGS = {

--- a/tests/functional/utils/tmp.py
+++ b/tests/functional/utils/tmp.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2024, Crash Override, Inc.
+#
+# This file is part of Chalk
+# (see https://crashoverride.com/docs/chalk)
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Optional
+
+import os
+
+
+@contextmanager
+def make_tmp_file(path: Optional[str] = None, mode="w+b", delete=True):
+    # tempfile does not allow to create file with specific path
+    # as it always randomizes the name
+    if path:
+        path = Path(path).resolve()
+        os.makedirs(path.parent, exist_ok=True)
+        try:
+            with path.open(mode) as f:
+                yield path
+        finally:
+            if delete:
+                path.unlink(missing_ok=True)
+    else:
+        with NamedTemporaryFile(mode=mode, delete=delete) as f:
+            yield Path(f.name)


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Description

sometimes cloud metadata endpoint is not reachable which doesnt allow Chalk to query all the relevant metadata such as its instance ID. Chalk now attempts to get the instance id from the sys board asset tag file (if present) before looking up rest of the cloud metadata.

## Testing

```
➜ make tests args="test_plugins.py::test_aws_no_imds --logs"
```
