### PR TITLE
feat: heartbeat minimal report template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@
   as otherwise semgrep is not able to find `pysemgrep` folder.
   ([#439](https://github.com/crashappsec/chalk/pull/439))
 
+### New Features
+
+- `_EXEC_ID` key which is unique for each `chalk` execution
+  for all commands while chalk process is alive.
+  For example it will send consistent values for both
+  `exec` and `heartbeat` reports hence allowing to tie
+  both reports together.
+- `heartbeat` report template. It is a minimal reporting
+  template which is now used as the default report template
+  for all heartbeat reports. Main purpose of heartbeat is
+  to indicate liveliness hence such a minimal report.
+  All other metadata should be collected as part of `exec`
+  report instead.
+
 ## 0.4.13
 
 **Oct 10, 2024**

--- a/configs/co/heartbeat.c4m
+++ b/configs/co/heartbeat.c4m
@@ -1,0 +1,28 @@
+parameter exec.heartbeat {
+  default:  true
+  shortdoc: "Enable heartbeat reports"
+  doc:      "Whether to send periodic heartbeat reports"
+}
+# TODO add duration parameter with libcon4m
+# currently parameters cannot be of Duration type
+exec.heartbeat_rate = <<10 minutes>>
+
+parameter sink_config.crashoverride_heartbeats.uri {
+  shortdoc: "Reporting URL where to send heartbeat reports"
+  doc:      "Reporting URL where to send heartbeat reports"
+  default:  "https://chalk.crashoverride.run/v0.1/report/heartbeats"
+}
+
+sink_config crashoverride_heartbeats {
+  ~enabled:         true
+  ~sink:            "presign"
+  ~priority:        999998
+  ~auth:            "crashoverride_reporting"
+}
+
+custom_report crashoverride_heartbeats {
+  ~enabled:         true
+  ~report_template: "heartbeat"
+  ~sink_configs:    ["crashoverride_heartbeats"]
+  ~use_when:        ["heartbeat"]
+}

--- a/configs/co/heartbeat.c4m
+++ b/configs/co/heartbeat.c4m
@@ -7,6 +7,11 @@ parameter exec.heartbeat {
 # currently parameters cannot be of Duration type
 exec.heartbeat_rate = <<10 minutes>>
 
+# disable heartbeats in lambda as lambda cannot run on arbitrary schedule
+if env_exists("AWS_LAMBDA_FUNCTION_NAME") and env_exists("AWS_LAMBDA_FUNCTION_VERSION") {
+  exec.heartbeat = false
+}
+
 parameter sink_config.crashoverride_heartbeats.uri {
   shortdoc: "Reporting URL where to send heartbeat reports"
   doc:      "Reporting URL where to send heartbeat reports"

--- a/configs/co/heartbeat.c4m
+++ b/configs/co/heartbeat.c4m
@@ -20,7 +20,7 @@ parameter sink_config.crashoverride_heartbeats.uri {
 
 sink_config crashoverride_heartbeats {
   ~enabled:         true
-  ~sink:            "presign"
+  ~sink:            "post"
   ~priority:        999998
   ~auth:            "crashoverride_reporting"
 }

--- a/configs/co/sast.c4m
+++ b/configs/co/sast.c4m
@@ -1,7 +1,7 @@
 parameter var run_sast {
-    default:   true
-    shortdoc: "Run SAST Tools"
-    doc:      "Whether to run semgrep for chalking operations"
+  default:   true
+  shortdoc: "Run SAST Tools"
+  doc:      "Whether to run semgrep for chalking operations"
 }
 
 ~run_sast_tools = run_sast

--- a/configs/co/sbom.c4m
+++ b/configs/co/sbom.c4m
@@ -1,7 +1,7 @@
 parameter var collect_sbom {
-    default:  true
-    shortdoc: "Collect SBOMs via syft"
-    doc:      "Whether SBOMs should be collected for chalking operations via syft"
+  default:  true
+  shortdoc: "Collect SBOMs via syft"
+  doc:      "Whether SBOMs should be collected for chalking operations via syft"
 }
 
 ~run_sbom_tools = collect_sbom

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -4000,8 +4000,8 @@ keyspec _ACTION_ID {
     since:            "0.1.0"
     shortdoc: "Unique ID per chalk report"
     doc:              """
-This is a unique identifier generated for the current run of chalk. It
-is not insertable into chalk marks, but may appear in any host report.
+This is a unique identifier generated for the current report run of chalk.
+It is not insertable into chalk marks, but may appear in any host report.
 
 The purpose of this value is to ensure every chalk action has a unique
 identifier, if desired.
@@ -4010,6 +4010,28 @@ The value is a 64-bit (secure) random value, encoded as hex.
 
 While there is a config-file callback associated with this metadata
 key, it is set by the system, and cannot be overridden by the user.
+"""
+}
+
+keyspec _EXEC_ID {
+    kind:             RunTimeHost
+    type:             string
+    standard:         true
+    system:           true
+    conf_as_system:   true
+    since:            "0.4.14"
+    shortdoc:         "Unique ID per chalk execution"
+    doc:              """
+This is a unique identifier generated for the current run of chalk.
+It is not insertable into chalk marks, but may appear in any host report.
+
+The purpose of this value is to ensure every chalk execution action
+has a unique identifier, if desired.
+For example, unlike `_ACTION_ID` which is unique for each report,
+`_EXEC_ID` is going to be the same for both `exec` and `heartbeat`
+reports hence allowing to tie them together.
+
+The value is a 64-bit (secure) random value, encoded as hex.
 """
 }
 

--- a/src/configs/base_outconf.c4m
+++ b/src/configs/base_outconf.c4m
@@ -32,7 +32,7 @@ outconf exec {
 }
 
 outconf heartbeat {
-  report_template:        "report_default"
+  report_template:        "heartbeat"
 }
 
 outconf delete {

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -35,7 +35,8 @@ plugin system {
                     "_OP_CHALKER_VERSION", "_OP_CHALK_COUNT", "_OP_CMD_FLAGS",
                     "_OP_EXE_NAME", "_OP_EXE_PATH", "_OP_ARGV", "_OP_HOSTNAME",
                     "_OP_HOST_REPORT_KEYS", "_OP_UNMARKED_COUNT", "_TIMESTAMP",
-                    "_DATE", "_TIME", "_TZ_OFFSET", "_DATETIME", "_ENV"]
+                    "_DATE", "_TIME", "_TZ_OFFSET", "_DATETIME", "_ENV",
+                    "_EXEC_ID"]
 
   ~priority:       0
   doc: """

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -332,6 +332,7 @@ report and subtract from it.
   key._SIGNATURES.use                         = true
   key._INVALID_SIGNATURE.use                  = true
   key._ACTION_ID.use                          = true
+  key._EXEC_ID.use                            = true
   key._ARGV.use                               = true
   key._ENV.use                                = true
   key._TENANT_ID.use                          = true
@@ -486,6 +487,7 @@ doc: """
   key.SBOM.use                                = true
   key.SAST.use                                = true
   key._ACTION_ID.use                          = true
+  key._EXEC_ID.use                            = true
   key._ARGV.use                               = true
   key._ENV.use                                = true
   key._TENANT_ID.use                          = true
@@ -976,6 +978,7 @@ container.
 
   # Runtime host keys.
   key._ACTION_ID.use                          = true
+  key._EXEC_ID.use                            = true
   key._ARGV.use                               = true
   key._ENV.use                                = true
   key._TENANT_ID.use                          = true
@@ -1441,6 +1444,7 @@ and keep the run-time key.
 
   # Runtime host keys.
   key._ACTION_ID.use                          = true
+  key._EXEC_ID.use                            = true
   key._ARGV.use                               = true
   key._ENV.use                                = true
   key._TENANT_ID.use                          = true
@@ -1857,6 +1861,7 @@ that do not generate a chalk report.
 """
   key._OPERATION.use                          = true
   key._ACTION_ID.use                          = true
+  key._EXEC_ID.use                            = true
   key._DATETIME.use                           = true
   key._ARGV.use                               = true
   key._OP_CHALKER_COMMIT_ID.use               = true
@@ -1905,6 +1910,25 @@ report_template usage {
   ~key._OP_CHALKER_COMMIT_ID.use              = true
   ~key._OP_CHALKER_VERSION.use                = true
   ~key._OP_PLATFORM.use                       = true
+}
+
+report_template heartbeat {
+  shortdoc: "Small report for periodic heartbeats"
+  doc: """
+Very small report template for sending heartbeats.
+Normally exec report should collect most of the information
+about the chalk runtime. After that point heartbeat report
+only indicates liveliness of the process so it can be very
+minimal.
+"""
+  ~key.METADATA_ID.use                        = true
+  ~key.CHALK_ID.use                           = true
+  ~key._CHALKS.use                            = true
+  ~key._OPERATION.use                         = true
+  ~key._TIMESTAMP.use                         = true
+  ~key._DATETIME.use                          = true
+  ~key._ACTION_ID.use                         = true
+  ~key._EXEC_ID.use                           = true
 }
 
 report_template terminal_insert {

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -45,6 +45,7 @@ This is mostly a copy of insert template however all keys are immutable.
 
   # Runtime host keys.
   ~key._ACTION_ID.use                                 = true
+  ~key._EXEC_ID.use                                   = true
   ~key._ARGV.use                                      = true
   ~key._ENV.use                                       = true
   ~key._OPERATION.use                                 = true

--- a/src/plugins/system.nim
+++ b/src/plugins/system.nim
@@ -17,6 +17,7 @@ import ".."/[config, plugin_api, normalize, chalkjson, attestation_api,
 
 var
   externalActions: seq[seq[string]] = @[]
+  execId = secureRand[uint64]().toHex().toLower()
 
 proc recordExternalActions(kind: string, details: string) =
   externalActions.add(@[kind, details])
@@ -212,23 +213,22 @@ proc sysGetRunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
   if len(cachedSearchPath) != 0:
     result.setIfNeeded("_OP_SEARCH_PATH", cachedSearchPath)
 
-  result.setIfNeeded("_OPERATION", getBaseCommandName())
-  result.setIfNeeded("_OP_CHALKER_VERSION", getChalkExeVersion())
-  result.setIfNeeded("_OP_PLATFORM", getChalkPlatform())
+  result.setIfNeeded("_OPERATION",            getBaseCommandName())
+  result.setIfNeeded("_EXEC_ID",              execId)
+  result.setIfNeeded("_OP_CHALKER_VERSION",   getChalkExeVersion())
+  result.setIfNeeded("_OP_PLATFORM",          getChalkPlatform())
   result.setIfNeeded("_OP_CHALKER_COMMIT_ID", getChalkCommitId())
-  result.setIfNeeded("_OP_CHALK_COUNT", len(getAllChalks()) -
-                                         len(getUnmarked()))
-  result.setIfNeeded("_OP_EXE_NAME", getMyAppPath().splitPath().tail)
-  result.setIfNeeded("_OP_EXE_PATH", getAppDir())
-  result.setIfNeeded("_OP_ARGV", @[getMyAppPath()] &
-                                          commandLineParams())
-  result.setIfNeeded("_OP_HOSTNAME", getHostName())
-  result.setIfNeeded("_OP_UNMARKED_COUNT", len(getUnmarked()))
-  result.setIfNeeded("_TIMESTAMP", pack(uint64(instant * 1000.0)))
-  result.setIfNeeded("_DATE", pack(getDate()))
-  result.setIfNeeded("_TIME", pack(getTime()))
-  result.setIfNeeded("_TZ_OFFSET", pack(getOffset()))
-  result.setIfNeeded("_DATETIME", pack(getDateTime()))
+  result.setIfNeeded("_OP_CHALK_COUNT",       len(getAllChalks()) - len(getUnmarked()))
+  result.setIfNeeded("_OP_EXE_NAME",          getMyAppPath().splitPath().tail)
+  result.setIfNeeded("_OP_EXE_PATH",          getAppDir())
+  result.setIfNeeded("_OP_ARGV",              @[getMyAppPath()] & commandLineParams())
+  result.setIfNeeded("_OP_HOSTNAME",          getHostName())
+  result.setIfNeeded("_OP_UNMARKED_COUNT",    len(getUnmarked()))
+  result.setIfNeeded("_TIMESTAMP",            uint64(instant * 1000.0))
+  result.setIfNeeded("_DATE",                 pack(getDate()))
+  result.setIfNeeded("_TIME",                 pack(getTime()))
+  result.setIfNeeded("_TZ_OFFSET",            pack(getOffset()))
+  result.setIfNeeded("_DATETIME",             pack(getDateTime()))
 
   if isSubscribedKey("_ENV"):
     result["_ENV"] = getEnvDict()

--- a/tests/functional/data/configs/docker_heartbeat.c4m
+++ b/tests/functional/data/configs/docker_heartbeat.c4m
@@ -1,5 +1,5 @@
 log_level: "trace"
-unsubscribe("report", "json_console_out")
+subscribe("report", "json_console_out")
 custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false
 
@@ -10,30 +10,3 @@ docker.wrap_entrypoint: true
 docker.wrap_cmd: true
 docker.custom_labels: {"HELLO": "CRASH_OVERRIDE_TEST_LABEL"}
 docker.arch_binary_locations: {"linux/amd64": "/tmp/chalk"}
-
-report_template docker_heartbeat_report {
-    key._CHALKS.use = true # Needed to include the per-artifact reports.
-    key._OPERATION.use  = true
-    key._OP_ARGV.use = true
-
-    key.CHALK_ID.use = true
-    key.CHALK_VERSION.use = true
-    key.ARTIFACT_TYPE.use = true
-    key._OP_ARTIFACT_PATH.use = true
-    key.HASH.use = true
-    key._CURRENT_HASH.use = true
-    key._IMAGE_ID.use = true
-    key.DOCKERFILE_PATH.use = true
-    key._PROCESS_PID.use = true
-}
-
-sink_config test_std_out {
-    sink: "stdout"
-    enabled: true
-}
-
-custom_report exec_heartbeat_test {
-  report_template: "docker_heartbeat_report"
-  sink_configs: ["test_std_out"]
-  use_when: ["exec", "heartbeat", "build"]
-}

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -860,7 +860,7 @@ def test_docker_heartbeat(chalk_copy: Chalk, random_hex: str):
     assert len(chalk_result.reports) > 1
     for heartbeat_report in chalk_result.reports[1:]:
         assert heartbeat_report["_OPERATION"] == "heartbeat"
-        assert heartbeat_report.mark == exec_report.mark
+        assert exec_report.mark.contains(heartbeat_report.mark)
 
 
 def test_docker_labels(chalk: Chalk, random_hex: str):


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Default heartbeat report is too large as it uses the default report which is quite heavy for simple liveliness checks

## Description

This adds minimal report template for heartbeats which simply reports exec id (to tie to exec report) as well as other basic metadata such as metadata id, operation, timestamp, etc.

Will be enabling it by default specifically for co config later.


## Testing

```
➜ make tests args="test_docker.py::test_docker_heartbeat --logs --pdb"
```
