### PR TITLE
build: wrapping all nimble build targets in make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ nimutils
 con4m
 /*.c4m
 /ls
+profile_results.txt

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,8 @@
 SHELL=bash
 BINARY=chalk
-CHALK_BUILD?=build
+CHALK_BUILD?=release
 
-# if CON4M_DEV exists, pass that to docker-compose
-# as docker-compose does not allow conditional env vars
 _DOCKER_ARGS=
-ifneq "$(shell echo $${CON4M_DEV+missing})" ""
-_DOCKER_ARGS=-e CON4M_DEV=true
-endif
 _DOCKER=docker compose run --rm $(_DOCKER_ARGS) chalk
 DOCKER?=$(_DOCKER)
 
@@ -25,6 +20,8 @@ SOURCES+=src/docs/CHANGELOG.md
 
 VERSION=$(shell cat src/configs/base_keyspecs.c4m \
           | grep -E "chalk_version\s+:=" | cut -d'"' -f2 | head -n1)
+
+BUILDS=$(shell cat *.nimble | grep -E '^task.*build' | cut -d, -f1 | awk '{print $$2}')
 
 # in case nimble bin is not in PATH - e.g. vanilla shell
 export PATH:=$(HOME)/.nimble/bin:$(PATH)
@@ -44,12 +41,10 @@ $(BINARY).bck: $(SOURCES)
 	cp $@ $(BINARY)
 	ls -la $(BINARY) $@
 
-.PHONY: debug release
-debug: CHALK_BUILD=build --define:debug
 debug: DEBUG=true
-release: CHALK_BUILD=build
-debug release:
-	$(eval export CHALK_BUILD DEBUG)
+$(BUILDS):
+	$(eval export CHALK_BUILD=$@)
+	$(eval export DEBUG)
 	-rm -f $(BINARY) $(BINARY).bck
 	$(MAKE) $(BINARY)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,9 @@ services:
       - $PWD:$PWD
       - $PWD/../nimutils:$PWD/../nimutils
       - $PWD/../con4m:$PWD/../con4m
-    # environment:
-    # CON4M_DEV is conditionally set in Makefile
+    environment:
+      DEBUG: ${DEBUG:-}
+      CHALK_PASSWORD: ${CHALK_PASSWORD:-}
 
   # --------------------------------------------------------------------------
   # SERVER


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

could not do memory profile builds via docker

also `make debug` stripped binary which is not correct

## Description

all tasks which have "build" in their description will be automatically wrapped by make

also passing DEBUG in compose so that make debug does not strip in docker builds

## Testing

```
make debug
make memprofile
```