### PR TITLE
feat: adding pingttl util

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,11 @@ jobs:
         run: |
           docker buildx bake chalk server tests --load
 
+      - name: Test pingttl
+        if: inputs.chalk_url == ''
+        run: |
+          make src/pingttl
+
       - name: Compile Chalk
         if: inputs.chalk_url == ''
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
 
   ([#422](https://github.com/crashappsec/chalk/pull/422))
 
+- `_NETWORK_PARTIAL_TRACEROUTE_IPS` - collect local network
+  subnet IPs even when running inside docker network-namespaced
+  (not using `--network=host`) container
+  ([#425](https://github.com/crashappsec/chalk/pull/425))
+
 ## 0.4.12
 
 **Aug 29, 2024**

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM nim as deps
 RUN apt-get update -y && \
     apt-get install -y \
         curl \
+        make \
         musl-tools \
         && \
     apt-get clean -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update -y && \
         curl \
         make \
         musl-tools \
+        strace \
         && \
     apt-get clean -y
 

--- a/Makefile
+++ b/Makefile
@@ -152,10 +152,11 @@ tests_parallel: tests
 tests_bash:
 	docker compose run --rm --no-deps tests bash
 
+.PHONY: src/pingttl
 src/pingttl: src/pingttl.nim
 	$(DOCKER) nim c -r $< 1.1.1.1 1
-	-$(DOCKER) strace $@ 1.1.1.1 1
-	-$(DOCKER) strace $@ 1.1.1.1 2
+	-docker compose run --rm --no-deps --entrypoint=strace tests -- $$(pwd)/$@ 1.1.1.1 1
+	-docker compose run --rm --no-deps --entrypoint=strace tests -- $$(pwd)/$@ 1.1.1.1 2
 
 # ----------------------------------------------------------------------------
 # MISC

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,10 @@ $(BINARY).bck: $(SOURCES)
 
 .PHONY: debug release
 debug: CHALK_BUILD=build --define:debug
+debug: DEBUG=true
 release: CHALK_BUILD=build
 debug release:
-	$(eval export CHALK_BUILD)
+	$(eval export CHALK_BUILD DEBUG)
 	-rm -f $(BINARY) $(BINARY).bck
 	$(MAKE) $(BINARY)
 

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,11 @@ tests_parallel: tests
 tests_bash:
 	docker compose run --rm --no-deps tests bash
 
+src/pingttl: src/pingttl.nim
+	$(DOCKER) nim c -r $< 1.1.1.1 1
+	-$(DOCKER) strace $@ 1.1.1.1 1
+	-$(DOCKER) strace $@ 1.1.1.1 2
+
 # ----------------------------------------------------------------------------
 # MISC
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -26,28 +26,6 @@ task test, "Run the unit tests":
     args = "--verbose pattern 'tests/unit/*.nim'" # By default, run all unit tests.
   exec "testament " & args
 
-proc con4mDevMode() =
-  let script = "bin/devmode"
-  # only missing in Dockerfile compile step
-  if not fileExists(script):
-    return
-  ## The devmode script is for use when doing combined work across
-  ## chalk and con4m / nimutils; it simply copies any con4m and nimble
-  ## source code into your most recent nimble directory before running
-  ## build.
-  ##
-  ## Note that by default the script assumes that con4m/ and nimtuils/
-  ## repos live under ../con4m/ and ../nimutils/ locally, and that
-  ## nimble's package directory is at ~/.nimble/pkgs. But you can use
-  ## environment variables: `CON4M_DIR`, `NIMUTILS_DIR`, `NIMBLE_PKGS`.
-  ##
-  ## And, the script only does stuff if `CON4M_DEV` is set in your
-  ## environment (the value doesn't matter).
-  exec script
-
-before build:
-  con4mDevMode()
-
 # Add --trace if needed.
 after build:
   when not defined(debug):

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#ee26bd28d99cd0aa2dc3c9b2cd83bb0d145ec167"
+requires "https://github.com/crashappsec/con4m#57c908650544ab045a3a9aa6f26d274b1859d238"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally
@@ -28,7 +28,12 @@ task test, "Run the unit tests":
 
 # Add --trace if needed.
 after build:
-  when not defined(debug):
+  # ideally this should work:
+  # when not defined(debug):
+  # however debug symbol doesnt seem to be defined by nimble?
+  # and it always runs strip
+  # instead we check env var set by Makefile
+  if getEnv("DEBUG", "false") != "true":
     exec "set -x && strip " & bin[0]
   exec "set -x && ./" & bin[0] & " --debug --no-use-external-config --skip-command-report load default"
 

--- a/config.nims
+++ b/config.nims
@@ -12,8 +12,6 @@ when not defined(debug):
     switch("warning", "Deprecated:off")
     switch("warning", "User:off")
 
-applyCommonLinkOptions()
-
 var
   default  = getEnv("HOME").joinPath(".local/c0")
   localDir = getEnv("LOCAL_INSTALL_DIR", default)

--- a/src/configs/base_init.c4m
+++ b/src/configs/base_init.c4m
@@ -31,6 +31,8 @@ cloud_provider {
   cloud_instance_hw_identifiers { }
 }
 
+network { }
+
 attestation {
   attestation_key_embed { }
   attestation_key_get { }

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -5667,7 +5667,7 @@ keyspec _NETWORK_PARTIAL_TRACEROUTE_IPS {
     type:             dict[string, list[string]]
     standard:         true
     since:            "0.4.13"
-    shortdoc:         "Partial traceroute IPs to discover local network resources"
+    shortdoc:         "Partial traceroute IPs for run-time environment discovery"
     doc:              """
 Partial traceroutes to IPs as configured by `network.tracerroute_ips`.
 This allows to discover local network resources such as local

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -5662,6 +5662,20 @@ AWS where imdsv2 is available.
 """
 }
 
+keyspec _NETWORK_PARTIAL_TRACEROUTE_IPS {
+    kind:             RunTimeHost
+    type:             dict[string, dict[string, string]]
+    standard:         true
+    since:            "0.4.13"
+    shortdoc:         "Partial traceroute IPs for configured TTLs"
+    doc:              """
+For all IPs to traceroute, intermediate IPs for given TTL values
+as configured by `network.traceroute_ips`.
+As this is not a complete traceroute all the way to the destination,
+it is useful to find local network configurations such as subnet gateway
+where chalk is running.
+"""
+}
 
 keyspec _CHALK_EXTERNAL_ACTION_AUDIT {
     kind: RunTimeHost

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -5664,16 +5664,14 @@ AWS where imdsv2 is available.
 
 keyspec _NETWORK_PARTIAL_TRACEROUTE_IPS {
     kind:             RunTimeHost
-    type:             dict[string, dict[string, string]]
+    type:             dict[string, list[string]]
     standard:         true
     since:            "0.4.13"
-    shortdoc:         "Partial traceroute IPs for configured TTLs"
+    shortdoc:         "Partial traceroute IPs to discover local network resources"
     doc:              """
-For all IPs to traceroute, intermediate IPs for given TTL values
-as configured by `network.traceroute_ips`.
-As this is not a complete traceroute all the way to the destination,
-it is useful to find local network configurations such as subnet gateway
-where chalk is running.
+Partial traceroutes to IPs as configured by `network.tracerroute_ips`.
+This allows to discover local network resources such as local
+ingress gateway IP even within docker network-namespaced containers.
 """
 }
 

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023, Crash Override, Inc.
+## Copyright (c) 2023-2024, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -228,6 +228,15 @@ plugin cloud_metadata {
     "_AWS_TAGS"]
     doc: """
 Captures metadata from cloud instances.
+"""
+}
+
+plugin network {
+  enabled: true
+  post_run_keys: ["_NETWORK_PARTIAL_TRACEROUTE_IPS"]
+  doc: """
+Collect external networking configurations.
+Some of them can be probe-based.
 """
 }
 

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -364,6 +364,7 @@ report and subtract from it.
   key._OP_CLOUD_METADATA.use                  = true
   key._OP_FAILED_KEYS.use                     = true
   key.FAILED_KEYS.use                         = true
+  key._NETWORK_PARTIAL_TRACEROUTE_IPS.use     = true
   key._OP_ERRORS.use                          = true
   key._OP_HOST_REPORT_KEYS.use                = true
   key._OP_TCP_SOCKET_INFO.use                 = true
@@ -517,6 +518,7 @@ doc: """
   key._OP_CLOUD_METADATA.use                  = true
   key._OP_FAILED_KEYS.use                     = true
   key.FAILED_KEYS.use                         = true
+  key._NETWORK_PARTIAL_TRACEROUTE_IPS.use     = true
   key._OP_ERRORS.use                          = true
   key._OP_HOST_REPORT_KEYS.use                = true
   key._OP_TCP_SOCKET_INFO.use                 = true
@@ -1004,6 +1006,7 @@ container.
   key._OP_CLOUD_METADATA.use                  = true
   key._OP_FAILED_KEYS.use                     = true
   key.FAILED_KEYS.use                         = true
+  key._NETWORK_PARTIAL_TRACEROUTE_IPS.use     = true
   key._CHALK_EXTERNAL_ACTION_AUDIT.use        = true
   key._OP_ERRORS.use                          = true
   key._OP_CLOUD_SYS_VENDOR.use                = true
@@ -1467,6 +1470,7 @@ and keep the run-time key.
   key._OP_CLOUD_METADATA.use                  = true
   key._OP_FAILED_KEYS.use                     = true
   key.FAILED_KEYS.use                         = true
+  key._NETWORK_PARTIAL_TRACEROUTE_IPS.use     = true
   key._CHALK_EXTERNAL_ACTION_AUDIT.use        = true
   key._OP_ERRORS.use                          = true
   key._OP_CLOUD_SYS_VENDOR.use                = true

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2595,6 +2595,32 @@ Configuration information for the different Cloud Provider
     hidden:  true
     doc:     "Default cloud metadata IP"
   }
+
+}
+
+singleton network {
+  gen_fieldname: "networkConfig"
+  gen_typename:  "NetworkConfig"
+  gen_setters:   false
+  user_def_ok:   false
+  shortdoc: """
+Configuration for network metadata collection
+"""
+
+  field partial_traceroute_ips {
+    type:    dict[string, list[string]]
+    default: {"1.1.1.1": ["1", "2"]}
+    hidden:  true
+    doc:     """
+IPs to partially traceroute for specified TTLs.
+This can be useful to find local subnets where chalk is running.
+For example in docker container in a cloud environment will reveal
+hosts subnet gateway IP for TTL=2.
+This is a dictionary to allow to potentially query multiple networks
+if there are multiple egress routes.
+By default partial traceroute runs for public cloudflare 1.1.1.1.
+"""
+  }
 }
 
 root {
@@ -2631,6 +2657,7 @@ root {
   allow tech_stack_rule
   allow linguist_language
   allow git
+  allow network
 
   shortdoc: "Chalk Configuration Options"
 

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2608,17 +2608,17 @@ Configuration for network metadata collection
 """
 
   field partial_traceroute_ips {
-    type:    dict[string, list[string]]
-    default: {"1.1.1.1": ["1", "2"]}
+    type:    dict[string, int]
+    default: {"1.1.1.1": 2}
     hidden:  true
     doc:     """
-IPs to partially traceroute for specified TTLs.
+IPs to partially traceroute for specified number of hops.
 This can be useful to find local subnets where chalk is running.
 For example in docker container in a cloud environment will reveal
-hosts subnet gateway IP for TTL=2.
+hosts subnet gateway IP with 2 hops (TTL=2).
 This is a dictionary to allow to potentially query multiple networks
 if there are multiple egress routes.
-By default partial traceroute runs for public cloudflare 1.1.1.1.
+By default partial traceroute runs for public cloudflare IP `1.1.1.1`.
 """
   }
 }

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2621,6 +2621,13 @@ if there are multiple egress routes.
 By default partial traceroute runs for public cloudflare IP `1.1.1.1`.
 """
   }
+
+  field partial_traceroute_timeout_ms {
+    type:    int
+    default: 10
+    hidden:  true
+    doc:     "Timeout to use in ms for each hop in partial traceroute"
+  }
 }
 
 root {

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -77,6 +77,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key._OP_CLOUD_METADATA.use                         = true
   ~key._OP_FAILED_KEYS.use                            = true
   ~key.FAILED_KEYS.use                                = true
+  ~key._NETWORK_PARTIAL_TRACEROUTE_IPS.use            = true
   ~key._CHALK_EXTERNAL_ACTION_AUDIT.use               = true
   ~key._OP_ERRORS.use                                 = true
   ~key._OP_CLOUD_SYS_VENDOR.use                       = true

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -5,26 +5,26 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
-when hostOs == "linux":
-  import std/[
-    nativesockets,
-    net,
-    options,
-    os,
-    oserrors,
-    posix,
-  ]
+import std/[
+  nativesockets,
+  net,
+  options,
+  os,
+  oserrors,
+  posix,
+]
 
+const
+  msec           = 1000
+  defaultTimeout = 10
+
+when hostOs == "linux":
   # allow to use this as standalone module for testing without chalk imports
   when isMainModule:
     proc trace(s: string) =
       echo(s)
   else:
     import "."/[config]
-
-  const
-    msec           = 1000
-    defaultTimeout = 10
 
   # these dont seem to be in stdlib?
   let

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -90,7 +90,7 @@ when hostOs == "linux":
     # convert to 16-bit by adding carry to sum
     while (sum shr 16) > 0:
       sum = (sum and 0xffff) + (sum shr 16)
-    result = not result
+    result = not uint16(sum)
 
   proc asArray(self: IcmpPing): array[8, uint8] =
     return cast[ptr array[sizeof(self), uint8]](self)[]

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -221,6 +221,8 @@ when hostOs == "linux":
       ).setChecksum()
       data = ping.asData()
       handle = createNativeSocket(posix.AF_INET, posix.SOCK_DGRAM, posix.IPPROTO_ICMP)
+    if handle == osInvalidSocket:
+      raise newException(OSError, "Could not open SOCK_DGRAM socket using IPPROTO_ICMP for partial tracerouting")
     defer: handle.close()
     handle.setSockOptInt(IPPROTO_IP, IP_TTL,           ttl)
     handle.setSockOptInt(IPPROTO_IP, IP_MULTICAST_TTL, ttl)

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -222,10 +222,10 @@ when hostOs == "linux":
         sequence:   uint16(sequence),
       ).setChecksum()
       data = ping.asData()
-    var handle = createNativeSocket(posix.AF_INET, posix.SOCK_RAW, posix.IPPROTO_ICMP)
+    var handle = createNativeSocket(posix.AF_INET, posix.SOCK_DGRAM, posix.IPPROTO_ICMP)
     if handle == osInvalidSocket:
-      trace("pingttl: cant open SOCK_RAW. retrying with SOCK_DGRAM")
-      handle = createNativeSocket(posix.AF_INET, posix.SOCK_DGRAM, posix.IPPROTO_ICMP)
+      trace("pingttl: cant open SOCK_DGRAM. retrying with SOCK_RAW")
+      handle = createNativeSocket(posix.AF_INET, posix.SOCK_RAW, posix.IPPROTO_ICMP)
     if handle == osInvalidSocket:
       raise newException(OSError, "Partial traceroute could not open SOCK_RAW or SOCK_DGRAM for IPPROTO_ICMP. Missing network capability perhaps?")
     defer: handle.close()

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -24,7 +24,7 @@ when hostOs == "linux":
 
   const
     msec           = 1000
-    defaultTimeout = 5
+    defaultTimeout = 10
 
   # these dont seem to be in stdlib?
   let

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -191,13 +191,17 @@ when hostOs == "linux":
         if int32(offender.sa_family) != posix.AF_INET:
           trace("pingttl: icmp error from unsupported offender source address family " & $offender.sa_family)
           raiseOSError(lastError)
-        # TODO how to get the sock len directly from the sockaddr structure?
-        # var
-        #   address: IpAddress
-        #   port:    Port
-        # fromSockAddr(cast[ptr Sockaddr_in](offender)[], ???, address, port)
-        let address = cast[ptr Sockaddr_in](offender)
-        return parseIpAddress($(inet_ntoa(address.sin_addr)))
+        var
+          address: IpAddress
+          port:    Port
+        # above we asserted only ipv4 so can pass size of ipv4 directly
+        # to add ipv6 will reuqire supporting icmp6 error codes as well
+        # which we dont need just yet
+        fromSockAddr(cast[ptr Sockaddr_in](offender)[],
+                     SockLen(sizeof(Sockaddr_in)),
+                     address,
+                     port)
+        return address
       cmsg = CMSG_NXTHDR(addr(msg), cmsg)
     raiseOSError(lastError)
 

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -1,0 +1,224 @@
+import std/[
+  cmdline,
+  nativesockets,
+  net,
+  options,
+  os,
+  oserrors,
+  posix,
+  strutils,
+]
+
+const msec = 1000
+
+# these dont seem to be in stdlib?
+let
+  MSG_ERRQUEUE      {.importc, header: "<sys/socket.h>".}:    int32
+  MSG_DONTWAIT      {.importc, header: "<sys/socket.h>".}:    int32
+  IPPROTO_IP        {.importc, header: "<netinet/in.h>".}:    int
+  IP_TTL            {.importc, header: "<netinet/in.h>".}:    int
+  IP_MULTICAST_TTL  {.importc, header: "<netinet/in.h>".}:    int
+  IP_RECVERR        {.importc, header: "<netinet/in.h>".}:    int
+  IP_RECVTTL        {.importc, header: "<netinet/in.h>".}:    int
+  IP_RECVOPTS       {.importc, header: "<netinet/in.h>".}:    int
+  SO_RCVTIMEO       {.importc, header: "<netinet/in.h>".}:    cint
+  SO_EE_ORIGIN_ICMP {.importc, header: "<linux/errqueue.h>"}: uint8
+
+type
+  SockExtendedErr {.importc: "struct sock_extended_err", header: "<linux/errqueue.h>".} = object
+    ee_errno:  uint32
+    ee_origin: uint8
+    ee_type:   uint8
+    ee_code:   uint8
+    ee_pad:    uint8
+    ee_info:   ptr uint32
+    ee_data:   ptr uint32
+  IcmpType = enum
+    EchoReply    = 0'u8
+    Unreachable  = 3'u8
+    EchoRequest  = 8'u8
+    TTLExceeded  = 11'u8
+  EchoRequestCode = enum
+    Ping         = 0'u8
+  IcmpPing = ref object
+    icmptype*:   IcmpType
+    icmpcode*:   EchoRequestCode
+    checksum*:   uint16
+    identifier*: uint16
+    sequence*:   uint16
+
+proc SO_EE_OFFENDER(err: ptr SockExtendedErr):
+  ptr Sockaddr {.importc, header: "<linux/errqueue.h>".}
+
+proc computeChecksum(x: openArray[uint8]): uint16 =
+  ## https://www.rfc-editor.org/rfc/rfc792
+  ## https://www.rfc-editor.org/rfc/rfc1071
+  ## The checksum is the 16-bit ones's complement of the one's
+  ## complement sum of the ICMP message starting with the ICMP Type.
+  ## For computing the checksum , the checksum field should be zero.
+  ## If the total length is odd, the received data is padded with one
+  ## octet of zeros for computing the checksum.  This checksum may be
+  ## replaced in the future.
+  var
+    sum: uint32 = 0
+    i           = 0
+    l           = len(x) - 1
+  while i < l:
+    # sum is 16-bit word whereas input is seq of 8-bit ints
+    # hence shift left 8 to align bytes
+    sum += (x[i] shl 8) + x[i + 1]
+    i += 2
+  # input is odd length - add last byte
+  if i < len(x):
+    sum += x[i] shl 8
+  # convert to 16-bit by adding carry to sum
+  while (sum shr 16) > 0:
+    sum = (sum and 0xffff) + (sum shr 16)
+  result = not result
+
+proc asArray(self: IcmpPing): array[8, uint8] =
+  return cast[ptr array[sizeof(self), uint8]](self)[]
+
+proc asData(self: IcmpPing): string =
+  for i in self.asArray():
+    result.add(cast[char](i))
+
+proc setChecksum(self: IcmpPing): IcmpPing =
+  self.checksum = computeChecksum(self.asArray())
+  return self
+
+proc sendTo(handle: SocketHandle, data: string, dest: IpAddress, port = Port(0)) =
+  # sending icmp packet requires native sockets which dont have easy API
+  # like sockets do in stdlib hence more data dances here
+  # which is mostly a copy from stdlib sendTo function
+  var
+    sockAddr: Sockaddr_storage
+    sockLen:  SockLen
+  toSockAddr(dest, port, sockAddr, sockLen)
+  let sent = handle.sendto(
+    cstring(data),
+    cint(len(data)),
+    cint(0'i32),
+    cast[ptr SockAddr](addr sockAddr),
+    sockLen,
+  )
+  if sent < 0:
+    raiseOSError(osLastError())
+
+proc recvIp(handle: SocketHandle, dest: IpAddress): IpAddress =
+  const length = 256
+  var
+    control: array[length, char]
+    msg      = Tmsghdr(
+      msg_control: addr(control),
+      msg_controllen: length,
+    )
+    received = handle.recvmsg(addr(msg), 0'i32)
+  if received >= 0:
+    return dest
+  let
+    lastError    = osLastError()
+    lastErrorMsg = osErrorMsg(lastError)
+  if int32(lastError) != EHOSTUNREACH:
+    echo("unsupporter errno " & lastErrorMsg)
+    raiseOSError(lastError)
+  received = handle.recvmsg(addr(msg), MSG_ERRQUEUE or MSG_DONTWAIT)
+  if received < 0:
+    echo("could not get errqueue")
+    raiseOSError(lastError)
+  if msg.msg_controllen == 0:
+    echo("control msg is empty")
+    raiseOSError(lastError)
+  var cmsg = CMSG_FIRSTHDR(addr(msg))
+  while cmsg != nil:
+    # https://www.man7.org/linux/man-pages/man7/ip.7.html
+    # > Enable extended reliable error message passing.  When
+    # > enabled on a datagram socket, all generated errors will be
+    # > queued in a per-socket error queue.  When the user
+    # > receives an error from a socket operation, the errors can
+    # > be received by calling recvmsg(2) with the MSG_ERRQUEUE
+    # > flag set.  The sock_extended_err structure describing the
+    # > error will be passed in an ancillary message with the type
+    # > IP_RECVERR and the level IPPROTO_IP.  This is useful for
+    # > reliable error handling on unconnected sockets.  The
+    # > received data portion of the error queue contains the
+    # > error packet.
+    if cmsg.cmsg_len   > 0 and
+       cmsg.cmsg_level == IPPROTO_IP and
+       cmsg.cmsg_type  == IP_RECVERR:
+      let err = cast[ptr SockExtendedErr](CMSG_DATA(cmsg))
+      if err.ee_origin != SO_EE_ORIGIN_ICMP:
+        # this can be either icmp6 or local errors
+        echo("origin is not icmp error")
+        raiseOSError(lastError)
+      if (err.ee_type != uint8(IcmpType.Unreachable) and
+          err.ee_type != uint8(IcmpType.TTLExceeded)):
+        echo("icmp type is neither unreachable or ttl exceeded ", err.ee_type)
+        raiseOSError(lastError)
+      # https://www.man7.org/linux/man-pages/man7/ip.7.html
+      # > ee_errno contains the errno number of the queued error.
+      # > ee_origin is the origin code of where the error
+      # > originated.  The other fields are protocol-specific.  The
+      # > macro SO_EE_OFFENDER returns a pointer to the address of
+      # > the network object where the error originated from given a
+      # > pointer to the ancillary message.  If this address is not
+      # > known, the sa_family member of the sockaddr contains
+      # > AF_UNSPEC and the other fields of the sockaddr are
+      # > undefined.
+      let offender = SO_EE_OFFENDER(err)
+      if int32(offender.sa_family) == posix.AF_UNSPEC:
+        echo("icmp error from unknown offender source address family ", offender.sa_family)
+        raiseOSError(lastError)
+      if int32(offender.sa_family) != posix.AF_INET:
+        echo("icmp error from unsupported offender source address family ", offender.sa_family)
+        raiseOSError(lastError)
+      # TODO how to get the sock len directly from the sockaddr structure?
+      # var
+      #   address: IpAddress
+      #   port:    Port
+      # fromSockAddr(cast[ptr Sockaddr_in](offender)[], ???, address, port)
+      let address = cast[ptr Sockaddr_in](offender)
+      return parseIpAddress($(inet_ntoa(address.sin_addr)))
+    cmsg = CMSG_NXTHDR(addr(msg), cmsg)
+  raiseOSError(lastError)
+
+proc getIpForTTL*(dest: IpAddress, ttl: int, sequence = 0): IpAddress =
+  let
+    id   = uint16(getpid())
+    ping = IcmpPing(
+      icmptype:   IcmpType.EchoRequest,
+      icmpcode:   EchoRequestCode.Ping,
+      checksum:   0'u16, # dummy checksum
+      identifier: id,
+      sequence:   uint16(sequence),
+    ).setChecksum()
+    data = ping.asData()
+    handle = createNativeSocket(posix.AF_INET, posix.SOCK_DGRAM, posix.IPPROTO_ICMP)
+  defer: handle.close()
+  handle.setSockOptInt(IPPROTO_IP, IP_TTL,           ttl)
+  handle.setSockOptInt(IPPROTO_IP, IP_MULTICAST_TTL, ttl)
+  handle.setSockOptInt(IPPROTO_IP, IP_RECVTTL,       1)
+  handle.setSockOptInt(IPPROTO_IP, IP_RECVERR,       1)
+  handle.setSockOptInt(IPPROTO_IP, IP_RECVOPTS,      1)
+  let timeout = Timeval(tv_sec: Time(0), tv_usec: Suseconds(200 * msec))
+  discard handle.setsockopt(SOL_SOCKET, SO_RCVTIMEO, addr(timeout), SockLen(sizeof(timeout)))
+  handle.sendTo(data, dest)
+  result = handle.recvIp(dest)
+
+proc tryGetIpForTTL*(dest: IpAddress, ttl: int, sequence = 0): Option[IpAddress] =
+  try:
+    result = some(getIpForTTL(dest, ttl = ttl, sequence = sequence))
+  except:
+    return none(IpAddress)
+
+when isMainModule:
+  if paramCount() < 2:
+    echo("usage: ", getAppFilename(), " <ip> <ttl>")
+    quit(1)
+  let
+    ip  = parseIpAddress(paramStr(1))
+    ttl = parseInt(paramStr(2))
+  try:
+    echo(getIpForTTL(ip, ttl = ttl))
+  except:
+    echo("could not determine TTL IP")

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -245,6 +245,7 @@ when hostOs == "linux":
         timeoutMs = timeoutMs,
       ))
     except:
+      trace("pingttl: could not find partial traceroute due to: " & getCurrentExceptionMsg())
       return none(IpAddress)
 
   when isMainModule:

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -34,7 +34,6 @@ when hostOs == "linux":
     MSG_DONTWAIT      {.importc, header: "<sys/socket.h>".}:    int32
     IPPROTO_IP        {.importc, header: "<netinet/in.h>".}:    int
     IP_TTL            {.importc, header: "<netinet/in.h>".}:    int
-    IP_MULTICAST_TTL  {.importc, header: "<netinet/in.h>".}:    int
     IP_RECVERR        {.importc, header: "<netinet/in.h>".}:    int
     IP_RECVTTL        {.importc, header: "<netinet/in.h>".}:    int
     IP_RECVOPTS       {.importc, header: "<netinet/in.h>".}:    int
@@ -230,7 +229,6 @@ when hostOs == "linux":
       raise newException(OSError, "Partial traceroute could not open SOCK_RAW or SOCK_DGRAM for IPPROTO_ICMP. Missing network capability perhaps?")
     defer: handle.close()
     handle.setSockOptInt(IPPROTO_IP, IP_TTL,           ttl)
-    handle.setSockOptInt(IPPROTO_IP, IP_MULTICAST_TTL, ttl)
     handle.setSockOptInt(IPPROTO_IP, IP_RECVTTL,       1)
     handle.setSockOptInt(IPPROTO_IP, IP_RECVERR,       1)
     handle.setSockOptInt(IPPROTO_IP, IP_RECVOPTS,      1)

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -1,224 +1,270 @@
-import std/[
-  cmdline,
-  nativesockets,
-  net,
-  options,
-  os,
-  oserrors,
-  posix,
-  strutils,
-]
+##
+## Copyright (c) 2024, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
 
-const msec = 1000
+when hostOs == "linux":
+  import std/[
+    nativesockets,
+    net,
+    options,
+    os,
+    oserrors,
+    posix,
+  ]
 
-# these dont seem to be in stdlib?
-let
-  MSG_ERRQUEUE      {.importc, header: "<sys/socket.h>".}:    int32
-  MSG_DONTWAIT      {.importc, header: "<sys/socket.h>".}:    int32
-  IPPROTO_IP        {.importc, header: "<netinet/in.h>".}:    int
-  IP_TTL            {.importc, header: "<netinet/in.h>".}:    int
-  IP_MULTICAST_TTL  {.importc, header: "<netinet/in.h>".}:    int
-  IP_RECVERR        {.importc, header: "<netinet/in.h>".}:    int
-  IP_RECVTTL        {.importc, header: "<netinet/in.h>".}:    int
-  IP_RECVOPTS       {.importc, header: "<netinet/in.h>".}:    int
-  SO_RCVTIMEO       {.importc, header: "<netinet/in.h>".}:    cint
-  SO_EE_ORIGIN_ICMP {.importc, header: "<linux/errqueue.h>"}: uint8
+  # allow to use this as standalone module for testing without chalk imports
+  when isMainModule:
+    proc trace(s: string) =
+      echo(s)
+  else:
+    import "."/[config]
 
-type
-  SockExtendedErr {.importc: "struct sock_extended_err", header: "<linux/errqueue.h>".} = object
-    ee_errno:  uint32
-    ee_origin: uint8
-    ee_type:   uint8
-    ee_code:   uint8
-    ee_pad:    uint8
-    ee_info:   ptr uint32
-    ee_data:   ptr uint32
-  IcmpType = enum
-    EchoReply    = 0'u8
-    Unreachable  = 3'u8
-    EchoRequest  = 8'u8
-    TTLExceeded  = 11'u8
-  EchoRequestCode = enum
-    Ping         = 0'u8
-  IcmpPing = ref object
-    icmptype*:   IcmpType
-    icmpcode*:   EchoRequestCode
-    checksum*:   uint16
-    identifier*: uint16
-    sequence*:   uint16
+  const
+    msec           = 1000
+    defaultTimeout = 5
 
-proc SO_EE_OFFENDER(err: ptr SockExtendedErr):
-  ptr Sockaddr {.importc, header: "<linux/errqueue.h>".}
+  # these dont seem to be in stdlib?
+  let
+    MSG_ERRQUEUE      {.importc, header: "<sys/socket.h>".}:    int32
+    MSG_DONTWAIT      {.importc, header: "<sys/socket.h>".}:    int32
+    IPPROTO_IP        {.importc, header: "<netinet/in.h>".}:    int
+    IP_TTL            {.importc, header: "<netinet/in.h>".}:    int
+    IP_MULTICAST_TTL  {.importc, header: "<netinet/in.h>".}:    int
+    IP_RECVERR        {.importc, header: "<netinet/in.h>".}:    int
+    IP_RECVTTL        {.importc, header: "<netinet/in.h>".}:    int
+    IP_RECVOPTS       {.importc, header: "<netinet/in.h>".}:    int
+    SO_SNDTIMEO       {.importc, header: "<netinet/in.h>".}:    cint
+    SO_RCVTIMEO       {.importc, header: "<netinet/in.h>".}:    cint
+    SO_EE_ORIGIN_ICMP {.importc, header: "<linux/errqueue.h>"}: uint8
 
-proc computeChecksum(x: openArray[uint8]): uint16 =
-  ## https://www.rfc-editor.org/rfc/rfc792
-  ## https://www.rfc-editor.org/rfc/rfc1071
-  ## The checksum is the 16-bit ones's complement of the one's
-  ## complement sum of the ICMP message starting with the ICMP Type.
-  ## For computing the checksum , the checksum field should be zero.
-  ## If the total length is odd, the received data is padded with one
-  ## octet of zeros for computing the checksum.  This checksum may be
-  ## replaced in the future.
-  var
-    sum: uint32 = 0
-    i           = 0
-    l           = len(x) - 1
-  while i < l:
-    # sum is 16-bit word whereas input is seq of 8-bit ints
-    # hence shift left 8 to align bytes
-    sum += (x[i] shl 8) + x[i + 1]
-    i += 2
-  # input is odd length - add last byte
-  if i < len(x):
-    sum += x[i] shl 8
-  # convert to 16-bit by adding carry to sum
-  while (sum shr 16) > 0:
-    sum = (sum and 0xffff) + (sum shr 16)
-  result = not result
+  type
+    SockExtendedErr {.importc: "struct sock_extended_err", header: "<linux/errqueue.h>".} = object
+      ee_errno:  uint32
+      ee_origin: uint8
+      ee_type:   uint8
+      ee_code:   uint8
+      ee_pad:    uint8
+      ee_info:   ptr uint32
+      ee_data:   ptr uint32
+    IcmpType = enum
+      EchoReply    = 0'u8
+      Unreachable  = 3'u8
+      EchoRequest  = 8'u8
+      TTLExceeded  = 11'u8
+    EchoRequestCode = enum
+      Ping         = 0'u8
+    IcmpPing = ref object
+      icmptype*:   IcmpType
+      icmpcode*:   EchoRequestCode
+      checksum*:   uint16
+      identifier*: uint16
+      sequence*:   uint16
 
-proc asArray(self: IcmpPing): array[8, uint8] =
-  return cast[ptr array[sizeof(self), uint8]](self)[]
+  proc SO_EE_OFFENDER(err: ptr SockExtendedErr):
+    ptr Sockaddr {.importc, header: "<linux/errqueue.h>".}
 
-proc asData(self: IcmpPing): string =
-  for i in self.asArray():
-    result.add(cast[char](i))
+  proc computeChecksum(x: openArray[uint8]): uint16 =
+    ## https://www.rfc-editor.org/rfc/rfc792
+    ## https://www.rfc-editor.org/rfc/rfc1071
+    ## The checksum is the 16-bit ones's complement of the one's
+    ## complement sum of the ICMP message starting with the ICMP Type.
+    ## For computing the checksum , the checksum field should be zero.
+    ## If the total length is odd, the received data is padded with one
+    ## octet of zeros for computing the checksum.  This checksum may be
+    ## replaced in the future.
+    var
+      sum: uint32 = 0
+      i           = 0
+      l           = len(x) - 1
+    while i < l:
+      # sum is 16-bit word whereas input is seq of 8-bit ints
+      # hence shift left 8 to align bytes
+      sum += (x[i] shl 8) + x[i + 1]
+      i += 2
+    # input is odd length - add last byte
+    if i < len(x):
+      sum += x[i] shl 8
+    # convert to 16-bit by adding carry to sum
+    while (sum shr 16) > 0:
+      sum = (sum and 0xffff) + (sum shr 16)
+    result = not result
 
-proc setChecksum(self: IcmpPing): IcmpPing =
-  self.checksum = computeChecksum(self.asArray())
-  return self
+  proc asArray(self: IcmpPing): array[8, uint8] =
+    return cast[ptr array[sizeof(self), uint8]](self)[]
 
-proc sendTo(handle: SocketHandle, data: string, dest: IpAddress, port = Port(0)) =
-  # sending icmp packet requires native sockets which dont have easy API
-  # like sockets do in stdlib hence more data dances here
-  # which is mostly a copy from stdlib sendTo function
-  var
-    sockAddr: Sockaddr_storage
-    sockLen:  SockLen
-  toSockAddr(dest, port, sockAddr, sockLen)
-  let sent = handle.sendto(
-    cstring(data),
-    cint(len(data)),
-    cint(0'i32),
-    cast[ptr SockAddr](addr sockAddr),
-    sockLen,
-  )
-  if sent < 0:
-    raiseOSError(osLastError())
+  proc asData(self: IcmpPing): string =
+    for i in self.asArray():
+      result.add(cast[char](i))
 
-proc recvIp(handle: SocketHandle, dest: IpAddress): IpAddress =
-  const length = 256
-  var
-    control: array[length, char]
-    msg      = Tmsghdr(
-      msg_control: addr(control),
-      msg_controllen: length,
+  proc setChecksum(self: IcmpPing): IcmpPing =
+    self.checksum = computeChecksum(self.asArray())
+    return self
+
+  proc sendTo(handle: SocketHandle, data: string, dest: IpAddress, port = Port(0)) =
+    # sending icmp packet requires native sockets which dont have easy API
+    # like sockets do in stdlib hence more data dances here
+    # which is mostly a copy from stdlib sendTo function
+    var
+      sockAddr: Sockaddr_storage
+      sockLen:  SockLen
+    toSockAddr(dest, port, sockAddr, sockLen)
+    let sent = handle.sendto(
+      cstring(data),
+      cint(len(data)),
+      cint(0'i32),
+      cast[ptr SockAddr](addr sockAddr),
+      sockLen,
     )
-    received = handle.recvmsg(addr(msg), 0'i32)
-  if received >= 0:
-    return dest
-  let
-    lastError    = osLastError()
-    lastErrorMsg = osErrorMsg(lastError)
-  if int32(lastError) != EHOSTUNREACH:
-    echo("unsupporter errno " & lastErrorMsg)
-    raiseOSError(lastError)
-  received = handle.recvmsg(addr(msg), MSG_ERRQUEUE or MSG_DONTWAIT)
-  if received < 0:
-    echo("could not get errqueue")
-    raiseOSError(lastError)
-  if msg.msg_controllen == 0:
-    echo("control msg is empty")
-    raiseOSError(lastError)
-  var cmsg = CMSG_FIRSTHDR(addr(msg))
-  while cmsg != nil:
-    # https://www.man7.org/linux/man-pages/man7/ip.7.html
-    # > Enable extended reliable error message passing.  When
-    # > enabled on a datagram socket, all generated errors will be
-    # > queued in a per-socket error queue.  When the user
-    # > receives an error from a socket operation, the errors can
-    # > be received by calling recvmsg(2) with the MSG_ERRQUEUE
-    # > flag set.  The sock_extended_err structure describing the
-    # > error will be passed in an ancillary message with the type
-    # > IP_RECVERR and the level IPPROTO_IP.  This is useful for
-    # > reliable error handling on unconnected sockets.  The
-    # > received data portion of the error queue contains the
-    # > error packet.
-    if cmsg.cmsg_len   > 0 and
-       cmsg.cmsg_level == IPPROTO_IP and
-       cmsg.cmsg_type  == IP_RECVERR:
-      let err = cast[ptr SockExtendedErr](CMSG_DATA(cmsg))
-      if err.ee_origin != SO_EE_ORIGIN_ICMP:
-        # this can be either icmp6 or local errors
-        echo("origin is not icmp error")
-        raiseOSError(lastError)
-      if (err.ee_type != uint8(IcmpType.Unreachable) and
-          err.ee_type != uint8(IcmpType.TTLExceeded)):
-        echo("icmp type is neither unreachable or ttl exceeded ", err.ee_type)
-        raiseOSError(lastError)
+    if sent < 0:
+      raiseOSError(osLastError())
+
+  proc recvIp(handle: SocketHandle, dest: IpAddress): IpAddress =
+    const length = 256
+    var
+      control: array[length, char]
+      msg      = Tmsghdr(
+        msg_control: addr(control),
+        msg_controllen: length,
+      )
+      received = handle.recvmsg(addr(msg), 0'i32)
+    if received >= 0:
+      return dest
+    let
+      lastError    = osLastError()
+      lastErrorMsg = osErrorMsg(lastError)
+    if int32(lastError) != EHOSTUNREACH:
+      trace("pingttl: unsupported errno " & $lastError & " - " & lastErrorMsg)
+      raiseOSError(lastError)
+    received = handle.recvmsg(addr(msg), MSG_ERRQUEUE or MSG_DONTWAIT)
+    if received < 0:
+      let
+        e = osLastError()
+        m = osErrorMsg(e)
+      trace("pingttl: could not get errqueue " & $e & " - " & m)
+      raiseOSError(lastError)
+    if msg.msg_controllen == 0:
+      trace("pingttl: errqueue control msg is empty")
+      raiseOSError(lastError)
+    var cmsg = CMSG_FIRSTHDR(addr(msg))
+    while cmsg != nil:
       # https://www.man7.org/linux/man-pages/man7/ip.7.html
-      # > ee_errno contains the errno number of the queued error.
-      # > ee_origin is the origin code of where the error
-      # > originated.  The other fields are protocol-specific.  The
-      # > macro SO_EE_OFFENDER returns a pointer to the address of
-      # > the network object where the error originated from given a
-      # > pointer to the ancillary message.  If this address is not
-      # > known, the sa_family member of the sockaddr contains
-      # > AF_UNSPEC and the other fields of the sockaddr are
-      # > undefined.
-      let offender = SO_EE_OFFENDER(err)
-      if int32(offender.sa_family) == posix.AF_UNSPEC:
-        echo("icmp error from unknown offender source address family ", offender.sa_family)
-        raiseOSError(lastError)
-      if int32(offender.sa_family) != posix.AF_INET:
-        echo("icmp error from unsupported offender source address family ", offender.sa_family)
-        raiseOSError(lastError)
-      # TODO how to get the sock len directly from the sockaddr structure?
-      # var
-      #   address: IpAddress
-      #   port:    Port
-      # fromSockAddr(cast[ptr Sockaddr_in](offender)[], ???, address, port)
-      let address = cast[ptr Sockaddr_in](offender)
-      return parseIpAddress($(inet_ntoa(address.sin_addr)))
-    cmsg = CMSG_NXTHDR(addr(msg), cmsg)
-  raiseOSError(lastError)
+      # > Enable extended reliable error message passing.  When
+      # > enabled on a datagram socket, all generated errors will be
+      # > queued in a per-socket error queue.  When the user
+      # > receives an error from a socket operation, the errors can
+      # > be received by calling recvmsg(2) with the MSG_ERRQUEUE
+      # > flag set.  The sock_extended_err structure describing the
+      # > error will be passed in an ancillary message with the type
+      # > IP_RECVERR and the level IPPROTO_IP.  This is useful for
+      # > reliable error handling on unconnected sockets.  The
+      # > received data portion of the error queue contains the
+      # > error packet.
+      if cmsg.cmsg_len   > 0 and
+         cmsg.cmsg_level == IPPROTO_IP and
+         cmsg.cmsg_type  == IP_RECVERR:
+        let err = cast[ptr SockExtendedErr](CMSG_DATA(cmsg))
+        if err.ee_origin != SO_EE_ORIGIN_ICMP:
+          # this can be either icmp6 or local errors
+          trace("pingttl: control message error origin is not icmp error " & $err.ee_origin)
+          raiseOSError(lastError)
+        if (err.ee_type != uint8(IcmpType.Unreachable) and
+            err.ee_type != uint8(IcmpType.TTLExceeded)):
+          trace("pingttl: control message icmp type is neither unreachable or ttl exceeded " & $err.ee_type)
+          raiseOSError(lastError)
+        # https://www.man7.org/linux/man-pages/man7/ip.7.html
+        # > ee_errno contains the errno number of the queued error.
+        # > ee_origin is the origin code of where the error
+        # > originated.  The other fields are protocol-specific.  The
+        # > macro SO_EE_OFFENDER returns a pointer to the address of
+        # > the network object where the error originated from given a
+        # > pointer to the ancillary message.  If this address is not
+        # > known, the sa_family member of the sockaddr contains
+        # > AF_UNSPEC and the other fields of the sockaddr are
+        # > undefined.
+        let offender = SO_EE_OFFENDER(err)
+        if int32(offender.sa_family) == posix.AF_UNSPEC:
+          trace("pingttl: icmp error from unknown offender source address family " & $offender.sa_family)
+          raiseOSError(lastError)
+        if int32(offender.sa_family) != posix.AF_INET:
+          trace("pingttl: icmp error from unsupported offender source address family " & $offender.sa_family)
+          raiseOSError(lastError)
+        # TODO how to get the sock len directly from the sockaddr structure?
+        # var
+        #   address: IpAddress
+        #   port:    Port
+        # fromSockAddr(cast[ptr Sockaddr_in](offender)[], ???, address, port)
+        let address = cast[ptr Sockaddr_in](offender)
+        return parseIpAddress($(inet_ntoa(address.sin_addr)))
+      cmsg = CMSG_NXTHDR(addr(msg), cmsg)
+    raiseOSError(lastError)
 
-proc getIpForTTL*(dest: IpAddress, ttl: int, sequence = 0): IpAddress =
-  let
-    id   = uint16(getpid())
-    ping = IcmpPing(
-      icmptype:   IcmpType.EchoRequest,
-      icmpcode:   EchoRequestCode.Ping,
-      checksum:   0'u16, # dummy checksum
-      identifier: id,
-      sequence:   uint16(sequence),
-    ).setChecksum()
-    data = ping.asData()
-    handle = createNativeSocket(posix.AF_INET, posix.SOCK_DGRAM, posix.IPPROTO_ICMP)
-  defer: handle.close()
-  handle.setSockOptInt(IPPROTO_IP, IP_TTL,           ttl)
-  handle.setSockOptInt(IPPROTO_IP, IP_MULTICAST_TTL, ttl)
-  handle.setSockOptInt(IPPROTO_IP, IP_RECVTTL,       1)
-  handle.setSockOptInt(IPPROTO_IP, IP_RECVERR,       1)
-  handle.setSockOptInt(IPPROTO_IP, IP_RECVOPTS,      1)
-  let timeout = Timeval(tv_sec: Time(0), tv_usec: Suseconds(200 * msec))
-  discard handle.setsockopt(SOL_SOCKET, SO_RCVTIMEO, addr(timeout), SockLen(sizeof(timeout)))
-  handle.sendTo(data, dest)
-  result = handle.recvIp(dest)
+  proc getIpForTTL*(dest:     IpAddress,
+                    ttl:      int,
+                    sequence  = 0,
+                    timeoutMs = defaultTimeout): IpAddress =
+    trace("pingttl: dest=" & $dest & " ttl=" & $ttl & " timeout=" & $timeoutMs)
+    let
+      id   = uint16(getpid())
+      ping = IcmpPing(
+        icmptype:   IcmpType.EchoRequest,
+        icmpcode:   EchoRequestCode.Ping,
+        checksum:   0'u16, # initial dummy checksum
+        identifier: id,
+        sequence:   uint16(sequence),
+      ).setChecksum()
+      data = ping.asData()
+      handle = createNativeSocket(posix.AF_INET, posix.SOCK_DGRAM, posix.IPPROTO_ICMP)
+    defer: handle.close()
+    handle.setSockOptInt(IPPROTO_IP, IP_TTL,           ttl)
+    handle.setSockOptInt(IPPROTO_IP, IP_MULTICAST_TTL, ttl)
+    handle.setSockOptInt(IPPROTO_IP, IP_RECVTTL,       1)
+    handle.setSockOptInt(IPPROTO_IP, IP_RECVERR,       1)
+    handle.setSockOptInt(IPPROTO_IP, IP_RECVOPTS,      1)
+    let timeout = Timeval(tv_sec: Time(0), tv_usec: Suseconds(timeoutMs * msec))
+    discard handle.setsockopt(SOL_SOCKET, SO_SNDTIMEO, addr(timeout), SockLen(sizeof(timeout)))
+    discard handle.setsockopt(SOL_SOCKET, SO_RCVTIMEO, addr(timeout), SockLen(sizeof(timeout)))
+    handle.sendTo(data, dest)
+    result = handle.recvIp(dest)
 
-proc tryGetIpForTTL*(dest: IpAddress, ttl: int, sequence = 0): Option[IpAddress] =
-  try:
-    result = some(getIpForTTL(dest, ttl = ttl, sequence = sequence))
-  except:
-    return none(IpAddress)
+  proc tryGetIpForTTL*(dest:     IpAddress,
+                       ttl:      int,
+                       sequence  = 0,
+                       timeoutMs = defaultTimeout): Option[IpAddress] =
+    try:
+      result = some(getIpForTTL(
+        dest,
+        ttl       = ttl,
+        sequence  = sequence,
+        timeoutMs = timeoutMs,
+      ))
+    except:
+      return none(IpAddress)
 
-when isMainModule:
-  if paramCount() < 2:
-    echo("usage: ", getAppFilename(), " <ip> <ttl>")
-    quit(1)
-  let
-    ip  = parseIpAddress(paramStr(1))
-    ttl = parseInt(paramStr(2))
-  try:
-    echo(getIpForTTL(ip, ttl = ttl))
-  except:
-    echo("could not determine TTL IP")
+  when isMainModule:
+    import std/[cmdline, strutils]
+    if paramCount() < 2:
+      echo("usage: ", getAppFilename(), " <ip> <ttl>")
+      quit(1)
+    let
+      ip  = parseIpAddress(paramStr(1))
+      ttl = parseInt(paramStr(2))
+    try:
+      echo(getIpForTTL(ip, ttl = ttl))
+    except:
+      echo("could not determine TTL IP")
+
+else:
+  proc getIpForTTL*(dest:     IpAddress,
+                    ttl:      int,
+                    sequence  = 0,
+                    timeoutMs = defaultTimeout): IpAddress =
+    raise newException(AssertionError, "only implemented on linux")
+
+  proc tryGetIpForTTL*(dest:     IpAddress,
+                       ttl:      int,
+                       sequence  = 0,
+                       timeoutMs = defaultTimeout): Option[IpAddress] =
+    raise newException(AssertionError, "only implemented on linux")

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -272,7 +272,7 @@ when hostOs == "linux":
     try:
       echo(getIpForTTL(ip, ttl = ttl))
     except:
-      echo("could not determine TTL IP")
+      echo("could not determine TTL IP: " & getCurrentExceptionMsg())
 
 else:
   proc getIpForTTL*(dest:     IpAddress,

--- a/src/pingttl.nim
+++ b/src/pingttl.nim
@@ -246,6 +246,7 @@ when hostOs == "linux":
       ))
     except:
       trace("pingttl: could not find partial traceroute due to: " & getCurrentExceptionMsg())
+      dumpExOnDebug()
       return none(IpAddress)
 
   when isMainModule:

--- a/src/plugin_load.nim
+++ b/src/plugin_load.nim
@@ -34,8 +34,27 @@ macro loadPlugins(list: static[openarray[string]]): untyped =
 # Putting `pluginName` in here will cause `loadPluginName()`
 # to get called.
 
-loadPlugins(["codecDocker", "codecElf", "codecMacOs", "codecPythonPyc",
-             "codecSource", "codecZip", "codecFallbackElf",
-             "ciGithub", "ciGitlab", "ciJenkins", "conffile", "awsEcs", "awsLambda",
-             "externalTool", "cloudMetadata", "ownerAuthors", "ownerGithub",
-             "procfs", "system", "vctlGit", "techStackGeneric"])
+loadPlugins([
+  "awsEcs",
+  "awsLambda",
+  "ciGithub",
+  "ciGitlab",
+  "ciJenkins",
+  "cloudMetadata",
+  "codecDocker",
+  "codecElf",
+  "codecFallbackElf",
+  "codecMacOs",
+  "codecPythonPyc",
+  "codecSource",
+  "codecZip",
+  "conffile",
+  "externalTool",
+  "network",
+  "ownerAuthors",
+  "ownerGithub",
+  "procfs",
+  "system",
+  "techStackGeneric",
+  "vctlGit",
+])

--- a/src/plugins/network.nim
+++ b/src/plugins/network.nim
@@ -16,8 +16,12 @@ proc getTtlIps(): Box =
     for dest, hops in ipHops:
       var route = newSeq[string]()
       for ttl in countup(1, hops):
-        let ip  = tryGetIpForTTL(parseIpAddress(dest), ttl = ttl)
-        route.add($(ip.get()))
+        let ip = tryGetIpForTTL(parseIpAddress(dest), ttl = ttl)
+        if ip.isSome():
+          route.add($(ip.get()))
+        else:
+          # ensure route list has all hops even if we could not detect intermediate IP
+          route.add("")
       if len(route) > 0:
         data[dest] = route
   return pack(data)

--- a/src/plugins/network.nim
+++ b/src/plugins/network.nim
@@ -12,13 +12,15 @@ proc getTtlIps(): Box =
   var data = newTable[string, seq[string]]()
   # pingttl is only implemented for linux
   when hostOs == "linux":
-    let ipHops = attrGet[TableRef[string, int]]("network.partial_traceroute_ips")
+    let
+      ipHops    = attrGet[TableRef[string, int]]("network.partial_traceroute_ips")
+      timeoutMs = attrGet[int]("network.partial_traceroute_timeout_ms")
     for dest, hops in ipHops:
       var
         route = newSeq[string]()
         anyIp = false
       for ttl in countup(1, hops):
-        let ip = tryGetIpForTTL(parseIpAddress(dest), ttl = ttl)
+        let ip = tryGetIpForTTL(parseIpAddress(dest), ttl = ttl, timeoutMs = timeoutMs)
         if ip.isSome():
           route.add($(ip.get()))
           anyIp = true

--- a/src/plugins/network.nim
+++ b/src/plugins/network.nim
@@ -14,15 +14,18 @@ proc getTtlIps(): Box =
   when hostOs == "linux":
     let ipHops = attrGet[TableRef[string, int]]("network.partial_traceroute_ips")
     for dest, hops in ipHops:
-      var route = newSeq[string]()
+      var
+        route = newSeq[string]()
+        anyIp = false
       for ttl in countup(1, hops):
         let ip = tryGetIpForTTL(parseIpAddress(dest), ttl = ttl)
         if ip.isSome():
           route.add($(ip.get()))
+          anyIp = true
         else:
           # ensure route list has all hops even if we could not detect intermediate IP
           route.add("")
-      if len(route) > 0:
+      if anyIp:
         data[dest] = route
   return pack(data)
 

--- a/src/plugins/network.nim
+++ b/src/plugins/network.nim
@@ -1,0 +1,35 @@
+##
+## Copyright (c) 2024, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+import std/[net]
+import ".."/[config, plugin_api, pingttl]
+
+proc getTtlIps(): Box =
+  var data = newTable[string, TableRef[string, string]]()
+  # pingttl is only implemented for linux
+  when hostOs == "linux":
+    let ipTTLs = attrGet[TableRef[string, seq[string]]]("network.partial_traceroute_ips")
+    for dest, ttls in ipTTLs:
+      var route = newTable[string, string]()
+      for t in ttls:
+        let ttl = parseInt(t)
+        let ip  = tryGetIpForTTL(parseIpAddress(dest), ttl = ttl)
+        if ip.isSome():
+          route[t] = $(ip.get())
+      if len(route) > 0:
+        data[dest] = route
+  return pack(data)
+
+proc networkGetRunTimeHostInfo*(self: Plugin,
+                                objs: seq[ChalkObj]):
+                               ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  result.setIfNeeded("_NETWORK_PARTIAL_TRACEROUTE_IPS", getTtlIps())
+
+proc loadNetwork*() =
+  newPlugin("network",
+            rtHostCallback = RunTimeHostCb(networkGetRunTimeHostInfo))

--- a/tests/functional/Dockerfile
+++ b/tests/functional/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --no-cache \
     curl \
     gdb \
     git \
-    gpg
+    gpg \
+    strace
 
 RUN if uname -m | grep -Ei "arm|aarch"; then \
     apk add --no-cache \
@@ -39,6 +40,7 @@ RUN apt-get update -y && \
         gettext-base \
         git \
         gpg \
+        strace \
         && \
     apt-get clean -y
 

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -28,6 +28,20 @@ from .utils.tmp import make_tmp_file
 logger = get_logger()
 
 
+@pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
+def test_network(copy_files: list[Path], chalk: Chalk):
+    bin_path = copy_files[0]
+    insert = chalk.insert(bin_path)
+    assert insert.report.has(
+        _NETWORK_PARTIAL_TRACEROUTE_IPS={
+            "1.1.1.1": {
+                "1": ANY,
+                "2": ANY,
+            },
+        },
+    )
+
+
 def test_codeowners(tmp_data_dir: Path, chalk: Chalk):
     folder = CODEOWNERS / "raw1"
     expected_owners = (folder / "CODEOWNERS").read_text()

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -36,7 +36,8 @@ def test_network(copy_files: list[Path], chalk: Chalk):
         _NETWORK_PARTIAL_TRACEROUTE_IPS={
             "1.1.1.1": {
                 "1": ANY,
-                "2": ANY,
+                # github runners subnet blocks icmp so
+                # we never get a response for TTL>1
             },
         },
     )

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -34,11 +34,8 @@ def test_network(copy_files: list[Path], chalk: Chalk):
     insert = chalk.insert(bin_path)
     assert insert.report.has(
         _NETWORK_PARTIAL_TRACEROUTE_IPS={
-            "1.1.1.1": {
-                "1": ANY,
-                # github runners subnet blocks icmp so
-                # we never get a response for TTL>1
-            },
+            # by default traceroute is for 2 hops
+            "1.1.1.1": [ANY, ANY],
         },
     )
 

--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -26,3 +26,6 @@ if not env_exists("VENDOR") {
 tool.syft.syft_container = "ghcr.io/anchore/syft"
 # unfortunately semgrep does not publish to ghcr
 # https://github.com/semgrep/semgrep/issues/9169
+
+# sometimes CI tests need longer TTL to get ICMP error back
+network.partial_traceroute_timeout_ms = 100


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

get some metadata when imds ip endpoint cannot be reached

## Description

This will allow to get transient IP addresses along the NAT route so that we can fetch intermediate IPs from within docker containers which might not be accessible otherwise. For example it can be used to get the subnet gateway IP which is not otherwise available as within the docker container unless its running with host networking chalk can only get the docker network private IP address. This should be useful in figuring out where within the network container is running.

## TODO

- [x] this works outside of chalk however some linux headers cannot be resolved inside chalk
- [x] this depends on linux data-structs so this should be only compiled for linux, not mac
- [x] tests

## Tests

```
➜ make tests args="test_plugins.py::test_network --logs"
```