### PR TITLE
fix: safeRequest memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   chalk-mark level. For example `SBOM` key with equivalent
   content was duplicated twice.
   ([#440](https://github.com/crashappsec/chalk/pull/440))
+- Memory leak in HTTP wrappers in `nimutils`.
+  This mostly manifested in `chalk exec` when heartbeats
+  were enabled as roughly each heartbeat would increase
+  memory footprint by ~1Mb.
+  ([#443](https://github.com/crashappsec/chalk/pull/443))
 
 ### New Features
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#57c908650544ab045a3a9aa6f26d274b1859d238"
+requires "https://github.com/crashappsec/con4m#14a351602fb09f867dde12a3f7c4c998047ecfd9"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 
 # this allows us to get version externally

--- a/src/chalk.nim
+++ b/src/chalk.nim
@@ -5,15 +5,14 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
+const cprofiling {.booldefine.} = false
+when cprofiling:
+  import nimprof
+
 # Note that imports cause topics and plugins to register.
 {.warning[UnusedImport]: off.}
 import "."/[config, confload, commands, norecurse, sinks,
             attestation_api, util]
-
-const cprofiling {.booldefine.} = false
-
-when cprofiling:
-  import nimprof
 
 when isMainModule:
   setupSignalHandlers() # util.nim

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -71,20 +71,21 @@ type
                                      ## need to inspect twice when we build + push.
     resourceType*:  set[ResourceType]
 
+  PluginClearCb*       = proc (a: Plugin) {.cdecl.}
   ChalkTimeHostCb*     = proc (a: Plugin): ChalkDict {.cdecl.}
   ChalkTimeArtifactCb* = proc (a: Plugin, b: ChalkObj): ChalkDict {.cdecl.}
-  RunTimeArtifactCb*   = proc (a: Plugin, b: ChalkObj, c: bool):
-                             ChalkDict {.cdecl.}
+  RunTimeArtifactCb*   = proc (a: Plugin, b: ChalkObj, c: bool): ChalkDict {.cdecl.}
   RunTimeHostCb*       = proc (a: Plugin, b: seq[ChalkObj]): ChalkDict {.cdecl.}
   ScanCb*              = proc (a: Plugin, b: string): Option[ChalkObj] {.cdecl.}
   UnchalkedHashCb*     = proc (a: Plugin, b: ChalkObj): Option[string] {.cdecl.}
   EndingHashCb*        = proc (a: Plugin, b: ChalkObj): Option[string] {.cdecl.}
   ChalkIdCb*           = proc (a: Plugin, b: ChalkObj): string {.cdecl.}
-  HandleWriteCb*       = proc (a: Plugin, b: ChalkObj,
-                               c: Option[string]) {.cdecl.}
+  HandleWriteCb*       = proc (a: Plugin, b: ChalkObj, c: Option[string]) {.cdecl.}
+
   Plugin* = ref object
     name*:                     string
     enabled*:                  bool
+    clearState*:               PluginClearCb
     getChalkTimeHostInfo*:     ChalkTimeHostCb
     getChalkTimeArtifactInfo*: ChalkTimeArtifactCb
     getRunTimeArtifactInfo*:   RunTimeArtifactCb
@@ -474,12 +475,13 @@ var
   doingTestRun*           = false
   nativeCodecsOnly*       = false
   passedHelpFlag*         = false
-  con4mRuntime*:          ConfigStack
-  commandName*:           string
-  gitExeLocation*:        string = ""
-  sshKeyscanExeLocation*: string = ""
-  dockerInvocation*:      DockerInvocation
-  externalActions*:       seq[seq[string]] = @[]
+  installedPlugins*       = Table[string, Plugin]()
+  externalActions*        = newSeq[seq[string]]()
+  commandName*            = ""
+  gitExeLocation*         = ""
+  sshKeyscanExeLocation*  = ""
+  con4mRuntime*:          ConfigStack # can be nil
+  dockerInvocation*:      DockerInvocation # ca be nil
 
 template dumpExOnDebug*() =
   when not defined(release):

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -479,6 +479,7 @@ var
   gitExeLocation*:        string = ""
   sshKeyscanExeLocation*: string = ""
   dockerInvocation*:      DockerInvocation
+  externalActions*:       seq[seq[string]] = @[]
 
 template dumpExOnDebug*() =
   when not defined(release):

--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -148,7 +148,6 @@ proc doHeartbeatReport(chalkOpt: Option[ChalkObj]) =
   if chalkOpt.isSome():
     let chalk = chalkOpt.get()
 
-
     chalk.addToAllChalks()
     chalk.collectedData = ChalkDict()
 

--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -143,7 +143,6 @@ proc getParentExitStatus(trueParentPid: Pid): bool =
   return false
 
 proc doHeartbeatReport(chalkOpt: Option[ChalkObj]) =
-  clearReportingState()
   initCollection()
   if chalkOpt.isSome():
     let chalk = chalkOpt.get()
@@ -166,10 +165,12 @@ template doHeartbeat(chalkOpt: Option[ChalkObj], pid: Pid, fn: untyped) =
     sleepInterval = int(inMicroSec / 1000)
 
   setCommandName("heartbeat")
+  clearReportingState()
 
   while true:
     sleep(sleepInterval)
     chalkOpt.doHeartbeatReport()
+    clearReportingState()
     if fn(pid):
       break
 

--- a/src/plugin_api.nim
+++ b/src/plugin_api.nim
@@ -544,9 +544,7 @@ proc defaultCodecWrite*(s:     Plugin,
   if not chalk.replaceFileContents(contents):
     chalk.opFailed = true
 
-var
-  installedPlugins: Table[string, Plugin]
-  codecs:           seq[Plugin] = @[]
+var codecs: seq[Plugin] = @[]
 
 template isCodec*(plugin: Plugin): bool = attrGet[bool]("plugin." & plugin.name & ".codec")
 
@@ -598,6 +596,7 @@ proc getAllCodecs*(): seq[Plugin] =
 
 proc newPlugin*(
   name:           string,
+  clearCallback:  PluginClearCb       = PluginClearCb(nil),
   ctHostCallback: ChalkTimeHostCb     = ChalkTimeHostCb(nil),
   ctArtCallback:  ChalkTimeArtifactCb = ChalkTimeArtifactCb(nil),
   rtArtCallback:  RunTimeArtifactCb   = RunTimeArtifactCb(nil),
@@ -605,6 +604,7 @@ proc newPlugin*(
   cache:          RootRef             = RootRef(nil)):
     Plugin {.discardable, cdecl.} =
   result = Plugin(name:                     name,
+                  clearState:               clearCallback,
                   getChalkTimeHostInfo:     ctHostCallback,
                   getChalkTimeArtifactInfo: ctArtCallback,
                   getRunTimeArtifactInfo:   rtArtCallback,

--- a/src/plugins/codecMacOs.nim
+++ b/src/plugins/codecMacOs.nim
@@ -12,7 +12,7 @@
 import std/base64
 import ".."/[config, chalkjson, util, plugin_api]
 
-var prefix = """
+let prefix = """
 #!/bin/bash
 
 BASE_NAME=$(basename -- "${BASH_SOURCE[0]}")
@@ -38,7 +38,7 @@ fi
 (base64 -d)  < /bin/cat << CHALK_DADFEDABBADABBEDBAD_END > ${CMDLOC}
 """
 
-var postfixLines = [
+let postfixLines = [
   "CHALK_DADFEDABBADABBEDBAD_END",
   "chmod +x ${CMDLOC}",
   "exec ${CMDLOC} ${@}"

--- a/src/plugins/codecZip.nim
+++ b/src/plugins/codecZip.nim
@@ -21,8 +21,8 @@ type
     tmpDir:        string
 
 var
-    zipDirs:  seq[string]
-    chalkIds: seq[Box]
+  zipDirs:  seq[string]
+  chalkIds: seq[Box]
 
 template pushZipDir(s: string)   = zipDirs.add(s)
 template popZipDir()             = discard zipDirs.pop()

--- a/src/plugins/procfs.nim
+++ b/src/plugins/procfs.nim
@@ -29,6 +29,9 @@ type
     udpSockInfoCache: Option[ProcTable]
     psInfoCache:      Option[ProcFdSet]
 
+proc clearCallback(self: Plugin) {.cdecl.} =
+  self.internalState = RootRef(ProcFsCache())
+
 const PATH_MAX = 4096 # PROC_PIDPATHINFO_MAXSIZE on mac
 let
   clockSpeed = float(sysconf(SC_CLK_TCK))
@@ -694,6 +697,7 @@ proc procfsGetRunTimeArtifactInfo(self: Plugin, obj: ChalkObj, ins: bool):
 proc loadProcFs*() =
   when hostOs == "linux":
     newPlugin("procfs",
+              clearCallback  = PluginClearCb(clearCallback),
               rtHostCallback = RunTimeHostCb(procfsGetRunTimeHostInfo),
               rtArtCallback  = RunTimeArtifactCb(procfsGetRunTimeArtifactInfo),
               cache          = RootRef(ProcFsCache()))

--- a/src/plugins/system.nim
+++ b/src/plugins/system.nim
@@ -15,9 +15,7 @@ import std/[monotimes, nativesockets, sequtils, times]
 import ".."/[config, plugin_api, normalize, chalkjson, attestation_api,
              util]
 
-var
-  externalActions: seq[seq[string]] = @[]
-  execId = secureRand[uint64]().toHex().toLower()
+var execId = secureRand[uint64]().toHex().toLower()
 
 proc recordExternalActions(kind: string, details: string) =
   externalActions.add(@[kind, details])

--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -272,6 +272,9 @@ type
     origin:     Option[string]
     vcsDirs:    OrderedTable[string, RepoInfo]
 
+proc clearCallback(self: Plugin) {.cdecl.} =
+  self.internalState = RootRef(GitInfo())
+
 proc isAnnotated(self: GitTag): bool =
   return self.tagCommitId != ""
 
@@ -793,8 +796,8 @@ proc isInRepo(obj: ChalkObj, repo: string): bool =
   return false
 
 proc gitInit(self: Plugin) =
-  once:
-    let cache = GitInfo(self.internalState)
+  let cache = GitInfo(self.internalState)
+  if len(cache.vcsDirs) == 0:
     for path in getContextDirectories():
       cache.findAndLoad(path.resolvePath())
 
@@ -837,6 +840,7 @@ proc gitGetRunTimeHostInfo(self: Plugin, chalks: seq[ChalkObj]):
 
 proc loadVctlGit*() =
   newPlugin("vctl_git",
+            clearCallback  = PluginClearCb(clearCallback),
             ctArtCallback  = ChalkTimeArtifactCb(gitGetChalkTimeArtifactInfo),
             rtHostCallback = RunTimeHostCb(gitGetRunTimeHostInfo),
             cache          = RootRef(GitInfo()))

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -82,6 +82,11 @@ proc clearReportingState*() =
   systemErrors    = @[]
   failedKeys      = ChalkDict()
   externalActions = @[]
+  for name, plugin in installedPlugins.pairs():
+    if plugin.clearState == nil:
+      continue
+    let cb = plugin.clearState
+    cb(plugin)
 
 proc pushCollectionCtx*(): CollectionCtx =
   result = CollectionCtx()

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -75,12 +75,13 @@ proc inSubscan*(): bool =
   return len(ctxStack) > 1
 
 proc clearReportingState*() =
-  startTime      = getMonoTime().ticks()
-  ctxStack       = @[CollectionCtx()]
-  hostInfo       = ChalkDict()
-  subscribedKeys = Table[string, bool]()
-  systemErrors   = @[]
-  failedKeys     = ChalkDict()
+  startTime       = getMonoTime().ticks()
+  ctxStack        = @[CollectionCtx()]
+  hostInfo        = ChalkDict()
+  subscribedKeys  = Table[string, bool]()
+  systemErrors    = @[]
+  failedKeys      = ChalkDict()
+  externalActions = @[]
 
 proc pushCollectionCtx*(): CollectionCtx =
   result = CollectionCtx()
@@ -108,7 +109,8 @@ proc getAllChalks*(): seq[ChalkObj] =
 proc getAllChalks*(cc: CollectionCtx): seq[ChalkObj] =
   cc.allChalks
 proc addToAllChalks*(o: ChalkObj) =
-  collectionCtx.allChalks.add(o)
+  if o notin collectionCtx.allChalks:
+    collectionCtx.allChalks.add(o)
 proc setAllChalks*(s: seq[ChalkObj]) =
   collectionCtx.allChalks = s
 proc removeFromAllChalks*(o: ChalkObj) =
@@ -118,7 +120,8 @@ proc removeFromAllChalks*(o: ChalkObj) =
 proc getUnmarked*(): seq[string] =
   collectionCtx.unmarked
 proc addUnmarked*(s: string) =
-  collectionCtx.unmarked.add(s)
+  if s notin collectionCtx.unmarked:
+    collectionCtx.unmarked.add(s)
 proc setContextDirectories*(l: seq[string]) =
   # Used for 'where to look for stuff' plugins, particularly version control.
   collectionCtx.contextDirectories = l


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary


## Issue

chalk running in as daemon with heartbeats had ever-increasing memory footprint

## Description

Each heartbeat report, it would send HTTP request to chalk api. That was done via `safeRequest` from nimutils which would initialize `SslContext`. That context included all root CA certs/etc and would use ~1Mb on average. At the end of the request, it wasnt correctly discarded as nim would GC its reference however it would call into openssl functions to clear all the inner data-structures. Now we explicitly destroy the context after each request to ensure its memory is correctly cleared.

for more:

https://github.com/crashappsec/nimutils/pull/81

## Tests

Run long running process with heartbeats enabled and check its memory utilization.