### PR TITLE
fix: context manager to scope logs collection for _OP_ERRORS and ERR_INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,18 @@
   wrong commit TZ was being reported as committed in git which was not correct.
   ([#458](https://github.com/crashappsec/chalk/pull/458))
 
+- `_OP_ERRORS` includes all logs from chalkmark `ERR_INFO`,
+  even when its collection fails
+  ([#459](https://github.com/crashappsec/chalk/pull/459))
+
+- `docker buildx build` without both `--push` or `--load` report their
+  chalkmarks now. Chalkmarks however are missing any runtime keys
+  as those cannot be inspected due to image neither being pushed
+  to a registry or loaded into local daemon. Such an image is normally
+  inaccessible however it is still in buildx cache hence it can be
+  used in subsequent builds.
+  ([#459](https://github.com/crashappsec/chalk/pull/459))
+
 ### New Features
 
 - Chalk pins base images in `Dockerfile`. For example:

--- a/src/collect.nim
+++ b/src/collect.nim
@@ -145,90 +145,92 @@ proc initCollection*() =
       collectChalkTimeHostInfo()
 
 proc collectRunTimeArtifactInfo*(artifact: ChalkObj) =
-  trace("Collecting run time artifact info")
-  for plugin in getAllPlugins():
-    let
-      data       = artifact.collectedData
-      subscribed = attrGet[seq[string]]("plugin." & plugin.name & ".post_chalk_keys")
+  artifact.withErrorContext():
+    trace("Collecting run time artifact info")
+    for plugin in getAllPlugins():
+      let
+        data       = artifact.collectedData
+        subscribed = attrGet[seq[string]]("plugin." & plugin.name & ".post_chalk_keys")
 
-    if chalkCollectionSuspendedFor(plugin.name):               continue
-    if not plugin.hasSubscribedKey(subscribed, data):          continue
-    if attrGet[bool]("plugin." & plugin.name & ".codec") and plugin != artifact.myCodec: continue
+      if chalkCollectionSuspendedFor(plugin.name):               continue
+      if not plugin.hasSubscribedKey(subscribed, data):          continue
+      if attrGet[bool]("plugin." & plugin.name & ".codec") and plugin != artifact.myCodec: continue
 
-    trace("Running plugin: " & plugin.name)
-    try:
-      let dict = plugin.callGetRunTimeArtifactInfo(artifact, isChalkingOp())
-      if dict == nil or len(dict) == 0: continue
-      for k, v in dict:
-        if not plugin.canWrite(k, attrGet[seq[string]]("plugin." & plugin.name & ".post_chalk_keys")): continue
-        if k notin artifact.collectedData or
-            k in attrGet[seq[string]]("plugin." & plugin.name & ".overrides") or
-            plugin.isSystem():
-          artifact.collectedData[k] = v
-      trace(plugin.name & ": Plugin called.")
-    except:
-      error("When collecting run-time artifact data, plugin implementation " &
-            plugin.name & " threw an exception it didn't handle (artifact = " &
-            artifact.name & "): " & getCurrentExceptionMsg())
-      dumpExOnDebug()
+      trace("Running plugin: " & plugin.name)
+      try:
+        let dict = plugin.callGetRunTimeArtifactInfo(artifact, isChalkingOp())
+        if dict == nil or len(dict) == 0: continue
+        for k, v in dict:
+          if not plugin.canWrite(k, attrGet[seq[string]]("plugin." & plugin.name & ".post_chalk_keys")): continue
+          if k notin artifact.collectedData or
+              k in attrGet[seq[string]]("plugin." & plugin.name & ".overrides") or
+              plugin.isSystem():
+            artifact.collectedData[k] = v
+        trace(plugin.name & ": Plugin called.")
+      except:
+        error("When collecting run-time artifact data, plugin implementation " &
+              plugin.name & " threw an exception it didn't handle (artifact = " &
+              artifact.name & "): " & getCurrentExceptionMsg())
+        dumpExOnDebug()
 
-  let hashOpt = artifact.callGetEndingHash()
-  if hashOpt.isSome():
-    artifact.collectedData["_CURRENT_HASH"] = pack(hashOpt.get())
+    let hashOpt = artifact.callGetEndingHash()
+    if hashOpt.isSome():
+      artifact.collectedData["_CURRENT_HASH"] = pack(hashOpt.get())
 
 proc rtaiLinkingHack*(artifact: ChalkObj) {.cdecl, exportc.} =
   artifact.collectRunTimeArtifactInfo()
 
 proc collectChalkTimeArtifactInfo*(obj: ChalkObj, override = false) =
-  # Note that callers must have set obj.collectedData to something
-  # non-null.
-  obj.opFailed      = false
-  let data          = obj.collectedData
+  obj.withErrorContext():
+    # Note that callers must have set obj.collectedData to something
+    # non-null.
+    obj.opFailed      = false
+    let data          = obj.collectedData
 
-  trace("Collecting chalk-time data.")
-  for plugin in getAllPlugins():
-    if chalkCollectionSuspendedFor(plugin.name): continue
+    trace("Collecting chalk-time data.")
+    for plugin in getAllPlugins():
+      if chalkCollectionSuspendedFor(plugin.name): continue
 
-    if plugin == obj.myCodec:
-      trace("Filling in codec info")
-      if "CHALK_ID" notin data:
-        data["CHALK_ID"]      = pack(obj.callGetChalkID())
-      let preHashOpt = obj.callGetUnchalkedHash()
-      if preHashOpt.isSome():
-        data["HASH"]          = pack(preHashOpt.get())
-      if obj.fsRef != "":
-        data["PATH_WHEN_CHALKED"] = pack(resolvePath(obj.fsRef))
+      if plugin == obj.myCodec:
+        trace("Filling in codec info")
+        if "CHALK_ID" notin data:
+          data["CHALK_ID"]      = pack(obj.callGetChalkID())
+        let preHashOpt = obj.callGetUnchalkedHash()
+        if preHashOpt.isSome():
+          data["HASH"]          = pack(preHashOpt.get())
+        if obj.fsRef != "":
+          data["PATH_WHEN_CHALKED"] = pack(resolvePath(obj.fsRef))
 
-    if attrGet[bool]("plugin." & plugin.name & ".codec") and plugin != obj.myCodec: continue
+      if attrGet[bool]("plugin." & plugin.name & ".codec") and plugin != obj.myCodec: continue
 
-    let subscribed = attrGet[seq[string]]("plugin." & plugin.name & ".pre_chalk_keys")
-    if not plugin.hasSubscribedKey(subscribed, data) and not plugin.isSystem():
-      trace(plugin.name & ": Skipping plugin; its metadata wouldn't be used.")
-      continue
-
-    if plugin.getChalkTimeArtifactInfo == nil:
-      continue
-
-    trace("Running plugin: " & plugin.name)
-    try:
-      let dict = plugin.callGetChalkTimeArtifactInfo(obj)
-      if dict == nil or len(dict) == 0:
-        trace(plugin.name & ": Plugin produced no keys to use.")
+      let subscribed = attrGet[seq[string]]("plugin." & plugin.name & ".pre_chalk_keys")
+      if not plugin.hasSubscribedKey(subscribed, data) and not plugin.isSystem():
+        trace(plugin.name & ": Skipping plugin; its metadata wouldn't be used.")
         continue
 
-      for k, v in dict:
-        if not plugin.canWrite(k, attrGet[seq[string]]("plugin." & plugin.name & ".pre_chalk_keys")): continue
-        if k notin obj.collectedData or
-            k in attrGet[seq[string]]("plugin." & plugin.name & ".overrides") or
-            plugin.isSystem() or
-            override:
-          obj.collectedData[k] = v
-      trace(plugin.name & ": Plugin called.")
-    except:
-      error("When collecting chalk-time artifact data, plugin implementation " &
-            plugin.name & " threw an exception it didn't handle (artifact = " &
-            obj.name & "): " & getCurrentExceptionMsg())
-      dumpExOnDebug()
+      if plugin.getChalkTimeArtifactInfo == nil:
+        continue
+
+      trace("Running plugin: " & plugin.name)
+      try:
+        let dict = plugin.callGetChalkTimeArtifactInfo(obj)
+        if dict == nil or len(dict) == 0:
+          trace(plugin.name & ": Plugin produced no keys to use.")
+          continue
+
+        for k, v in dict:
+          if not plugin.canWrite(k, attrGet[seq[string]]("plugin." & plugin.name & ".pre_chalk_keys")): continue
+          if k notin obj.collectedData or
+              k in attrGet[seq[string]]("plugin." & plugin.name & ".overrides") or
+              plugin.isSystem() or
+              override:
+            obj.collectedData[k] = v
+        trace(plugin.name & ": Plugin called.")
+      except:
+        error("When collecting chalk-time artifact data, plugin implementation " &
+              plugin.name & " threw an exception it didn't handle (artifact = " &
+              obj.name & "): " & getCurrentExceptionMsg())
+        dumpExOnDebug()
 
 proc collectRunTimeHostInfo*() =
   if hostCollectionSuspended(): return
@@ -359,49 +361,49 @@ iterator artifacts*(argv: seq[string], notTmp=true): ChalkObj =
       let chalks = codec.scanArtifactLocations(iterInfo)
 
       for obj in chalks:
-        iterInfo.fileExclusions.add(obj.fsRef)
+        obj.withErrorContext():
+          iterInfo.fileExclusions.add(obj.fsRef)
 
-        if obj.extract != nil and "MAGIC" in obj.extract:
-          obj.marked = true
+          if obj.extract != nil and "MAGIC" in obj.extract:
+            obj.marked = true
 
-        if ResourceFile in obj.resourceType:
-          if obj.fsRef == "":
-            obj.fsRef = obj.name
-            warn("Codec did not properly set the fsRef field.")
+          if ResourceFile in obj.resourceType:
+            if obj.fsRef == "":
+              obj.fsRef = obj.name
+              warn("Codec did not properly set the fsRef field.")
 
-        let path = obj.fsRef
-        if isChalkingOp():
-          if path.ignoreArtifact(iterInfo.skips):
-            if notTmp: addUnmarked(path)
-            if obj.isMarked():
-              info(path & ": Ignoring, but previously chalked")
+          let path = obj.fsRef
+          if isChalkingOp():
+            if path.ignoreArtifact(iterInfo.skips):
+              if notTmp: addUnmarked(path)
+              if obj.isMarked():
+                info(path & ": Ignoring, but previously chalked")
+              else:
+                trace(path & ": ignoring artifact")
             else:
-              trace(path & ": ignoring artifact")
+              if notTmp: obj.addToAllChalks()
+              if obj.isMarked():
+                info(path & ": Existing chalk mark extracted")
+              else:
+                trace(path & ": Currently unchalked")
           else:
             if notTmp: obj.addToAllChalks()
-            if obj.isMarked():
-              info(path & ": Existing chalk mark extracted")
+            if not obj.isMarked():
+              if notTmp: addUnmarked(path)
+              warn(path & ": Artifact is unchalked")
             else:
-              trace(path & ": Currently unchalked")
-        else:
-          if notTmp: obj.addToAllChalks()
-          if not obj.isMarked():
-            if notTmp: addUnmarked(path)
-            warn(path & ": Artifact is unchalked")
-          else:
-            for k, v in obj.extract:
-              obj.collectedData[k] = v
+              for k, v in obj.extract:
+                obj.collectedData[k] = v
 
-            info(path & ": Chalk mark extracted")
+              info(path & ": Chalk mark extracted")
 
-        if getCommandName() in ["insert", "docker"]:
-          obj.persistInternalValues()
-        yield obj
+          if getCommandName() in ["insert", "docker"]:
+            obj.persistInternalValues()
+          yield obj
 
-        clearErrorObject()
-        if not inSubscan() and not obj.forceIgnore and
-           obj.name notin getUnmarked():
-          obj.collectRuntimeArtifactInfo()
+          if not inSubscan() and not obj.forceIgnore and
+             obj.name notin getUnmarked():
+            obj.collectRuntimeArtifactInfo()
 
   if not inSubscan():
     if getCommandName() != "extract":
@@ -419,10 +421,10 @@ iterator artifacts*(argv: seq[string], notTmp=true): ChalkObj =
             error(item & ": No image or container found")
         else:
           let chalk = objOpt.get()
-          chalk.addToAllChalks()
-          if chalk.extract == nil:
-            info(chalk.name & ": Artifact is unchalked.")
-          trace("Collecting artifact runtime info")
-          chalk.collectRuntimeArtifactInfo()
-          yield chalk
-          clearErrorObject()
+          chalk.withErrorContext():
+            chalk.addToAllChalks()
+            if chalk.extract == nil:
+              info(chalk.name & ": Artifact is unchalked.")
+            trace("Collecting artifact runtime info")
+            chalk.collectRuntimeArtifactInfo()
+            yield chalk

--- a/src/commands/cmd_extract.nim
+++ b/src/commands/cmd_extract.nim
@@ -11,13 +11,13 @@ import "../docker"/[scan]
 import ".."/[config, collect, reporting]
 
 proc processDockerChalk(item: ChalkObj) =
-  trace("Processing artifact: " & item.name)
-  item.addToAllChalks()
-  trace("Collecting artifact runtime info")
-  item.collectRuntimeArtifactInfo()
-  if item.extract == nil:
-    info(item.name & ": Artifact is unchalked.")
-  clearErrorObject()
+  item.withErrorContext():
+    trace("Processing artifact: " & item.name)
+    item.addToAllChalks()
+    trace("Collecting artifact runtime info")
+    item.collectRuntimeArtifactInfo()
+    if item.extract == nil:
+      info(item.name & ": Artifact is unchalked.")
 
 proc coreExtractFiles(path: seq[string]) =
   var numExtracts = 0

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -497,8 +497,6 @@ proc dockerBuild*(ctx: DockerInvocation): int =
   trace("docker: preparing chalk marks for build")
   var oneChalk         = baseChalk
   let chalksByPlatform = baseChalk.copyPerPlatform(ctx.platforms)
-  for _, chalk in chalksByPlatform:
-    chalk.addToAllChalks()
   # chalk time artifact info determines metadata id/etc
   # so has to be done by platform
   for _, chalk in chalksByPlatform:
@@ -574,6 +572,12 @@ proc dockerBuild*(ctx: DockerInvocation): int =
       ValueError,
       "wrapped docker build exited with " & $result
     )
+
+  # build succeeded so safe to add these chalks to all chalks
+  # as otherwise if we add too early chalkmark might be reported
+  # before artifact/image is built
+  for _, chalk in chalksByPlatform:
+    chalk.addToAllChalks()
 
   ctx.readIidFile()
   ctx.readMetadataFile()

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -1016,7 +1016,7 @@ def test_nonvirtual_invalid(chalk: Chalk, test_file: str, random_hex: str):
         expected_success=False,
     )
 
-    assert result.report.has(_OP_EXIT_CODE=result.exit_code)
+    assert result.report.has(_OP_EXIT_CODE=result.exit_code, _CHALKS=MISSING)
 
 
 def test_docker_heartbeat(chalk_copy: Chalk, random_hex: str):

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -1407,8 +1407,8 @@ def test_multiplatform_build(
     if not push:
         # as no image is loaded without --push,
         # we cant inspect anything
-        with pytest.raises(KeyError):
-            build.marks
+        for mark in build.marks:
+            assert mark.has(_CURRENT_HASH=MISSING, _IMAGE_ID=MISSING)
         return
 
     assert len(build.marks) == len(platforms)


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

not all logs were showing up in `_OP_ERRORS`

## Description

without context manager it was a manual process which was setting the current error object which is responsible for populating either _OP_ERRORS or ERR_INFO keys. As such for example during docker build, as soon as chalk was starting subscan of the docker binary, its target was switched to the docker binary chalk object hence no more logs were collected for `_OP_ERRORS` even after subscan was complete.

Now operations explicitly have to use context manager to limit the scope of the current error object hence guaranteeing scope is always reverted to the original object. Docker collection is more involved due to multi-platform builds as a single base-chalk is used to create possibly many subplatform chalk objects hence the context manager is necessary in a few surgical places.

## Testing

```
➜ reset; CHALK_BUILD=debug make; and echo ------------------------------; and ./chalk docker build -f (echo FROM alpines | psub) .
```
