### PR TITLE
refactor: extracting chalk mark from registry

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -37,6 +37,8 @@ after build:
   if getEnv("DEBUG", "false") != "true":
     exec "set -x && strip " & bin[0]
   exec "set -x && ./" & bin[0] & " --debug --no-use-external-config --skip-command-report load default"
+  if getEnv("CHALK_PASSWORD") != "":
+    exec "set -x && ./" & bin[0] & " --debug setup"
 
 task debug, "Get a debug build":
   # additional flags are configured in config.nims

--- a/src/attestation_api.nim
+++ b/src/attestation_api.nim
@@ -230,7 +230,7 @@ proc verifyBySigStore*(chalk: ChalkObj): (ValidateResult, ChalkDict) =
     return (vNoHash, dict)
   if not isChalkingOp():
     if "INJECTOR_PUBLIC_KEY" notin chalk.extract:
-      error(chalk.name & ": Bad chalk mark; missing INJECTOR_PUBLIC_KEY")
+      warn(chalk.name & ": Bad chalk mark; missing INJECTOR_PUBLIC_KEY")
       return (vNoPk, dict)
     key = chalk.getCosignKey()
   if not key.canAttestVerify():

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -313,6 +313,7 @@ type
     mediaType*:        string
     size*:             int
     json*:             JsonNode
+    annotations*:      JsonNode
     isFetched*:        bool
     case kind*:        DockerManifestType
     of list:

--- a/src/docker/collect.nim
+++ b/src/docker/collect.nim
@@ -10,7 +10,7 @@
 ## collect - use inspection result to load info into chalk
 
 import std/[json]
-import ".."/[config, chalkjson, util, semver]
+import ".."/[config, chalkjson, util]
 import "."/[inspect, exe, manifest, json, ids]
 
 # https://docs.docker.com/engine/api/v1.44/#tag/Image/operation/ImageInspect
@@ -241,9 +241,6 @@ proc collectDigestsFromManifest(chalk: ChalkObj, manifest: DockerManifest) =
     chalk.setIfNeeded("_IMAGE_LIST_DIGEST", chalk.listDigest)
 
 proc collectProvenance(chalk: ChalkObj) =
-  # https://github.com/docker/buildx/releases/tag/v0.13.0
-  if getBuildXVersion() < parseVersion("0.13"):
-    return
   if chalk.listDigest == "":
     return
   if not isSubscribedKey("_IMAGE_PROVENANCE"):
@@ -257,9 +254,6 @@ proc collectProvenance(chalk: ChalkObj) =
       continue
 
 proc collectSBOM(chalk: ChalkObj) =
-  # https://github.com/docker/buildx/releases/tag/v0.13.0
-  if getBuildXVersion() < parseVersion("0.13"):
-    return
   if chalk.listDigest == "":
     return
   if not isSubscribedKey("_IMAGE_SBOM"):
@@ -282,7 +276,12 @@ proc collectDigests(chalk: ChalkObj) =
   # we dont have any images
   if chalk.imageDigest == "" or len(chalk.images) == 0:
     return
-  if hasBuildX():
+  if not hasBuildX() and dockerInvocation != nil and dockerInvocation.cmd == push:
+    # if there is no buildx, this means its a vanilla docker push
+    # which means for docker push it cannot be a list manifest
+    # so we should be able to normalize it
+    chalk.setIfNeeded("_IMAGE_DIGEST", chalk.imageDigest)
+  else:
     for image in chalk.images:
       try:
         let manifest = fetchImageManifest(image.withDigest(chalk.imageDigest), chalk.platform)
@@ -290,12 +289,6 @@ proc collectDigests(chalk: ChalkObj) =
         break
       except:
         continue
