### PR TITLE
build(common): switch cosign registry from GCR to GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/crashappsec/nim:ubuntu-2.0.8 as nim
-FROM gcr.io/projectsigstore/cosign:v2.2.3 as cosign
+FROM ghcr.io/sigstore/cosign/cosign:v2.2.3 as cosign
 
 # -------------------------------------------------------------------
 

--- a/tests/functional/Dockerfile
+++ b/tests/functional/Dockerfile
@@ -8,7 +8,7 @@ ARG POETRY_VERSION=1.5.1
 
 FROM docker:$DOCKER_VERSION as docker
 FROM docker/buildx-bin:$BUILDX_VERSION as buildx
-FROM gcr.io/projectsigstore/cosign:v$COSIGN_VERSION as cosign
+FROM ghcr.io/sigstore/cosign/cosign:v$COSIGN_VERSION as cosign
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description
This changes the Dockerfile to pull the cosign container image from GHCR instead of Google Cloud. This helps the Sigstore team manage their cloud spend (as GHCR is provided for free and Google Cloud Artifact Registry is not).

Note the container hash does not change and images are posted to both locations upon cosign's release process.

## Testing

<!-- What are the steps needed to test this PR? -->
