### PR TITLE
feat: adding _OP_EXIT_CODE key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## On the `main` branch
 
+### New Features
+
+- `_OP_EXIT_CODE` key which reports external commands
+  exit code such as for `chalk docker build`.
+  ([#417](https://github.com/crashappsec/chalk/pull/417))
+
 ## 0.4.12
 
 **Aug 29, 2024**

--- a/src/commands/cmd_docker.nim
+++ b/src/commands/cmd_docker.nim
@@ -57,4 +57,4 @@ proc runCmdDocker*(args: seq[string]) =
     # exit with appropriate exitCode if docker command passed
     error("docker post-command: " & getCurrentExceptionMsg())
   finally:
-    quitChalk(exitCode)
+    quitChalk()

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -4077,6 +4077,21 @@ generate reports.
 """
 }
 
+keyspec _OP_EXIT_CODE {
+  kind:     RunTimeHost
+  type:     int
+  standard: true
+  system:   true
+  since:    "0.4.13"
+  shortdoc: "Exit code of chalk operation"
+  doc:      """
+For operations such as docker builds, chalk invokes an external command
+which chalk proxies through. This key reports the external command
+exit code. This is useful for example for reports without any
+chalkmarks due to an external command failure.
+"""
+}
+
 keyspec _TIMESTAMP {
     kind:             RunTimeHost
     type:             int

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -62,7 +62,8 @@ plugin metsys {
     pre_chalk_keys:  ["METADATA_HASH", "ERR_INFO", "METADATA_ID",
                       "SIGNING", "SIGNATURE", "INJECTOR_PUBLIC_KEY"]
     post_chalk_keys: ["_SIGNATURES"]
-    post_run_keys:   ["_OP_ERRORS", "_CHALK_EXTERNAL_ACTION_AUDIT", "_CHALK_RUN_TIME"]
+    post_run_keys:   ["_OP_ERRORS", "_CHALK_EXTERNAL_ACTION_AUDIT",
+                      "_CHALK_RUN_TIME", "_OP_EXIT_CODE"]
     ~priority:       high()
     doc: """
 Like the `system` module, this module is non-overridable keys added by

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -48,6 +48,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key._ARGV.use                                      = true
   ~key._ENV.use                                       = true
   ~key._OPERATION.use                                 = true
+  ~key._OP_EXIT_CODE.use                              = true
   ~key._TIMESTAMP.use                                 = true
   ~key._DATE.use                                      = false # Go with _DATETIME
   ~key._TIME.use                                      = false

--- a/src/docker/base.nim
+++ b/src/docker/base.nim
@@ -26,6 +26,7 @@ proc dockerFailsafe*(ctx: DockerInvocation) {.noreturn.} =
     exitCode = runCmdNoOutputCapture(docker,
                                      ctx.originalArgs,
                                      ctx.originalStdIn)
+    setExitCode(exitCode)
     doReporting("fail")
     showConfigValues()
   finally:

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -443,7 +443,7 @@ proc dockerBuild*(ctx: DockerInvocation): int =
   ctx.setIidFile()
   ctx.setMetadataFile()
 
-  result = ctx.runMungedDockerInvocation()
+  result = setExitCode(ctx.runMungedDockerInvocation())
   if result != 0:
     raise newException(
       ValueError,

--- a/src/docker/push.nim
+++ b/src/docker/push.nim
@@ -5,7 +5,7 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
-import ".."/[config, collect, plugin_api]
+import ".."/[config, collect, plugin_api, util]
 import "."/[base, collect, scan]
 
 proc dockerPush*(ctx: DockerInvocation): int =
@@ -37,7 +37,7 @@ proc dockerPush*(ctx: DockerInvocation): int =
   chalk.addToAllChalks()
   chalk.collectChalkTimeArtifactInfo()
 
-  result = ctx.runMungedDockerInvocation()
+  result = setExitCode(ctx.runMungedDockerInvocation())
 
   chalk.collectImage() # refetch repo tags/digests
   chalk.collectRunTimeArtifactInfo()

--- a/src/plugins/system.nim
+++ b/src/plugins/system.nim
@@ -313,6 +313,8 @@ proc metsysGetRunTimeHostInfo(self: Plugin, objs: seq[ChalkObj]):
                               ChalkDict {.cdecl.} =
   result = ChalkDict()
 
+  result.setIfNeeded("_OP_EXIT_CODE", getExitCode())
+
   if len(systemErrors)  != 0:
     result.setIfNeeded("_OP_ERRORS", systemErrors)
 

--- a/src/util.nim
+++ b/src/util.nim
@@ -305,8 +305,12 @@ var exitCode = 0
 proc quitChalk*(errCode = exitCode) {.noreturn.} =
   quit(errcode)
 
-proc setExitCode*(code: int) =
+proc getExitCode*(): int =
+  return exitCode
+
+proc setExitCode*(code: int): int {.discardable.} =
   exitCode = code
+  return code
 
 proc replaceFileContents*(chalk: ChalkObj, contents: string): bool =
   if chalk.fsRef == "":

--- a/tests/functional/data/configs/docker_wrap.c4m
+++ b/tests/functional/data/configs/docker_wrap.c4m
@@ -1,9 +1,3 @@
 docker.wrap_entrypoint = true
 docker.download_arch_binary_urls = [env("CHALK_SERVER") + "/dummy/chalk-%version-%os-%architecture"]
 docker.arch_binary_locations_path = env("CHALK_TMP")
-report_template terminal_insert {
-  key._IMAGE_ENTRYPOINT.use = true
-  key._IMAGE_CMD.use = true
-  key._IMAGE_SBOM.use = true
-  key._IMAGE_PROVENANCE.use = true
-}

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -122,6 +122,7 @@ def test_build(
     )
     assert image_id
     assert build.mark.has(_IMAGE_ENTRYPOINT=["/chalk", "exec", "--"])
+    assert build.report.has(_OP_EXIT_CODE=build.exit_code)
 
 
 @pytest.mark.parametrize("buildkit", [True, False])
@@ -754,12 +755,14 @@ def test_virtual_invalid(
 ):
     tag = f"{test_file}_{random_hex}"
     dockerfile = DOCKERFILES / test_file / "Dockerfile"
-    chalk.docker_build(
+    _, result = chalk.docker_build(
         dockerfile=dockerfile,
         tag=tag,
         virtual=True,
         expected_success=False,
     )
+
+    assert result.report.has(_OP_EXIT_CODE=result.exit_code)
 
     # invalid dockerfile should not create any chalk output
     assert not (
@@ -814,11 +817,13 @@ def test_nonvirtual_valid(chalk: Chalk, test_file: str, random_hex: str):
 @pytest.mark.parametrize("test_file", ["invalid/sample_1", "invalid/sample_2"])
 def test_nonvirtual_invalid(chalk: Chalk, test_file: str, random_hex: str):
     tag = f"{test_file}_{random_hex}"
-    chalk.docker_build(
+    _, result = chalk.docker_build(
         dockerfile=DOCKERFILES / test_file / "Dockerfile",
         tag=tag,
         expected_success=False,
     )
+
+    assert result.report.has(_OP_EXIT_CODE=result.exit_code)
 
 
 def test_docker_heartbeat(chalk_copy: Chalk, random_hex: str):

--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -1,8 +1,13 @@
 subscribe("report", "json_console_out")
+subscribe("fail",   "json_console_out")
 custom_report.github_group_chalk_time.enabled: false
 custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false
 custom_report.terminal_other_op.use_when: ["extract", "delete", "exec", "env", "heartbeat"]
+
+report_template insertion_default {
+  key._OP_EXIT_CODE.use = true
+}
 
 if not env_exists("CHALK_USAGE_URL") {
   crashoverride_usage_reporting_url: "https://chalk-test.crashoverride.run/v0.1/usage"


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

its hard to say the reason why docker build report doesnt have any chalkmarks without any specific error indicators

## Description

this is especially useful for when chalk invoked external commands such as for docker build chalk reports final exit code which can be insightful whenever external command fails

## Testing

run tests for `test_docker.py` file