-  else:
-    if dockerInvocation != nil and dockerInvocation.cmd == push:
-      # if there is no buildx, this means its a vanilla docker push
-      # which means for docker push it cannot be a list manifest
-      # so we should be able to normalize it
-      chalk.setIfNeeded("_IMAGE_DIGEST", chalk.imageDigest)
   let repoDigests = extractDockerHashMap($(chalk.images.withDigest(chalk.imageDigest)))
   chalk.setIfNeeded("_REPO_DIGESTS", pack(repoDigests))
 
@@ -303,9 +296,8 @@ proc collectImage*(chalk: ChalkObj, name: string, digest = "") =
   let contents = inspectImageJson(name)
   chalk.collectImageFrom(contents, name, digest = digest)
   chalk.collectDigests()
-  if hasBuildX():
-    chalk.collectProvenance()
-    chalk.collectSBOM()
+  chalk.collectProvenance()
+  chalk.collectSBOM()
 
 proc collectImage*(chalk: ChalkObj) =
   if chalk.imageId == "":

--- a/src/docker/extract.nim
+++ b/src/docker/extract.nim
@@ -208,6 +208,7 @@ proc extractImage*(self: ChalkObj) =
   if self.imageDigest != "":
     try:
       self.extractFrom(self.extractMarkFromSigStore(), self.getImageName())
+      self.signed = true
       info("docker: " & self.getImageName() & ": chalk mark successfully extracted from in-toto attestation from registry")
       return
     except:
@@ -224,7 +225,7 @@ proc extractImage*(self: ChalkObj) =
 
   if self.canVerifyBySigStore():
     try:
-      self.extractFrom(self.extractMarkFromSigStore(), self.getImageName())
+      self.extractFrom(self.extractMarkFromSigStoreCosign(), self.getImageName())
       self.signed = true
       info("docker: " & self.getImageName() & ": chalk mark successfully extracted from attestation.")
       return

--- a/src/docker/extract.nim
+++ b/src/docker/extract.nim
@@ -215,14 +215,6 @@ proc extractImage*(self: ChalkObj) =
       trace("docker: " & self.getImageName() & ": could not extract chalk mark " &
             "via in-toto attestation due to: " & getCurrentExceptionMsg())
 
-    try:
-      self.extractFrom(self.extractMarkFromLayer(), self.getImageName())
-      info("docker: " & self.getImageName() & ": chalk mark successfully extracted from layer from registry")
-      return
-    except:
-      trace("docker: " & self.getImageName() & ": could not extract chalk mark " &
-            "via layer in registry due to: " & getCurrentExceptionMsg())
-
   if self.canVerifyBySigStore():
     try:
       self.extractFrom(self.extractMarkFromSigStoreCosign(), self.getImageName())
@@ -233,6 +225,15 @@ proc extractImage*(self: ChalkObj) =
       self.noCosign = true
       trace("docker: " & self.getImageName & ": could not extract chalk mark " &
            "via attestation due to: " & getCurrentExceptionMsg())
+
+  if self.imageDigest != "":
+    try:
+      self.extractFrom(self.extractMarkFromLayer(), self.getImageName())
+      info("docker: " & self.getImageName() & ": chalk mark successfully extracted from layer from registry")
+      return
+    except:
+      trace("docker: " & self.getImageName() & ": could not extract chalk mark " &
+            "via layer in registry due to: " & getCurrentExceptionMsg())
 
   self.extractFrom(self.extractImageMark(), self.getImageName())
   info("docker: " & self.getImageName() & ": chalk mark successfuly extracted from image.")

--- a/src/docker/extract.nim
+++ b/src/docker/extract.nim
@@ -112,10 +112,10 @@ proc extractMarkFromLayer(self: ChalkObj): string =
           "Last layer for " & $spec & " does not contain /chalk.json",
         )
       let lastLayer = manifest.layers[^1]
-      return lastLayer.nameRef.layerGetFSFileStream(
+      return lastLayer.nameRef.layerGetFSFileString(
         name   = "chalk.json",
         accept = manifest.mediaType,
-      ).readAll()
+      )
     except:
       err = getCurrentExceptionMsg()
       trace("docker: could not extract chalk mark from registry: " & err)

