### PR TITLE
feat: adding docker registry mirrors support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,6 +222,22 @@ services:
       start_period: 30s
       interval: 1s
 
+  registry-proxy:
+    image: registry:2
+    ports:
+      - "5047:5047"
+    environment:
+      - REGISTRY_HTTP_ADDR=0.0.0.0:5047
+      - REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io
+    networks:
+      - chalk
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - sh -c "echo 'GET / HTTP/1.1' | nc -v localhost 5047"
+      start_period: 30s
+      interval: 1s
+
   sqlite:
     image: coleifer/sqlite-web
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,8 @@ services:
         condition: service_healthy
       registry-tls-insecure:
         condition: service_healthy
+      registry-proxy:
+        condition: service_healthy
       server:
         condition: service_healthy
       server-tls:

--- a/src/docker/ids.nim
+++ b/src/docker/ids.nim
@@ -293,9 +293,12 @@ proc withRegistry*(self: DockerImage, registry: string): DockerImage =
   if registry == "":
     return self
   # parseUri doesnt parse uri without any scheme
-  let normalized = self.normalize()
-  var uri        = parseUri("https://" & normalized.repo)
-  uri.hostname   = registry
+  let
+    normalized = self.normalize()
+    parsed     = parseUri("https://" & registry)
+  var uri      = parseUri("https://" & normalized.repo)
+  uri.hostname = parsed.hostname
+  uri.port     = parsed.port
   let repo = ($uri).removePrefix("https://")
   result = (
     repo,

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -11,7 +11,7 @@
 ## https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file
 ## https://docs.docker.com/build/buildkit/toml-configuration/
 
-import std/[net, uri, httpclient, nativesockets]
+import std/[net, uri, httpclient, nativesockets, sets]
 import pkg/nimutils/net
 import ".."/[config, ip, util, www_authenticate]
 import "."/[exe, json, ids]
@@ -50,6 +50,14 @@ const
     "application/vnd.oci.image.manifest.v1+json": DockerManifestType.image,
     "application/vnd.oci.image.config.v1+json": DockerManifestType.config,
   }.toTable()
+
+iterator uses(use: RegistryUse): RegistryUse =
+  ## which uses lookups are applicable for the registry use
+  ## ReadOnly use can only be used for reads
+  ## however ReadWrite use can be used for both
+  yield use
+  if use == RegistryUse.ReadWrite:
+    yield RegistryUse.ReadOnly
 
 proc withBasicAuth(self: RegistryConfig, token: string): RegistryConfig =
   if token != "":
@@ -189,46 +197,121 @@ iterator iterDaemonRegistryConfigs(self: DockerImage, use: RegistryUse): Registr
   for i in self.iterDaemonSpecificRegistryConfigs():
     yield i
 
+proc findRegistry(self: JsonNode, registry: string): JsonNode =
+  for r in registry.registryAliases():
+    if r in self{"registry"}:
+      return self["registry"][r]
+  return nil
+
+iterator iterBuildxSpecificRegistryConfigs(self:         DockerImage,
+                                           node:         string,
+                                           config:       JsonNode,
+                                           project     = "",
+                                           fallthrough = false): RegistryConfig =
+  let registry = config.findRegistry(self.registry)
+  if registry != nil:
+    let
+      http     = registry{"http"}{"value"}.getStr()
+      insecure = registry{"insecure"}{"value"}.getStr()
+      certs    = registry{"ca"}{"value"}
+    if insecure != "true" and http != "true":
+      yield RegistryConfig(
+        scheme:      "https://",
+        registry:    self.registry,
+        project:     project,
+        verifyMode:  CVerifyPeer,
+        fallthrough: fallthrough,
+      )
+    if certs != nil and certs.kind == JArray:
+      for cert in certs:
+        let path = cert{"value"}.getStr()
+        try:
+          let data = dockerInvocation.readBuilderNodeFile(node, path)
+          trace("docker: found CA certificate for " & self.registry & " at " & path & " in buildx node " & node)
+          yield RegistryConfig(
+            scheme:      "https://",
+            registry:    self.registry,
+            project:     project,
+            verifyMode:  CVerifyPeer,
+            fallthrough: fallthrough,
+            certPath:    path,
+            pinnedCert:  writeNewTempFile(
+              data,
+              prefix = self.domain,
+              suffix = ".crt",
+            ),
+          )
+        except:
+          trace("docker: cannot read buildx registry CA from " & path & " in buildx node " & node)
+          continue
+    if insecure == "true":
+      trace("docker: " & self.registry & " is configured as an insecure registry in docker buildx node " & node)
+      yield RegistryConfig(
+        scheme:      "https://",
+        registry:    self.registry,
+        project:     project,
+        verifyMode:  CVerifyNone,
+        fallthrough: fallthrough,
+      )
+    if http == "true":
+      trace("docker: " & self.registry & " is configured as an http registry in docker buildx node " & node)
+      yield RegistryConfig(
+        scheme:      "http://",
+        registry:    self.registry,
+        project:     project,
+        verifyMode:  CVerifyNone,
+        fallthrough: fallthrough,
+      )
+
 iterator iterBuildxRegistryConfigs(self: DockerImage, use: RegistryUse): RegistryConfig =
