### PR TITLE
build: bumping nimutils/con4m for aws region-specific endpoint fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   present. This allows to report `_AWS_INSTANCE_ID` even
   when cloud metadata endpoint is not reachable.
   ([#413](https://github.com/crashappsec/chalk/pull/413))
+- Reporting AWS Lambda functions ARN for non-us-east-1
+  regions. Previously global STS AWS endpoint was used
+  which cannot fetch STS get-caller-identity for other
+  AWS regions.
+  ([#414](https://github.com/crashappsec/chalk/pull/414))
 
 ## 0.4.11
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#5d58901a470c38ab0a242f0806d1ad08436a2fc7"
+requires "https://github.com/crashappsec/con4m#ee26bd28d99cd0aa2dc3c9b2cd83bb0d145ec167"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

AWS lambda ARN was not reported for non-us-east-1 regions

## Description

accessing sts via global endpoint which is equivalent to us-east-1 doesnt allow to access region-specific tokens hence the need to use region-specific endpoints

## Testing

test lambda in another region