--- a/src/docker/ids.nim
+++ b/src/docker/ids.nim
@@ -194,6 +194,9 @@ proc parseImages*(names: seq[string]): seq[DockerImage] =
     if name != "":
       result.add(parseImage(name))
 
+proc withTag*(self: DockerImage, tag: string): DockerImage =
+  return (self.repo, tag, self.digest)
+
 proc withDigest*(self: DockerImage, digest: string): DockerImage =
   return (self.repo, self.tag, digest.extractDockerHash())
 
@@ -405,6 +408,9 @@ proc getImageName*(self: ChalkObj): string =
   if len(self.images) > 0:
     return $(self.images[0])
   return self.name
+
+proc nameRef*(self: DockerManifest): DockerImage =
+  return self.name.withDigest(self.digest)
 
 # ----------------------------------------------------------------------------
 

--- a/src/docker/json.nim
+++ b/src/docker/json.nim
@@ -18,6 +18,13 @@ proc parseAndDigestJson*(data: string): DigestedJson =
     size:   len(data),
   )
 
+proc parseAndDigestJson*(data: string, digest: string): DigestedJson =
+  return DigestedJson(
+    json:   parseJson(data),
+    digest: digest,
+    size:   len(data),
+  )
+
 proc newDockerDigestedJson*(data: string,
                             digest: string,
                             mediaType: string,

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -47,6 +47,8 @@ proc requestManifestJson(name: DockerImage, flags = @["--raw"], fallback = true)
   ## however if that fails withs 401 error, attept to manually
   ## fetch the manifest via the URL from the error message
   ## as the error could be due to www-authenticate challenge
+  if not hasBuildX():
+    raise newException(ValueError, "No buildx to iteract with registry")
   let key = name.asRepoDigest() & $flags
   if key in jsonCache:
     return jsonCache[key]

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -8,7 +8,7 @@
 ## module for interacting with remote registry docker manifests
 
 import std/[httpclient]
-import ".."/[chalk_common, config, www_authenticate]
+import ".."/[chalk_common, config, www_authenticate, semver]
 import "."/[exe, json, ids, registry]
 
 # cache is by repo ref as its normalized in buildx imagetools command
@@ -167,7 +167,8 @@ proc setImageLayers(self: DockerManifest, data: DigestedJson) =
       annotations:   layer{"annotations"},
     ))
 
-proc fetch(self: DockerManifest, fetchConfig = true) =
+proc fetch(self: DockerManifest, fetchConfig = true): DockerManifest {.discardable.} =
+  result = self
   if self.isFetched:
     return
   let name = self.nameRef()
