### PR TITLE
fix: semgrep needs to be on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- When running `semgrep`, its always added to `PATH`,
+  as otherwise semgrep is not able to find `pysemgrep` folder.
+  ([#439](https://github.com/crashappsec/chalk/pull/439))
+
 ## 0.4.13
 
 **Oct 10, 2024**

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -93,6 +93,10 @@ func semgrep_system() {
     trace("find_semgrep: Unable to find semgrep in $PATH")
   } else {
     trace("find_semgrep: found semgrep in $PATH: " + result)
+    # ensure semgrep is on PATH
+    # https://github.com/semgrep/semgrep/issues/10652
+    head, tail := path_split(result)
+    result := "PATH=" + head + ":$PATH " + result
   }
 }
 


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

when docker is not available, installed semgrep via chalk cannot run

## Description

starting with 1.94.0, if semgrep is not on PATH, its not able to run and throws:

```
Error: exception Unix_error: No such file or directory execvp pysemgrep
```

related issue https://github.com/semgrep/semgrep/issues/10652

## Testing

```
➜ make tests args="test_plugins.py::test_semgrep[sample_1-False] --logs --pdb"
```
