### PR TITLE
feat: report relative path of Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   subnet IPs even when running inside docker network-namespaced
   (not using `--network=host`) container
   ([#425](https://github.com/crashappsec/chalk/pull/425))
+- `DOCKERFILE_PATH_WITHIN_VCTL` key reports the path of a
+  `Dockerfile` relative to the VCS' project root.
+  ([#426](https://github.com/crashappsec/chalk/pull/426))
 
 ## 0.4.12
 

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1640,6 +1640,22 @@ Platform passed when performing `docker build`, if any.
 """
 }
 
+keyspec DOCKERFILE_PATH_WITHIN_VCTL {
+    kind:             ChalkTimeArtifact
+    type:             string
+    standard:         true
+    system:           false
+    since:            "0.4.13"
+    shortdoc:         "Relative path of the Dockerfile to the VCS' root."
+    doc:              """
+The path of the Dockerfile used during `docker build` relative to the version
+control system's project root. Defaults to an empty string in the case of:
+
+* Dockerfile content was passed from `stdin` or process substitution
+* the relative path is outside the project (e.g., `../../Dockerfile`)
+"""
+}
+
 keyspec DOCKER_PLATFORM {
     kind:             ChalkTimeArtifact
     type:             string

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -521,8 +521,8 @@ plugin docker {
     enabled:  true
     pre_chalk_keys: ["ARTIFACT_TYPE",
                      "DOCKER_FILE", "DOCKER_FILE_CHALKED", "DOCKERFILE_PATH",
-                     "DOCKER_PLATFORM", "DOCKER_PLATFORMS",
-                     "DOCKER_LABELS", "DOCKER_TAGS",
+                     "DOCKERFILE_PATH_WITHIN_VCTL", "DOCKER_PLATFORM",
+                     "DOCKER_PLATFORMS", "DOCKER_LABELS", "DOCKER_TAGS",
                      "DOCKER_BASE_IMAGE", "DOCKER_BASE_IMAGE_REPO",
                      "DOCKER_BASE_IMAGE_TAG", "DOCKER_BASE_IMAGE_DIGEST",
                      "DOCKER_CONTEXT", "DOCKER_ADDITIONAL_CONTEXTS",

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -116,6 +116,7 @@ report and subtract from it.
   key.DOCKER_FILE.use                         = true
   key.DOCKER_FILE_CHALKED.use                 = true
   key.DOCKERFILE_PATH.use                     = true
+  key.DOCKERFILE_PATH_WITHIN_VCTL.use         = true
   key.DOCKER_PLATFORM.use                     = true
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true
@@ -695,6 +696,7 @@ doc: """
   key.DOCKER_FILE.use                         = true
   key.DOCKER_FILE_CHALKED.use                 = true
   key.DOCKERFILE_PATH.use                     = true
+  key.DOCKERFILE_PATH_WITHIN_VCTL.use         = true
   key.DOCKER_PLATFORM.use                     = true
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true
@@ -1159,6 +1161,7 @@ container.
   key.DOCKER_FILE.use                         = true
   key.DOCKER_FILE_CHALKED.use                 = true
   key.DOCKERFILE_PATH.use                     = true
+  key.DOCKERFILE_PATH_WITHIN_VCTL.use         = true
   key.DOCKER_PLATFORM.use                     = true
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true
@@ -1623,6 +1626,7 @@ and keep the run-time key.
   key.DOCKER_FILE.use                         = true
   key.DOCKER_FILE_CHALKED.use                 = true
   key.DOCKERFILE_PATH.use                     = true
+  key.DOCKERFILE_PATH_WITHIN_VCTL.use         = true
   key.DOCKER_PLATFORM.use                     = true
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true
@@ -1963,6 +1967,7 @@ running insert commands.
   key.DOCKER_FILE.use                         = true
   key.DOCKER_FILE_CHALKED.use                 = true
   key.DOCKERFILE_PATH.use                     = true
+  key.DOCKERFILE_PATH_WITHIN_VCTL.use         = true
   key.DOCKER_PLATFORM.use                     = true
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true
@@ -2047,6 +2052,7 @@ running commands that do NOT insert chalk marks.
   key.DOCKER_FILE.use                         = true
   key.DOCKER_FILE_CHALKED.use                 = true
   key.DOCKERFILE_PATH.use                     = true
+  key.DOCKERFILE_PATH_WITHIN_VCTL.use         = true
   key.DOCKER_PLATFORM.use                     = true
   key.DOCKER_PLATFORMS.use                    = true
   key.DOCKER_LABELS.use                       = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -230,6 +230,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.DOCKER_FILE.use                         = true
   ~key.DOCKER_FILE_CHALKED.use                 = true
   ~key.DOCKERFILE_PATH.use                     = true
+  ~key.DOCKERFILE_PATH_WITHIN_VCTL.use         = true
   ~key.DOCKER_PLATFORM.use                     = true
   ~key.DOCKER_PLATFORMS.use                    = true
   ~key.DOCKER_LABELS.use                       = true

--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -792,15 +792,14 @@ proc isInRepo(obj: ChalkObj, repo: string): bool =
 
   return false
 
-proc gitInit(self: Plugin): Plugin =
+proc gitInit(self: Plugin) =
   once:
     let cache = GitInfo(self.internalState)
     for path in getContextDirectories():
       cache.findAndLoad(path.resolvePath())
-  return self
 
 proc gitFirstDir*(self: Plugin): string =
-  discard self.gitInit()
+  self.gitInit()
   let cache = GitInfo(self.internalState)
   for dir, _ in cache.vcsDirs:
     return dir
@@ -808,7 +807,7 @@ proc gitFirstDir*(self: Plugin): string =
 
 proc gitGetChalkTimeArtifactInfo(self: Plugin, obj: ChalkObj):
                                 ChalkDict {.cdecl.} =
-  discard self.gitInit()
+  self.gitInit()
 
   result    = ChalkDict()
   let cache = GitInfo(self.internalState)
@@ -828,7 +827,7 @@ proc gitGetChalkTimeArtifactInfo(self: Plugin, obj: ChalkObj):
 
 proc gitGetRunTimeHostInfo(self: Plugin, chalks: seq[ChalkObj]):
                            ChalkDict {.cdecl.} =
-  discard self.gitInit()
+  self.gitInit()
 
   result = ChalkDict()
   let cache = GitInfo(self.internalState)

--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -792,16 +792,23 @@ proc isInRepo(obj: ChalkObj, repo: string): bool =
 
   return false
 
-proc gitInit(self: Plugin) =
-  let cache = GitInfo(self.internalState)
+proc gitInit(self: Plugin): Plugin =
+  once:
+    let cache = GitInfo(self.internalState)
+    for path in getContextDirectories():
+      cache.findAndLoad(path.resolvePath())
+  return self
 
-  for path in getContextDirectories():
-    cache.findAndLoad(path.resolvePath())
+proc gitFirstDir*(self: Plugin): string =
+  discard self.gitInit()
+  let cache = GitInfo(self.internalState)
+  for dir, _ in cache.vcsDirs:
+    return dir
+  raise newException(ValueError, "no git folder in any of the contexts")
 
 proc gitGetChalkTimeArtifactInfo(self: Plugin, obj: ChalkObj):
                                 ChalkDict {.cdecl.} =
-  once:
-    self.gitInit()
+  discard self.gitInit()
 
   result    = ChalkDict()
   let cache = GitInfo(self.internalState)
@@ -821,8 +828,7 @@ proc gitGetChalkTimeArtifactInfo(self: Plugin, obj: ChalkObj):
 
 proc gitGetRunTimeHostInfo(self: Plugin, chalks: seq[ChalkObj]):
                            ChalkDict {.cdecl.} =
-  once:
-    self.gitInit()
+  discard self.gitInit()
 
   result = ChalkDict()
   let cache = GitInfo(self.internalState)

--- a/src/util.nim
+++ b/src/util.nim
@@ -617,3 +617,12 @@ proc getOrDefault*[T](self: openArray[T], i: int, default: T): T =
   if len(self) > i:
     return self[i]
   return default
+
+proc getRelativePathBetween*(fromPath: string, toPath: string) : string =
+  ## Given the `fromPath`, usually the project root, return the relative
+  ## path of the file's `toPath`. Return nothing if its outside the project root
+  ## or if `toPath` is an empty string.
+  result = toPath.relativePath(fromPath)
+  if result.startsWith("..") or result == "":
+    trace("File is ephemeral or not contained within VCS project")
+    return ""

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -28,6 +28,7 @@ from .conf import (
     DOCKER_TOKEN_REPO,
     MARKS,
     REGISTRY,
+    ROOT,
 )
 from .utils.dict import ANY, MISSING, Contains
 from .utils.docker import Docker
@@ -716,6 +717,9 @@ def test_virtual_valid(
             "_IMAGE_ID": image_hash,
             "_REPO_TAGS": Contains({f"{tag}:latest"}),
             "DOCKERFILE_PATH": str(dockerfile),
+            "DOCKERFILE_PATH_WITHIN_VCTL": str(
+                dockerfile.relative_to(ROOT.parent.parent)
+            ),
             # docker tags should be set to tag above
             "DOCKER_TAGS": Contains({f"{tag}:latest"}),
         },
@@ -775,8 +779,9 @@ def test_virtual_invalid(
 )
 def test_nonvirtual_valid(chalk: Chalk, test_file: str, random_hex: str):
     tag = f"{test_file}_{random_hex}"
+    dockerfile = DOCKERFILES / test_file / "Dockerfile"
     image_hash, build = chalk.docker_build(
-        dockerfile=DOCKERFILES / test_file / "Dockerfile",
+        dockerfile=dockerfile,
         tag=tag,
         config=CONFIGS / "docker_wrap.c4m",
     )
@@ -790,6 +795,9 @@ def test_nonvirtual_valid(chalk: Chalk, test_file: str, random_hex: str):
             "_IMAGE_ID": image_hash,
             "_REPO_TAGS": Contains({f"{tag}:latest"}),
             "DOCKERFILE_PATH": str(DOCKERFILES / test_file / "Dockerfile"),
+            "DOCKERFILE_PATH_WITHIN_VCTL": str(
+                dockerfile.relative_to(ROOT.parent.parent)
+            ),
             # docker tags should be set to tag above
             "DOCKER_TAGS": Contains({f"{tag}:latest"}),
         },


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

Provides the `DOCKERFILE_PATH_WITHIN_VCTL` chalk key with the relative path of the Dockerfile to the version control system's project root. If that path is outside the project or the Dockerfile was provided via `stdin`, the key is omitted.

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

## Testing
Run relevant tests with:

```bash
make tests args="test_docker.py"
```

<!-- What are the steps needed to test this PR? -->