-  # TODO this should be compatible outside of build commands
-  # where docker daemon takes precedence
   if hasBuildx():
-    # TODO should consult mirror
-    yield RegistryConfig(scheme: "https://", verifyMode: CVerifyPeer)
-    for node, config in dockerInvocation.iterBuilderNodesConfigs():
-      if self.registry notin config{"registry"}:
-        continue
-      try:
-        let
-          registry = config["registry"][self.registry]
-          http     = registry{"http"}{"value"}.getStr()
-          insecure = registry{"insecure"}{"value"}.getStr()
-          certs    = registry{"ca"}{"value"}
-        if certs != nil and certs.kind == JArray:
-          for cert in certs:
-            let path = cert{"value"}.getStr()
-            try:
-              let data = dockerInvocation.readBuilderNodeFile(node, path)
-              trace("docker: found CA certificate for " & self.registry & " at " & path & " in buildx node " & node)
-              yield RegistryConfig(
-                scheme:     "https://",
-                verifyMode: CVerifyPeer,
-                certPath:   path,
-                pinnedCert: writeNewTempFile(
-                  data,
-                  prefix = self.domain,
-                  suffix = ".crt",
-                ),
-              )
-            except:
-              trace("docker: cannot read buildx registry CA from " & path & " in buildx node " & node)
+    if use == RegistryUse.ReadOnly:
+      for node, config in dockerInvocation.iterBuilderNodesConfigs():
+        try:
+          let rconfig = config.findRegistry(self.registry)
+          if rconfig == nil:
+            continue
+          let mirrors  = rconfig{"mirrors"}{"value"}
+          if mirrors == nil or mirrors.kind != JArray:
+            continue
+          for m in mirrors:
+            let mirror = m{"value"}.getStr()
+            trace("docker: for registry " & self.registry & " attempting to use mirror: " & mirror)
+            let
+              mirrorUri = parseUri("https://" & mirror)
+              registry  = mirrorUri.registry
+              project   = mirrorUri.path
+              mirrored  = self.withRegistry(registry)
+            # mirror is to the same thing. skip
+            if registry == self.registry:
+              trace("docker: mirror is to itself. skipping")
               continue
-        if insecure == "true":
-          trace("docker: " & self.registry & " is configured as an insecure registry in docker buildx node " & node)
-          yield RegistryConfig(scheme: "https://", verifyMode: CVerifyNone)
-        if http == "true":
-          trace("docker: " & self.registry & " is configured as an http registry in docker buildx node " & node)
-          yield RegistryConfig(scheme: "http://", verifyMode: CVerifyNone)
+            try:
+              for i in mirrored.iterBuildxSpecificRegistryConfigs(
+                node,
+                config,
+                project     = project,
+                fallthrough = true,
+              ):
+                yield i
+            except:
+              trace("docker: cannot inspect buildx mirror " & mirror & " config due to: " & getCurrentExceptionMsg())
+              continue
+        except:
+          trace("docker: cannot inspect buildx mirror config due to: " & getCurrentExceptionMsg())
+          continue
+
+    # try most secure config just in case it works
+    # to avoid parsing configs when use is readwrite
+    yield RegistryConfig(
+      scheme:      "https://",
+      registry:    self.registry,
+      verifyMode:  CVerifyPeer,
+    )
+    for node, config in dockerInvocation.iterBuilderNodesConfigs():
+      try:
+        for i in self.iterBuildxSpecificRegistryConfigs(node, config):
+          yield i
       except:
         trace("docker: cannot inspect buildx config due to: " & getCurrentExceptionMsg())
         continue
@@ -294,9 +377,10 @@ proc request(self:       DockerImage,
              ): (string, Response) =
   for config in self.getConfigs(use = use):
     let uri = self.withRegistry(config.registry).uri(
-      scheme = config.scheme,
-      prefix = config.prefix,
-      path   = path,
+      scheme  = config.scheme,
+      prefix  = config.prefix,
+      project = config.project,
+      path    = path,
     )
     var msg = $httpMethod & " " & $uri
     if uri.scheme == "https":
