### PR TITLE
test: adding test for 500 sink

### DIFF
--- a/server/server/api.py
+++ b/server/server/api.py
@@ -105,6 +105,11 @@ async def presign_report_url(
     )
 
 
+@app.post("/500")
+async def error_500():
+    raise HTTPException(500)
+
+
 @app.post("/report", status_code=200)
 @app.put("/report", status_code=200)
 async def accept_report(

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -108,7 +108,8 @@ class ChalkReport(ContainsMixin, dict):
 
     @classmethod
     def from_json(cls, data: str):
-        return cls(json.loads(data)[0])
+        info = json.loads(data)
+        return cls(info if isinstance(info, dict) else info[0])
 
 
 class ChalkMark(ContainsMixin, dict):
@@ -254,6 +255,23 @@ class ChalkProgram(Program):
         assert len(marks) == 1
         return marks[0]
 
+    @property
+    def logged_reports_path(self):
+        return Path.cwd() / "chalk-reports.jsonl"
+
+    @property
+    def logged_reports(self):
+        return [
+            ChalkReport.from_json(json.loads(i)["$message"])
+            for i in self.logged_reports_path.read_text().splitlines()
+        ]
+
+    @property
+    def logged_report(self):
+        reports = self.logged_reports
+        assert len(reports) == 1
+        return reports[0]
+
 
 class Chalk:
     def __init__(
@@ -382,6 +400,7 @@ class Chalk:
         ignore_errors: bool = False,
         expecting_report: bool = True,
         expecting_chalkmarks: bool = True,
+        use_embedded: bool = True,
     ) -> ChalkProgram:
         result = self.run(
             command="insert",
@@ -392,6 +411,7 @@ class Chalk:
             env=env,
             ignore_errors=ignore_errors,
             expecting_report=expecting_report,
+            use_embedded=use_embedded,
         )
         if expecting_report:
             if expecting_chalkmarks:


### PR DESCRIPTION
when sink fails it should cache report but proceed as usual

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~~Updated `CHANGELOG.md` if necessary~~

## Issue

we have seen a possibly hanging chalk after 500 in a sink

## Description

adding test case for when sink errors with 500, rest of the chalk report proceeds as needed

## Testing

```
➜ make tests args="test_sink.py::test_500_http_fastapi --logs --pdb"
```