@@ -225,14 +226,15 @@ proc newManifest(name: DockerImage, data: DigestedJson, otherNames: seq[DockerIm
     for item in json["manifests"].items():
       let platform = item{"platform"}
       list.manifests.add(DockerManifest(
-        kind:       DockerManifestType.image,
-        name:       name,
-        list:       list,
-        otherNames: otherNames,
-        mediaType:  item{"mediaType"}.getStr(),
-        digest:     item{"digest"}.getStr(),
-        size:       item{"size"}.getInt(),
-        platform:   DockerPlatform(
+        kind:        DockerManifestType.image,
+        name:        name,
+        list:        list,
+        otherNames:  otherNames,
+        mediaType:   item{"mediaType"}.getStr(),
+        digest:      item{"digest"}.getStr(),
+        size:        item{"size"}.getInt(),
+        annotations: item{"annotations"},
+        platform:    DockerPlatform(
           os:           platform{"os"}.getStr(),
           architecture: platform{"architecture"}.getStr(),
           variant:      platform{"variant"}.getStr(),
@@ -261,45 +263,6 @@ proc newManifest(name: DockerImage, data: DigestedJson, otherNames: seq[DockerIm
 
   else:
     raise newException(ValueError, "Unsupported docker manifest json")
-
-proc fetchProvenance*(name: DockerImage, platform: DockerPlatform): JsonNode =
-  # https://docs.docker.com/reference/cli/docker/buildx/imagetools/inspect/
-  try:
-    # for single-platform manifests, there is only a single provenance
-    return requestManifestJson(
-      name,
-      flags    = @["--format", "{{json .Provenance.SLSA}}"],
-      fallback = false,
-    ).json
-  except:
-    # for multi-platform we have to filter on the platform
-    # note index only supports a few keys so have to manually
-    # take SLSA key
-    return requestManifestJson(
-      name,
-      flags    = @["--format", "{{json (index .Provenance \"" & $platform & "\")}}"],
-      fallback = false,
-    ).json{"SLSA"}
-
-
-proc fetchSBOM*(name: DockerImage, platform: DockerPlatform): JsonNode =
-  # https://docs.docker.com/reference/cli/docker/buildx/imagetools/inspect/
-  try:
-    # for single-platform manifests, there is only a single sbom
-    return requestManifestJson(
-      name,
-      flags    = @["--format", "{{json .SBOM.SPDX}}"],
-      fallback = false,
-    ).json
-  except:
-    # for multi-platform we have to filter on the platform
-    # note index only supports a few keys so have to manually
-    # take SPDX key
-    return requestManifestJson(
-      name,
-      flags    = @["--format", "{{json (index .SBOM \"" & $platform & "\")}}"],
-      fallback = false,
-    ).json{"SPDX"}
 
 proc fetchManifest*(name: DockerImage,
                     otherNames: seq[DockerImage] = @[],
@@ -343,7 +306,7 @@ proc fetchOnlyImageManifest*(name: DockerImage, fetchConfig = true): DockerManif
 proc fetchImageManifest*(name: DockerImage,
                          platform: DockerPlatform,
                          otherNames: seq[DockerImage] = @[]): DockerManifest =
-  trace("docker: fetching manifest for: " & $name)
+  trace("docker: fetching image manifest for: " & $name)
   var manifest = fetchManifest(name, otherNames = otherNames)
   if manifest.kind == DockerManifestType.list:
     manifest = manifest.findPlatformManifest(platform)
@@ -357,3 +320,94 @@ proc fetchImageManifest*(name: DockerImage,
       $platform & " != " & "" & $manifest.platform
     )
   return manifest
+
+proc findSibling(self: DockerManifest, reference = "attestation-manifest"): DockerManifest =
+  if self.kind != DockerManifestType.image:
+    raise newException(ValueError, "Can only lookup sibling for image manifest")
+  if self.list == nil:
+    raise newException(ValueError, "Need reference to list manifest to lookup sibling")
+  for i in self.list.manifests:
+    if i.annotations == nil:
+      continue
+    if (
+      i.annotations{"vnd.docker.reference.type"}.getStr().toLower() == reference.toLower() and
+      i.annotations{"vnd.docker.reference.digest"}.getStr().toLower() == self.nameRef.imageRef.toLower()
+    ):
+      return i.fetch()
+  raise newException(KeyError, "Could not find sibling image of reference type: " & reference)
+
+proc findInTotoLayer(self: DockerManifest, predicate: string): DockerManifest =
+  if self.kind != DockerManifestType.image:
+    raise newException(ValueError, "Can only lookup layers in image manifest")
+  for l in self.layers:
+    if l.annotations == nil:
+      continue
+    if l.annotations{"in-toto.io/predicate-type"}.getStr().toLower().startsWith(predicate.toLower()):
+      return l
+  raise newException(KeyError, "Could not find in-toto layer for predicate: " & predicate)
+
+proc fetchProvenance*(name: DockerImage, platform: DockerPlatform): JsonNode =
+  # https://docs.docker.com/reference/cli/docker/buildx/imagetools/inspect/
+  try:
+    trace("docker: looking up provenance for: " & $name)
+    let layer = name.fetchImageManifest(platform).findSibling().findInTotoLayer("https://slsa.dev/provenance/")
+    result = layer.nameRef.layerGetJson(accept = layer.mediaType).json{"predicate"}
+    trace("docker: in registry found provenance for: " & $name)
+  except RegistryResponseError, KeyError:
+    trace("docker: " & getCurrentExceptionMsg())
+    raise
+  except:
+    error("docker: " & getCurrentExceptionMsg())
+    dumpExOnDebug()
+    # https://github.com/docker/buildx/releases/tag/v0.13.0
+    if getBuildXVersion() < parseVersion("0.13"):
+      raise newException(ValueError, "buildx 0.13 is required to collect provenance via imagetools")
+    try:
+      # for single-platform manifests, there is only a single provenance
+      return requestManifestJson(
+        name,
+        flags    = @["--format", "{{json .Provenance.SLSA}}"],
+        fallback = false,
+      ).json
+    except:
+      # for multi-platform we have to filter on the platform
+      # note index only supports a few keys so have to manually
+      # take SLSA key
+      return requestManifestJson(
+        name,
+        flags    = @["--format", "{{json (index .Provenance \"" & $platform & "\")}}"],
+        fallback = false,
+      ).json{"SLSA"}
+
+proc fetchSBOM*(name: DockerImage, platform: DockerPlatform): JsonNode =
+  # https://docs.docker.com/reference/cli/docker/buildx/imagetools/inspect/
+  try:
+    trace("docker: looking up SBOM for: " & $name)
+    let layer = name.fetchImageManifest(platform).findSibling().findInTotoLayer("https://spdx.dev/Document")
+    result = layer.nameRef.layerGetJson(accept = layer.mediaType).json{"predicate"}
+    trace("docker: in registry found SBOM for: " & $name)
+  except RegistryResponseError, KeyError:
+    trace("docker: " & getCurrentExceptionMsg())
+    raise
+  except:
+    error("docker: " & getCurrentExceptionMsg())
+    dumpExOnDebug()
+    # https://github.com/docker/buildx/releases/tag/v0.13.0
+    if getBuildXVersion() < parseVersion("0.13"):
+      raise newException(ValueError, "buildx 0.13 is required to collect SBOM via imagetools")
+    try:
+      # for single-platform manifests, there is only a single sbom
+      return requestManifestJson(
+        name,
+        flags    = @["--format", "{{json .SBOM.SPDX}}"],
+        fallback = false,
+      ).json
+    except:
+      # for multi-platform we have to filter on the platform
+      # note index only supports a few keys so have to manually
+      # take SPDX key
+      return requestManifestJson(
+        name,
+        flags    = @["--format", "{{json (index .SBOM \"" & $platform & "\")}}"],
+        fallback = false,
+      ).json{"SPDX"}

--- a/tests/functional/data/templates/docker/daemon.py
+++ b/tests/functional/data/templates/docker/daemon.py
@@ -48,6 +48,12 @@ if __name__ == "__main__":
             f"{IP}:5047",
         }
     )
+    updated["registry-mirrors"] = sorted(
+        set(updated.get("registry-mirrors", []))
+        | {
+            f"http://{IP}:5047",
+        }
+    )
     has_changes = config != updated
     formatted = json.dumps(updated, indent=4)
 

--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -29,4 +29,4 @@ tool.syft.syft_container = "ghcr.io/anchore/syft"
 # https://github.com/semgrep/semgrep/issues/9169
 
 # sometimes CI tests need longer TTL to get ICMP error back
-network.partial_traceroute_timeout_ms = 100
+network.partial_traceroute_timeout_ms = 500


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~~Updated `CHANGELOG.md` if necessary~~

## Description

chalk can extract chalk mark from either:

* in-toto attestation layer
* last layer directly from registry

this will be necessary for base image inspection as well as dropping cosign dep in the future

also now we can directly grab provenance/sbom from the registry

## Testing

run `test_docker.py` tests. all existing functionality should still work as-is