@@ -327,11 +411,14 @@ proc request(self:       DockerImage,
       # hence we need to fallthrough to the next config
       invalid = not config.fallthrough
       discard response.check(url = uri, only2xx = true)
-      configByRegistry[(use, self.registry)] = config
+      for u in use.uses():
+        configByRegistry[(u, self.registry)] = config
       return (msg, response)
     except:
       if invalid:
         raise newException(RegistryResponseError, getCurrentExceptionMsg())
+      else:
+        trace("docker: ignoring error: " & getCurrentExceptionMsg())
   raise newException(ValueError, "could not find working registry configuration for " & $self)
 
 proc manifestHead*(image: DockerImage,

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -23,7 +23,7 @@ type
   # for read-only docker can consult mirrors
   # whereas if it indents to write to the registry,
   # it only talks to the upstream registry
-  RegistryUse = enum
+  RegistryUse* = enum
     ReadWrite
     ReadOnly # allows use of mirrors
 
@@ -31,6 +31,7 @@ type
     scheme*:      string
     registry*:    string
     prefix*:      string
+    project*:     string
     certPath*:    string
     pinnedCert*:  string
     verifyMode*:  SslCVerifyMode

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -19,12 +19,22 @@ import "."/[exe, json, ids]
 type
   RegistryResponseError* = object of ValueError
 
+  # depending on use, mirror is allowed to be used or not
+  # for read-only docker can consult mirrors
+  # whereas if it indents to write to the registry,
+  # it only talks to the upstream registry
+  RegistryUse = enum
+    ReadWrite
+    ReadOnly # allows use of mirrors
+
   RegistryConfig = ref object
-    scheme*:     string
-    certPath*:   string
-    pinnedCert*: string
-    verifyMode*: SslCVerifyMode
-    auth*:       HttpHeaders
+    scheme*:      string
+    registry*:    string
+    certPath*:    string
+    pinnedCert*:  string
+    verifyMode*:  SslCVerifyMode
+    auth*:        HttpHeaders
+    fallthrough*: bool # whether to fallthrough to next config on http errors
 
 const
   TIMEOUT = 3000 # sec
@@ -48,7 +58,16 @@ proc withBasicAuth(self: RegistryConfig, token: string): RegistryConfig =
     self.auth = newHttpHeaders()
   return self
 
-iterator iterDaemonRegistryConfigs(self: DockerImage): RegistryConfig =
+iterator iterDaemonSpecificRegistryConfigs(self:         DockerImage,
+                                           withHttp    = true,
+                                           fallthrough = false): RegistryConfig =
+  yield RegistryConfig(
+    scheme:      "https://",
+    registry:    self.registry,
+    verifyMode:  CVerifyPeer,
+    fallthrough: fallthrough,
+  )
+
   var (path, cert) =
     try:
       readFirstDockerHostFile(@[
@@ -60,25 +79,35 @@ iterator iterDaemonRegistryConfigs(self: DockerImage): RegistryConfig =
   if cert != "":
     trace("docker: found CA certificate for " & self.registry & " at " & path & " in docker daemon")
     yield RegistryConfig(
-      scheme:     "https://",
-      verifyMode: CVerifyPeer,
-      certPath:   path,
-      pinnedCert: writeNewTempFile(
+      scheme:      "https://",
+      registry:    self.registry,
+      verifyMode:  CVerifyPeer,
+      fallthrough: fallthrough,
+      certPath:    path,
+      pinnedCert:  writeNewTempFile(
         cert,
         prefix = self.domain,
         suffix = ".crt",
       ),
     )
 
-  template yieldInsecure() =
-    trace("docker: " & self.registry & " will attempt TLS without verifying server cert")
-    yield RegistryConfig(scheme: "https://", verifyMode: CVerifyNone)
-    yield RegistryConfig(scheme: "http://", verifyMode: CVerifyNone)
-
   for i in getDockerInfoSubList("insecure registries:"):
     if self.registry == i or self.domain == i:
       trace("docker: " & i & " is configured as an insecure registry in docker daemon")
-      yieldInsecure()
+      trace("docker: " & self.registry & " will attempt TLS without verifying server cert")
+      yield RegistryConfig(
+        scheme:      "https://",
+        registry:    self.registry,
+        verifyMode:  CVerifyNone,
+        fallthrough: fallthrough,
+      )
+      if withHttp:
+        yield RegistryConfig(
+          scheme:      "http://",
+          registry:    self.registry,
+          verifyMode:  CVerifyNone,
+          fallthrough: fallthrough,
+        )
     else:
       # docker does not support port numbers along with cidr blocks
       # so 127.0.0.0/8 cannot be combined with a port number
@@ -101,14 +130,61 @@ iterator iterDaemonRegistryConfigs(self: DockerImage): RegistryConfig =
           continue
         if selfIp in ipRange:
           trace("docker: " & self.domain & " (" & $selfIp & ") is an insecure registry via IP address match for " & i)
-          yieldInsecure()
+          trace("docker: " & self.registry & " will attempt TLS without verifying server cert")
+          yield RegistryConfig(
+            scheme:      "https://",
+            registry:    self.registry,
+            verifyMode:  CVerifyNone,
+            fallthrough: fallthrough,
+          )
+          if withHttp:
+            yield RegistryConfig(
+              scheme:      "http://",
+              registry:    self.registry,
+              verifyMode:  CVerifyNone,
+              fallthrough: fallthrough,
+            )
       except:
         continue
 
-iterator iterBuildxRegistryConfigs(self: DockerImage): RegistryConfig =
+iterator iterDaemonRegistryConfigs(self: DockerImage, use: RegistryUse): RegistryConfig =
+  # docker daemon only suports docker hub mirror
+  if use == RegistryUse.ReadOnly and self.isDockerHub():
+    for mirror in getDockerInfoSubList("registry mirrors:"):
+      trace("docker: attempting to use docker hub mirror: " & mirror)
+      let
+        mirrorUri = parseUri(mirror)
+        domain = mirrorUri.hostname
+        registry =
+          if mirrorUri.port == "":
+            domain
+          else:
+            domain & ":" & mirrorUri.port
+        mirrored = self.withRegistry(registry)
+      # mirror is to the same thing. skip
+      if registry == self.registry:
+        trace("docker: mirror is using docker hub itself. skipping")
+        continue
+      if mirrorUri.scheme == "https":
+        for i in mirrored.iterDaemonSpecificRegistryConfigs(withHttp = false, fallthrough = true):
+          yield i
+      else:
+        yield RegistryConfig(
+          scheme:      "http://",
+          registry:    registry,
+          verifyMode:  CVerifyNone,
+          fallthrough: true,
+        )
+
+  for i in self.iterDaemonSpecificRegistryConfigs():
+    yield i
+
+iterator iterBuildxRegistryConfigs(self: DockerImage, use: RegistryUse): RegistryConfig =
   # TODO this should be compatible outside of build commands
   # where docker daemon takes precedence
   if hasBuildx():
+    # TODO should consult mirror
+    yield RegistryConfig(scheme: "https://", verifyMode: CVerifyPeer)
     for node, config in dockerInvocation.iterBuilderNodesConfigs():
       if self.registry notin config{"registry"}:
         continue
@@ -157,8 +233,8 @@ proc getBasicAuth(self: DockerImage): string =
     trace("docker: invalid auth config: " & getCurrentExceptionMsg())
     return ""
 
-var configByRegistry = initTable[string, RegistryConfig]()
-iterator getConfigs(self: DockerImage): RegistryConfig =
+var configByRegistry = initTable[(RegistryUse, string), RegistryConfig]()
+iterator getConfigs(self: DockerImage, use: RegistryUse): RegistryConfig =
   ## get all plausible configs for iteracting with the registry
   ## note this is explicitly implemented as an iterator
   ## as getting specific config can be more expensive as it might
@@ -166,8 +242,8 @@ iterator getConfigs(self: DockerImage): RegistryConfig =
   ## and iterators allow to make that lazy where if a config attempt
   ## fails, only then next config is fetched until a working config
   ## is found
-  if self.registry in configByRegistry:
-    yield configByRegistry[self.registry]
+  if (use, self.registry) in configByRegistry:
+    yield configByRegistry[(use, self.registry)]
 
   else:
     # find basic auth from docker config file
@@ -177,21 +253,13 @@ iterator getConfigs(self: DockerImage): RegistryConfig =
     # nodex they might all have equivalent configs
     var checkedConfigs = newSeq[RegistryConfig]()
 
-    # always attempt to talk to registry via https first
-    # which will bypass parsing all daemon/buildx configs/etc
-    # plus in most production flows this should be most common case
-    trace("docker: attempting secure registry config for " & self.registry)
-    let https = RegistryConfig(scheme: "https://", verifyMode: CVerifyPeer).withBasicAuth(token)
-    checkedConfigs.add(https)
-    yield https
-
     let isBuildx = (
       dockerInvocation != nil and
       dockerInvocation.cmd == build and
       dockerInvocation.foundBuildx
     )
     template buildx() =
-      for i in self.iterBuildxRegistryConfigs():
+      for i in self.iterBuildxRegistryConfigs(use = use):
         if i notin checkedConfigs:
           let i = i.withBasicAuth(token)
           checkedConfigs.add(i)
@@ -200,7 +268,7 @@ iterator getConfigs(self: DockerImage): RegistryConfig =
     # over daemon configs but we still scan both just in case
     if isBuildx:
       buildx()
-    for i in self.iterDaemonRegistryConfigs():
+    for i in self.iterDaemonRegistryConfigs(use = use):
       if i notin checkedConfigs:
         let i = i.withBasicAuth(token)
         checkedConfigs.add(i)
@@ -208,12 +276,14 @@ iterator getConfigs(self: DockerImage): RegistryConfig =
     if not isBuildx:
       buildx()
 
-proc request(self: DockerImage,
+proc request(self:       DockerImage,
              httpMethod: HttpMethod,
-             path: string,
-             accept: string): (string, Response) =
-  for config in self.getConfigs():
-    let uri = self.uri(scheme = config.scheme, path = path)
+             path:       string,
+             accept:     string,
+             use =       RegistryUse.ReadOnly,
+             ): (string, Response) =
+  for config in self.getConfigs(use = use):
+    let uri = self.withRegistry(config.registry).uri(scheme = config.scheme, path = path)
     var msg = $httpMethod & " " & $uri
     if uri.scheme == "https":
       msg &= " " & $config.verifyMode
@@ -233,21 +303,29 @@ proc request(self: DockerImage,
         timeout    = TIMEOUT,
         retries    = 2,
       )
+      # for non-mirror registry:
       # as we can talk to the registry, any errors from this point on
       # mean image doesnt exist in the registry or invalid config such as
       # invalid auth which we cant improve even if we attempt other configs
-      invalid = true
+      # for mirror registry:
+      # as mirror might be missing the image, on 404s docker reattempts
+      # to fetch the image from upstream registry bypassing the mirror
+      # hence we need to fallthrough to the next config
+      invalid = not config.fallthrough
       discard response.check(url = uri, only2xx = true)
-      configByRegistry[self.registry] = config
+      configByRegistry[(use, self.registry)] = config
       return (msg, response)
     except:
       if invalid:
         raise newException(RegistryResponseError, getCurrentExceptionMsg())
   raise newException(ValueError, "could not find working registry configuration for " & $self)
 
-proc manifestHead*(image: DockerImage): DockerDigestedJson =
+proc manifestHead*(image: DockerImage,
+                   use =  RegistryUse.ReadOnly,
+                   ): DockerDigestedJson =
   let
     (msg, response) = image.request(
+      use        = use,
       httpMethod = HttpHead,
       path       = "/manifests/" & image.imageRef,
       accept     = (
@@ -269,20 +347,28 @@ proc manifestHead*(image: DockerImage): DockerDigestedJson =
   let kind = CONTENT_TYPE_MAPPING[contentType]
   return newDockerDigestedJson("{}", digest, contentType, kind)
 
-proc manifestGet*(image: DockerImage, accept: string): DockerDigestedJson =
+proc manifestGet*(image:  DockerImage,
+                  accept: string,
+                  use =   RegistryUse.ReadOnly,
+                  ): DockerDigestedJson =
   let
     kind          = CONTENT_TYPE_MAPPING[accept]
     (_, response) = image.request(
+      use        = use,
       httpMethod = HttpGet,
       path       = "/manifests/" & image.imageRef,
       accept     = accept,
     )
   return newDockerDigestedJson(response.body(), image.imageRef, accept, kind)
 
-proc layerGet*(image: DockerImage, accept: string): DockerDigestedJson =
+proc layerGet*(image:  DockerImage,
+               accept: string,
+               use =   RegistryUse.ReadOnly,
+               ): DockerDigestedJson =
   let
     kind          = CONTENT_TYPE_MAPPING[accept]
     (_, response) = image.request(
+      use        = use,
       httpMethod = HttpGet,
       path       = "/blobs/" & image.imageRef,
       accept     = accept,

--- a/src/util.nim
+++ b/src/util.nim
@@ -512,7 +512,7 @@ proc rSplitBy*(s: string, sep: string, default: string = ""): (string, string) =
     return (parts[0], parts[1])
   return (s, default)
 
-proc removeSuffix*(s: string, suffix: string): string =
+proc removeSuffix*(s: string, suffix: string | char): string =
   # similar to strutil except it returns result back
   # vs in-place removal in stdlib
   result = s

--- a/tests/functional/conf.py
+++ b/tests/functional/conf.py
@@ -45,6 +45,7 @@ BASE_OUTCONF = ROOT.parent.parent / "src" / "configs" / "base_outconf.c4m"
 REGISTRY = f"{os.environ.get('IP') or 'localhost'}:5044"
 REGISTRY_TLS = f"{os.environ.get('IP') or 'localhost'}:5045"
 REGISTRY_TLS_INSECURE = f"{os.environ.get('IP') or 'localhost'}:5046"
+REGISTRY_PROXY = f"{os.environ.get('IP') or 'localhost'}:5047"
 
 SERVER_CHALKDUST = "https://chalkdust.io"
 SERVER_IMDS = "http://169.254.169.254"

--- a/tests/functional/data/templates/docker/buildkitd.toml
+++ b/tests/functional/data/templates/docker/buildkitd.toml
@@ -1,4 +1,6 @@
 debug = true
+[registry."docker.io"]
+  mirrors = ["${IP}:5047/foo", "${IP}:5047"]
 [registry."localhost:5044"]
   http = true
 [registry."registry:5044"]
@@ -9,3 +11,5 @@ debug = true
   ca=["/etc/docker/certs.d/${IP}:5045/ca.crt"]
 [registry."${IP}:5046"]
   insecure = true
+[registry."${IP}:5047"]
+  http = true

--- a/tests/functional/data/templates/docker/daemon.py
+++ b/tests/functional/data/templates/docker/daemon.py
@@ -45,6 +45,7 @@ if __name__ == "__main__":
             "registry:5044",
             f"{IP}:5044",
             f"{IP}:5046",
+            f"{IP}:5047",
         }
     )
     has_changes = config != updated

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -22,6 +22,7 @@ from .conf import (
     MAGIC,
     MARKS,
     REGISTRY,
+    REGISTRY_PROXY,
     REGISTRY_TLS,
     REGISTRY_TLS_INSECURE,
     ROOT,
@@ -288,6 +289,8 @@ def test_onbuild(chalk: Chalk, base: Path, test: Path, random_hex: str):
         ("registry.k8s.io/pause:3.9", "/pause"),
         ("k8s.gcr.io/pause", "/pause"),
         ("ghcr.io/crashappsec/pgcli:3.5.0", "pgcli"),
+        ("nginx:1.27", "/docker-entrypoint.sh"),
+        (f"{REGISTRY_PROXY}/library/nginx:1.27", "/docker-entrypoint.sh"),
     ],
 )
 def test_base_registry(chalk: Chalk, image: str, entrypoint: str, buildx: bool):

--- a/tests/unit/test_docker_ids.nim
+++ b/tests/unit/test_docker_ids.nim
@@ -44,6 +44,7 @@ proc main() =
   assertEq($(parseImage("localhost/bar").uri(scheme="https://")), "https://localhost/v2/bar")
 
   assertEq($(parseImage("foo").withRegistry("foo.com").uri), "https://foo.com/v2/library/foo")
+  assertEq($(parseImage("foo").withRegistry("foo.com").uri(prefix = "bar")), "https://foo.com/bar/v2/library/foo")
 
   assertEq($(parseImage("foo").uri(path = "/manifests/latest")), "https://registry-1.docker.io/v2/library/foo/manifests/latest")
 

--- a/tests/unit/test_docker_ids.nim
+++ b/tests/unit/test_docker_ids.nim
@@ -41,11 +41,12 @@ proc main() =
   assertEq($(parseImage("127.0.0.1/bar").uri), "http://127.0.0.1/v2/bar")
   assertEq($(parseImage("127.0.0.1/bar").uri), "http://127.0.0.1/v2/bar")
   assertEq($(parseImage("127.0.0.1:1234/bar").uri), "http://127.0.0.1:1234/v2/bar")
+
   assertEq($(parseImage("localhost/bar").uri(scheme="https://")), "https://localhost/v2/bar")
+  assertEq($(parseImage("foo").uri(path = "/manifests/latest")), "https://registry-1.docker.io/v2/library/foo/manifests/latest")
+  assertEq($(parseImage("foo").uri(prefix = "/bar")), "https://registry-1.docker.io/bar/v2/library/foo")
+  assertEq($(parseImage("foo").uri(project = "/bar")), "https://registry-1.docker.io/v2/bar/library/foo")
 
   assertEq($(parseImage("foo").withRegistry("foo.com").uri), "https://foo.com/v2/library/foo")
-  assertEq($(parseImage("foo").withRegistry("foo.com").uri(prefix = "bar")), "https://foo.com/bar/v2/library/foo")
-
-  assertEq($(parseImage("foo").uri(path = "/manifests/latest")), "https://registry-1.docker.io/v2/library/foo/manifests/latest")
 
 main()

--- a/tests/unit/test_docker_ids.nim
+++ b/tests/unit/test_docker_ids.nim
@@ -48,5 +48,10 @@ proc main() =
   assertEq($(parseImage("foo").uri(project = "/bar")), "https://registry-1.docker.io/v2/bar/library/foo")
 
   assertEq($(parseImage("foo").withRegistry("foo.com").uri), "https://foo.com/v2/library/foo")
+  assertEq($(parseImage("foo").withRegistry("foo.com:1234").uri), "https://foo.com:1234/v2/library/foo")
+  assertEq($(parseImage("example.com/foo").withRegistry("foo.com").uri), "https://foo.com/v2/foo")
+  assertEq($(parseImage("example.com:1234/foo").withRegistry("foo.com").uri), "https://foo.com/v2/foo")
+  assertEq($(parseImage("example.com/foo").withRegistry("foo.com:1234").uri), "https://foo.com:1234/v2/foo")
+  assertEq($(parseImage("example.com:4567/foo").withRegistry("foo.com:1234").uri), "https://foo.com:1234/v2/foo")
 
 main()

--- a/tests/unit/test_docker_ids.nim
+++ b/tests/unit/test_docker_ids.nim
@@ -1,35 +1,50 @@
 import std/uri
+import ../../src/chalk_common
 import ../../src/docker/ids
 
+template assertEq(a, b: untyped) =
+  doAssert a == b, $a & " != " & $b
+
+proc image(a, b, c: string): DockerImage =
+  return (a, b, c)
+
 proc main() =
-  doAssert parseImage("foo") == ("foo", "latest", "")
-  doAssert parseImage("foo/bar") == ("foo/bar", "latest", "")
-  doAssert parseImage("foo:tag") == ("foo", "tag", "")
-  doAssert parseImage("foo/bar:tag") == ("foo/bar", "tag", "")
-  doAssert parseImage("foo@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("foo", "latest", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
-  doAssert parseImage("foo/bar@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("foo/bar", "latest", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
-  doAssert parseImage("foo:tag@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("foo", "tag", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
-  doAssert parseImage("foo/bar:tag@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("foo/bar", "tag", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
-  doAssert parseImage("foo.com/test") == ("foo.com/test", "latest", "")
-  doAssert parseImage("foo.com/test:tag") == ("foo.com/test", "tag", "")
-  doAssert parseImage("foo.com:1234/test") == ("foo.com:1234/test", "latest", "")
-  doAssert parseImage("foo.com:1234/test:tag") == ("foo.com:1234/test", "tag", "")
-  doAssert parseImage("127.0.0.1/test:tag") == ("127.0.0.1/test", "tag", "")
-  doAssert parseImage("127.0.0.1:1234/test:tag") == ("127.0.0.1:1234/test", "tag", "")
-  doAssert parseImage("sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630") == ("", "", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630")
+  assertEq(parseImage("foo"), image("foo", "latest", ""))
+  assertEq(parseImage("foo/bar"), image("foo/bar", "latest", ""))
+  assertEq(parseImage("foo:tag"), image("foo", "tag", ""))
+  assertEq(parseImage("foo/bar:tag"), image("foo/bar", "tag", ""))
+  assertEq(parseImage("foo@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"), image("foo", "latest", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"))
+  assertEq(parseImage("foo/bar@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"), image("foo/bar", "latest", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"))
+  assertEq(parseImage("foo:tag@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"), image("foo", "tag", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"))
+  assertEq(parseImage("foo/bar:tag@sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"), image("foo/bar", "tag", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"))
+  assertEq(parseImage("foo.com/test"), image("foo.com/test", "latest", ""))
+  assertEq(parseImage("foo.com/test:tag"), image("foo.com/test", "tag", ""))
+  assertEq(parseImage("foo.com:1234/test"), image("foo.com:1234/test", "latest", ""))
+  assertEq(parseImage("foo.com:1234/test:tag"), image("foo.com:1234/test", "tag", ""))
+  assertEq(parseImage("127.0.0.1/test:tag"), image("127.0.0.1/test", "tag", ""))
+  assertEq(parseImage("127.0.0.1:1234/test:tag"), image("127.0.0.1:1234/test", "tag", ""))
+  assertEq(parseImage("sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"), image("", "", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"))
 
-  doAssert $(parseImage("foo").uri) == "https://registry-1.docker.io/v2/library/foo"
-  doAssert $(parseImage("foo/bar").uri) == "https://registry-1.docker.io/v2/foo/bar"
-  doAssert $(parseImage("Foo/bar").uri) == "https://Foo/v2/bar"
-  doAssert $(parseImage("foo.com/bar").uri) == "https://foo.com/v2/bar"
-  doAssert $(parseImage("foo:1234/bar").uri) == "https://foo:1234/v2/bar"
-  doAssert $(parseImage("localhost/bar").uri) == "http://localhost/v2/bar"
-  doAssert $(parseImage("localhost:1234/bar").uri) == "http://localhost:1234/v2/bar"
-  doAssert $(parseImage("127.0.0.1/bar").uri) == "http://127.0.0.1/v2/bar"
-  doAssert $(parseImage("127.0.0.1/bar").uri) == "http://127.0.0.1/v2/bar"
-  doAssert $(parseImage("127.0.0.1:1234/bar").uri) == "http://127.0.0.1:1234/v2/bar"
-  doAssert $(parseImage("localhost/bar").uri(scheme="https://")) == "https://localhost/v2/bar"
+  assertEq($(parseImage("foo").uri), "https://registry-1.docker.io/v2/library/foo")
+  assertEq($(parseImage("docker.io/foo").uri), "https://registry-1.docker.io/v2/library/foo")
+  assertEq($(parseImage("index.docker.io/foo").uri), "https://registry-1.docker.io/v2/library/foo")
+  assertEq($(parseImage("registry-1.docker.io/foo").uri), "https://registry-1.docker.io/v2/library/foo")
+  assertEq($(parseImage("foo/bar").uri), "https://registry-1.docker.io/v2/foo/bar")
+  assertEq($(parseImage("docker.io/foo/bar").uri), "https://registry-1.docker.io/v2/foo/bar")
+  assertEq($(parseImage("index.docker.io/foo/bar").uri), "https://registry-1.docker.io/v2/foo/bar")
+  assertEq($(parseImage("registry-1.docker.io/foo/bar").uri), "https://registry-1.docker.io/v2/foo/bar")
+  assertEq($(parseImage("Foo/bar").uri), "https://Foo/v2/bar")
+  assertEq($(parseImage("foo.com/bar").uri), "https://foo.com/v2/bar")
+  assertEq($(parseImage("foo:1234/bar").uri), "https://foo:1234/v2/bar")
+  assertEq($(parseImage("localhost/bar").uri), "http://localhost/v2/bar")
+  assertEq($(parseImage("localhost:1234/bar").uri), "http://localhost:1234/v2/bar")
+  assertEq($(parseImage("127.0.0.1/bar").uri), "http://127.0.0.1/v2/bar")
+  assertEq($(parseImage("127.0.0.1/bar").uri), "http://127.0.0.1/v2/bar")
+  assertEq($(parseImage("127.0.0.1:1234/bar").uri), "http://127.0.0.1:1234/v2/bar")
+  assertEq($(parseImage("localhost/bar").uri(scheme="https://")), "https://localhost/v2/bar")
 
-  doAssert $(parseImage("foo").uri(path = "/manifests/latest")) == "https://registry-1.docker.io/v2/library/foo/manifests/latest"
+  assertEq($(parseImage("foo").withRegistry("foo.com").uri), "https://foo.com/v2/library/foo")
+
+  assertEq($(parseImage("foo").uri(path = "/manifests/latest")), "https://registry-1.docker.io/v2/library/foo/manifests/latest")
 
 main()


### PR DESCRIPTION

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~~Updated `CHANGELOG.md` if necessary~~

## Issue

adds support for mirrors in both docker daemon config as well as buildx node configs

## Description

Whenever mirror is configured, docker pulls images from the mirror unless there is an error in which case it falls back to the upstream registry. Chalk should match that behavior so that we can both interact with the registries in the same manner as docker as well as in the future be able to report metadata about registry use more accurately.

## Testing

```
➜ make tests args="test_docker.py::test_base_registry --logs"
```

**note** this is PR to upstream `registry` branch