### PR TITLE
fix: DOCKERFILE_PATH_WITHIN_VCTL cannot have :stdin: as value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 ### Fixes
 
 - `DOCKERFILE_PATH_WITHIN_VCTL` key is no longer reported when providing Dockerfile contents
-via `stdin` ([#454](https://github.com/crashappsec/chalk/pull/454)).
+  via `stdin` ([#454](https://github.com/crashappsec/chalk/pull/454)).
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@
 
   ([#450](https://github.com/crashappsec/chalk/pull/450))
 
+### Fixes
+
+- `DOCKERFILE_PATH_WITHIN_VCTL` key is no longer reported when providing Dockerfile contents
+via `stdin` ([#454](https://github.com/crashappsec/chalk/pull/454)).
+
 ### New Features
 
 - Chalk pins base images in `Dockerfile`. For example:

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -459,6 +459,7 @@ const
   commitID*           = staticexec("git rev-parse HEAD")
   archStr*            = staticexec("uname -m")
   osStr*              = staticexec("uname -o")
+  stdinIndicator*     = ":stdin:"
 
   # Make sure that ARTIFACT_TYPE fields are consistently named. I'd love
   # these to be const, but nim doesn't seem to be able to handle that :(

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -7,7 +7,6 @@
 
 import std/json
 import ".."/[
-  chalk_common,
   chalkjson,
   collect,
   config,

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -7,6 +7,7 @@
 
 import std/json
 import ".."/[
+  chalk_common,
   chalkjson,
   collect,
   config,
@@ -51,7 +52,7 @@ proc processGitContext(ctx: DockerInvocation) =
     raise
 
 proc processDockerFile(ctx: DockerInvocation) =
-  if ctx.dockerFileLoc == ":stdin:":
+  if ctx.dockerFileLoc == stdinIndicator:
     let input           = stdin.readAll()
     ctx.inDockerFile  = input
     ctx.originalStdIn = input

--- a/src/docker/cmdline.nim
+++ b/src/docker/cmdline.nim
@@ -11,7 +11,7 @@
 ## is in configs/dockercmd.c4m), so we really just need to look at
 ## the command and flag info returned.
 
-import ".."/[config]
+import ".."/[chalk_common, config]
 import "."/[ids]
 
 proc extractBuildx(ctx: DockerInvocation) =
@@ -71,7 +71,7 @@ proc extractDockerFile(ctx: DockerInvocation) =
     let files = unpack[seq[string]](ctx.processedFlags["file"].getValue())
     ctx.foundFileArg = files[0]
     if ctx.foundFileArg == "-":
-      ctx.dockerFileLoc = ":stdin:"
+      ctx.dockerFileLoc = stdinIndicator
     else:
       ctx.dockerFileLoc = resolvePath(ctx.foundFileArg)
 

--- a/src/docker/cmdline.nim
+++ b/src/docker/cmdline.nim
@@ -11,7 +11,7 @@
 ## is in configs/dockercmd.c4m), so we really just need to look at
 ## the command and flag info returned.
 
-import ".."/[chalk_common, config]
+import ".."/[config]
 import "."/[ids]
 
 proc extractBuildx(ctx: DockerInvocation) =

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -8,7 +8,7 @@
 ## module for interacting with remote registry docker manifests
 
 import std/[httpclient]
-import ".."/[chalk_common, config, www_authenticate, semver, util]
+import ".."/[config, www_authenticate, semver, util]
 import "."/[exe, json, ids, registry]
 
 # cache is by repo ref as its normalized in buildx imagetools command

--- a/src/util.nim
+++ b/src/util.nim
@@ -631,7 +631,7 @@ proc getRelativePathBetween*(fromPath: string, toPath: string) : string =
   ## path of the file's `toPath`. Return nothing if its outside the project root,
   ## if `toPath` is an empty string or, if Dockerfile contents was passed via stdin.
   result = toPath.relativePath(fromPath)
-  if result.startsWith("..") or result == "" or result.endsWith(":stdin:"):
+  if result.startsWith("..") or result == "" or result.endsWith(stdinIndicator):
     trace("File is ephemeral or not contained within VCS project")
     return ""
 

--- a/src/util.nim
+++ b/src/util.nim
@@ -628,10 +628,10 @@ proc getOrDefault*[T](self: openArray[T], i: int, default: T): T =
 
 proc getRelativePathBetween*(fromPath: string, toPath: string) : string =
   ## Given the `fromPath`, usually the project root, return the relative
-  ## path of the file's `toPath`. Return nothing if its outside the project root
-  ## or if `toPath` is an empty string.
+  ## path of the file's `toPath`. Return nothing if its outside the project root,
+  ## if `toPath` is an empty string or, if Dockerfile contents was passed via stdin.
   result = toPath.relativePath(fromPath)
-  if result.startsWith("..") or result == "":
+  if result.startsWith("..") or result == "" or result.endsWith(":stdin:"):
     trace("File is ephemeral or not contained within VCS project")
     return ""
 

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -534,6 +534,7 @@ def test_base_images(chalk: Chalk, random_hex: str):
                 }
             ],
         },
+        DOCKERFILE_PATH_WITHIN_VCTL=MISSING,
     )
 
 


### PR DESCRIPTION
If the contents of a Dockerfile is passed via stdin (e.g. FROM alpine | chalk build) the key reporting the relative path should be dropped.

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

The predicates that would trigger the dropping of `DOCKERFILE_PATH_WITHIN_VCTL` were insufficient in the case where a Dockerfile's contents was provided via a pipe (e.g., `FROM alpine | chalk docker build -f - .`). This resulted in the reporting of values like `:stdin:` or `some/path/:stdin:`.

## Testing

<!-- What are the steps needed to test this PR? -->
make tests args="test_docker.py::test_piped_dockerfile_has_no_relative_path --logs
