### PR TITLE
fix: external tools producing duplicate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Docker pushing non-chalked images did not report metsys
   plugin keys such as `_EXIT_CODE`, `_CHALK_RUN_TIME`.
   ([#438](https://github.com/crashappsec/chalk/pull/438))
+- External tools for non-file artifacts (e.g. docker image)
+  sent duplicate keys in both report-level as well as
+  chalk-mark level. For example `SBOM` key with equivalent
+  content was duplicated twice.
+  ([#440](https://github.com/crashappsec/chalk/pull/440))
 
 ### New Features
 

--- a/tests/functional/chalk/validate.py
+++ b/tests/functional/chalk/validate.py
@@ -95,16 +95,16 @@ def validate_chalk_report(
     for artifact in artifact_map.values():
         assert chalk_report.contains(artifact.host_info)
 
-    for chalk in chalk_report.marks:
-        path = chalk["PATH_WHEN_CHALKED"]
+    for mark in chalk_report.marks:
+        path = mark.lifted["PATH_WHEN_CHALKED"]
         assert path in artifact_map, "chalked artifact incorrect"
         artifact = artifact_map[path]
 
-        assert chalk.has(
+        assert mark.lifted.has(
             ARTIFACT_TYPE=artifact.type,
             **artifact.chalk_info,
         )
-        assert chalk.has_if(
+        assert mark.lifted.has_if(
             chalk_action == "insert",
             _VIRTUAL=virtual,
         )

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -18,7 +18,7 @@ from .chalk.validate import (
     validate_virtual_chalk,
 )
 from .conf import CODEOWNERS, CONFIGS, DATA, DOCKERFILES, LS_PATH, PYS
-from .utils.dict import ANY
+from .utils.dict import ANY, MISSING
 from .utils.docker import Docker
 from .utils.git import Git
 from .utils.log import get_logger
@@ -868,6 +868,9 @@ def test_syft_docker(chalk_copy: Chalk, test_file: str, random_hex: str):
         dockerfile=DOCKERFILES / test_file / "Dockerfile",
         tag=tag,
     )
+
+    assert build.report.contains(sbom_data)
+    assert build.mark.has(SBOM=MISSING)
 
     # artifact is the docker image
     artifact_info = ArtifactInfo(


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

SBOM key was reported both on report and chalk mark level:

```json
{
  "_CHALKS": {"SBOM": {...}},
  "SBOM": {...}
}
```

## Description

Some tools work on context directories (e.g. sbom) and for non-fs artifacts (e.g. docker image), sbom tool would run both during host chalk time as well as artifact chalk time collections. As both would collect its output for the same path input, it would produce duplicate output in both report and chalk mark levels.

Now any tool can run at most once and any future attempts for the same path are skipped which removes duplicate keys.

## Testing

```
➜ make tests args="test_plugins.py::test_syft_docker --logs"
```
