### PR TITLE
bug: chalk docker autocomplete

### DIFF
--- a/src/autocomplete/default.bash
+++ b/src/autocomplete/default.bash
@@ -27,6 +27,10 @@ function _chalk_delete_completions {
     fi
 }
 
+function _chalk_docker_completions {
+    _command_offset 1
+}
+
 function _chalk_load_completions {
     if [ ${_CHALK_CUR_WORD::1} = "-" ] ; then
         COMPREPLY=($(compgen -W "--color --no-color --help --log-level --config-file --enable-report --disable-report --report-cache-file --time --no-time --use-embedded-config --no-use-embedded-config --use-external-config --no-use-external-config --show-config --no-show-config --use-report-cache --no-use-report-cache --debug --no-debug --replace --no-replace --update-arch-binaries --no-update-arch-binaries --params --no-params --validation --no-validation --validation-warning --no-validation-warning" -- ${_CHALK_CUR_WORD}))

--- a/src/autocomplete/mac.bash
+++ b/src/autocomplete/mac.bash
@@ -20,6 +20,10 @@ function _chalk_delete_completions {
     fi
 }
 
+function _chalk_docker_completions {
+    _command_offset 1
+}
+
 function _chalk_load_completions {
     if [ ${_CHALK_CUR_WORD::1} = "-" ] ; then
         COMPREPLY=($(compgen -W "--color --no-color --help --log-level --config-file --enable-report --disable-report --report-cache-file --time --no-time --use-embedded-config --no-use-embedded-config --use-external-config --no-use-external-config --show-config --no-show-config --use-report-cache --no-use-report-cache --debug --no-debug --replace --no-replace --update-arch-binaries --no-update-arch-binaries --params --no-params --validation --no-validation --validation-warning --no-validation-warning" -- ${_CHALK_CUR_WORD}))


### PR DESCRIPTION
Adds the _chalk_docker_autocompletions function to autocomplete docker commands

<!-- Please ensure you have done the following steps: -->

- [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ ] Filled out the template to a useful degree
- [ ] Updated `CHANGELOG.md` if necessary

## Issue

#281 
<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

Small one line change to add autocompletions for docker commands 

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

## Testing

<!-- What are the steps needed to test this PR? -->

source autocompletion file, and run `chalk docker <tab><tab>` and `chalk docker rmi <tab><tab>` to confirm whether tab completion is working for docker and docker subcommands