### PR TITLE
feat: Option to build with profiling

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -44,8 +44,11 @@ task debug, "Get a debug build":
 task release, "Package the release build":
   exec "nimble build"
 
-task performance, "Get a build that adds profiling support":
+task performance, "Get a build that adds execution profiling support":
   exec "nimble build --profiler:on --stackTrace:on -d:cprofiling"
+
+task memprofile, "Get a build that adds memory profiling to the binary":
+  exec "nimble build --profiler:off --stackTrace:on -d:memProfiler -d:cprofiling"
 
 let completion_script_version = version
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -44,6 +44,9 @@ task debug, "Get a debug build":
 task release, "Package the release build":
   exec "nimble build"
 
+task performance, "Get a build that adds profiling support":
+  exec "nimble build --profiler:on --stackTrace:on -d:cprofiling"
+
 let completion_script_version = version
 
 task mark_completion, "Replace the chalk mark in a completion script, including the articact version":

--- a/src/chalk.nim
+++ b/src/chalk.nim
@@ -10,6 +10,11 @@
 import "."/[config, confload, commands, norecurse, sinks,
             attestation_api, util]
 
+const cprofiling {.booldefine.} = false
+
+when cprofiling:
+  import nimprof
+
 when isMainModule:
   setupSignalHandlers() # util.nim
   setupTerminal()       # util.nim


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [X] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [X] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [X] Filled out the template to a useful degree
- [X] Updated `CHANGELOG.md` if necessary


## Issue
#435 

## Description

Added the ability to compile chalk with nim's profiling support. 

To compile w/ execution time support, run 'nimble performance'.
For memory profling, run 'nimble memprofile'.

You cannot turn both on at once (Nim doesn't allow it).

The resulting chalk binary will, on exit, drop 'profile_results.txt' in the directory from which Chalk is run.

The overhead for nim profiling seems like it might be high :/

## Testing

Follow the above instructions and profile some stuff.
