### PR TITLE
feat: require TTY to generate new keys in chalk setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   be desirable to add additional files in current working directory.
   ([#445](https://github.com/crashappsec/chalk/pull/445))
 
+- `chalk setup` requires interactive shell to generate new
+  key-material. This will avoid accidentally generating
+  new keys in CI.
+  ([#447](https://github.com/crashappsec/chalk/pull/447))
+
 ### Fixes
 
 - When running `semgrep`, its always added to `PATH`,

--- a/src/attestation/embed.nim
+++ b/src/attestation/embed.nim
@@ -5,6 +5,7 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
+import std/[posix]
 import ".."/[chalk_common, config]
 import "."/utils
 
@@ -20,6 +21,8 @@ proc initCallback(this: AttestationKeyProvider) =
   self.get_paths = attrGet[seq[string]]("attestation.attestation_key_embed.get_paths")
 
 proc generateKeyCallback(this: AttestationKeyProvider): AttestationKey =
+  if isatty(0) == 0:
+    raise newException(ValueError, "Can only generate chalk keys in interactive shell")
   let self = Embed(this)
   result = mintCosignKey(self.save_path.joinPath(self.filename))
   echo()

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -315,6 +315,7 @@ class Chalk:
         cwd: Optional[Path] = None,
         env: Optional[dict[str, str]] = None,
         stdin: Optional[bytes] = None,
+        tty: bool = False,
     ) -> ChalkProgram:
         params = params or []
         cmd: list[str] = [str(self.binary)]
@@ -362,6 +363,7 @@ class Chalk:
                 cwd=cwd,
                 env=env,
                 stdin=stdin,
+                tty=tty,
             )
         )
         if not ignore_errors and expected_success and result.errors:

--- a/tests/functional/test_command.py
+++ b/tests/functional/test_command.py
@@ -162,7 +162,7 @@ def test_setup(
         "CHALK_GET_URL": f"{server_http}/cosign",
     }
     chalk_copy.load(config, replace=False)
-    setup = chalk_copy.run(command="setup", env=env)
+    setup = chalk_copy.run(command="setup", env=env, tty=True)
     assert setup.mark.contains(
         {
             "$CHALK_PUBLIC_KEY": re.compile(r"^-----BEGIN PUBLIC KEY"),


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

it is possible to accidentally generate new keys in CI where it is not desirable.

## Description

follow up to https://github.com/crashappsec/chalk/pull/445

## Testing

```
➜ make tests args="test_command.py::test_setup --logs"
```
