### PR TITLE
fix: empty buildx node config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,7 +256,7 @@
   {
     "_DOCKER_USED_REGISTIES" {
       "example.com:5044": {
-        "url": "https://example.com:5044/v2",
+        "url": "https://example.com:5044/v2/",
         "source": "buildx",
         "scheme": "https",
         "http": false,

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023-2024, Crash Override, Inc.
+## Copyright (c) 2023-2025, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -449,7 +449,8 @@ const
                         staticRead("configs/base_report_templates.c4m") &
                         staticRead("configs/base_outconf.c4m") &
                         staticRead("configs/base_sinkconfs.c4m") &
-                        staticRead("configs/dockercmd.c4m")
+                        staticRead("configs/dockercmd.c4m") &
+                        staticRead("configs/buildkitcmd.c4m")
   sbomConfig*         = staticRead(sbomConfName)
   sastConfig*         = staticRead(sastConfName)
   techStackConfig*    = staticRead(techStackConfName)

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023, Crash Override, Inc.
+## Copyright (c) 2023-2025, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -2312,7 +2312,7 @@ For example:
 ```json
 {
   "example.com:5044": {
-    "url": "https://example.com:5044/v2",
+    "url": "https://example.com:5044/v2/",
     "source": "buildx",
     "scheme": "https",
     "http": false,

--- a/src/configs/buildkitcmd.c4m
+++ b/src/configs/buildkitcmd.c4m
@@ -1,0 +1,22 @@
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Used to (liberally) parse the buildkit command line.
+
+buildkit {
+  getopts {
+    args: (0, high())
+    default_yes_prefixes: []
+    default_no_prefixes:  []
+    show_doc_on_err:      false
+    add_help_commands:    false
+    ignore_bad_flags:     true
+    colon_ok:             false
+    space_ok:             true
+    flag_multi_arg config { }
+  }
+}

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023-2024, Crash Override, Inc.
+## Copyright (c) 2023-2025, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -1914,6 +1914,18 @@ ENV ARTIFACT_IDENTIFIER="X6VRPZ-C828-KDNS-QDXRT0"
   }
 }
 
+singleton buildkit {
+  gen_fieldname: "buildkitConfig"
+  gen_typename:  "BuildkitConfig"
+  gen_setters:   false
+  user_def_ok:   false
+  doc: """
+Buildkit cmdline parsing options
+"""
+  allow getopts
+}
+
+
 singleton git {
   gen_fieldname: "gitConfig"
   gen_typename:  "GitConfig"
@@ -2677,6 +2689,7 @@ root {
   allow tool
   allow extract
   allow docker
+  allow buildkit
   allow exec
   allow load
   allow env_config

--- a/src/docker/exe.nim
+++ b/src/docker/exe.nim
@@ -1,13 +1,12 @@
 ##
-## Copyright (c) 2023-2024, Crash Override, Inc.
+## Copyright (c) 2023-2025, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
 import std/[os, sets]
-import pkg/[parsetoml]
-import ".."/[config, util, semver, toml]
+import ".."/[config, util, semver]
 
 var
   dockerExeLocation   = ""
@@ -201,69 +200,6 @@ proc getBuilderInfo*(ctx: DockerInvocation): string =
         trace("docker: could not get buildx builder information: " & output.getStdErr())
       builderInfo = output.getStdOut()
   return builderInfo
-
-proc getBuilderNodesInfo*(ctx: DockerInvocation): TableRef[string, string] =
-  result = newTable[string, string]()
-  var
-    foundNodes = false
-    name       = ""
-  for line in ctx.getBuilderInfo().splitLines():
-    let lower = line.toLower()
-    if lower.startsWith("driver:"):
-      let driver = line.splitWhitespace()[^1]
-      if driver != "docker-container":
-        trace("docker: unsupported buildx builder driver: " & driver)
-        return
-    if lower.startsWith("nodes:"):
-      foundNodes = true
-      continue
-    if not foundNodes:
-      continue
-    if lower.startsWith("name:"):
-      name = line.splitWhitespace()[^1]
-      result[name] = ""
-    result[name] &= line & "\n"
-
-var nodeFiles = newTable[string, string]()
-proc readBuilderNodeFile*(ctx: DockerInvocation, node: string, path: string): string =
-  let key = node & ":" & path
-  if key in nodeFiles:
-    return nodeFiles[key]
-  let
-    # ideally we can query the namespaces however they are not exposed
-    # via docker info output and are only stored in the buildx config files
-    # which we cant read until we know the namespaces
-    # TODO search through all running containers if the default namespace is not found
-    container = "buildx_buildkit_" & node
-    output    = runDockerGetEverything(
-      @[
-        "exec",
-        container,
-        "cat",
-        path,
-      ],
-      silent = false,
-    )
-  if output.exitCode != 0:
-    raise newException(ValueError, "could not read buildx node's " & container & " " & path)
-  result = output.stdOut
-  nodeFiles[key] = result
-
-iterator iterBuilderNodesConfigs*(ctx: DockerInvocation): tuple[name: string, config: JsonNode] =
-  for name, _ in ctx.getBuilderNodesInfo():
-    try:
-      let
-        toml   = ctx.readBuilderNodeFile(name, "/etc/buildkit/buildkitd.toml")
-        config = parsetoml.parseString(toml).toJson().fromTomlJson()
-      yield (name, config)
-    except:
-      trace("docker: could not load toml for buildx node " & name & " due to: " & getCurrentExceptionMsg())
-      continue
-
-proc getBuilderNodesConfigs*(ctx: DockerInvocation): TableRef[string, JsonNode] =
-  result = newTable[string, JsonNode]()
-  for name, config in ctx.iterBuilderNodesConfigs():
-    result[name] = config
 
 proc getBuildKitVersion*(ctx: DockerInvocation): Version =
   once:

--- a/src/docker/nodes.nim
+++ b/src/docker/nodes.nim
@@ -1,0 +1,89 @@
+##
+## Copyright (c) 2024-2025, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+import pkg/[parsetoml]
+import ".."/[config, util, toml]
+import "."/[exe, inspect]
+
+proc getBuilderNodesInfo*(ctx: DockerInvocation): TableRef[string, string] =
+  result = newTable[string, string]()
+  var
+    foundNodes = false
+    name       = ""
+  for line in ctx.getBuilderInfo().splitLines():
+    let lower = line.toLower()
+    if lower.startsWith("driver:"):
+      let driver = line.splitWhitespace()[^1]
+      if driver != "docker-container":
+        trace("docker: unsupported buildx builder driver: " & driver)
+        return
+    if lower.startsWith("nodes:"):
+      foundNodes = true
+      continue
+    if not foundNodes:
+      continue
+    if lower.startsWith("name:"):
+      name = line.splitWhitespace()[^1]
+      result[name] = ""
+    result[name] &= line & "\n"
+
+proc containerNameForBuilderNode*(node: string): string =
+  # ideally we can query the namespaces however they are not exposed
+  # via docker info output and are only stored in the buildx config files
+  # which we cant read until we know the namespaces
+  # TODO search through all running containers if the default namespace is not found
+  return "buildx_buildkit_" & node
+
+var nodeFiles = newTable[string, string]()
+proc readBuilderNodeFile*(ctx: DockerInvocation, node: string, path: string): string =
+  let key = node & ":" & path
+  if key in nodeFiles:
+    return nodeFiles[key]
+  let
+    container = containerNameForBuilderNode(node)
+    output    = runDockerGetEverything(
+      @[
+        "exec",
+        container,
+        "cat",
+        path,
+      ],
+      silent = false,
+    )
+  if output.exitCode != 0:
+    raise newException(ValueError, "could not read buildx node's " & container & " " & path)
+  result = output.stdOut
+  nodeFiles[key] = result
+
+iterator iterBuilderNodesConfigs*(ctx: DockerInvocation): tuple[name: string, config: JsonNode] =
+  for name, _ in ctx.getBuilderNodesInfo():
+    try:
+      let
+        container  = containerNameForBuilderNode(name)
+        config     = inspectContainerJson(container){"Config"}
+        entrypoint = config{"Entrypoint"}
+        cmd        = config{"Cmd"}
+        args       = (entrypoint & cmd).getStrElems()
+      con4mRuntime.addStartGetopts("buildkit.getopts", args = args).run()
+      let flags    = con4mRuntime.getFlags()
+      if "config" notin flags:
+        trace("docker: " & name & " builder node is not using custom configuration. using empty default config")
+        yield (name, newJObject())
+      else:
+        let
+          configs  = unpack[seq[string]](flags["config"].getValue())
+          toml     = ctx.readBuilderNodeFile(name, configs[0])
+          config   = parsetoml.parseString(toml).toJson().fromTomlJson()
+        yield (name, config)
+    except:
+      trace("docker: could not load toml for buildx node " & name & " due to: " & getCurrentExceptionMsg())
+      continue
+
+proc getBuilderNodesConfigs*(ctx: DockerInvocation): TableRef[string, JsonNode] =
+  result = newTable[string, JsonNode]()
+  for name, config in ctx.iterBuilderNodesConfigs():
+    result[name] = config

--- a/src/plugins/codecDocker.nim
+++ b/src/plugins/codecDocker.nim
@@ -5,7 +5,7 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
-import "../docker"/[collect, ids, exe, registry]
+import "../docker"/[collect, ids, exe, registry, nodes]
 import ".."/[config, plugin_api, semver, chalkjson]
 
 const markLocation = "/chalk.json"

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, Crash Override, Inc.
+# Copyright (c) 2023-2025, Crash Override, Inc.
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
@@ -579,6 +579,7 @@ class Chalk:
         load: bool = True,
         platforms: Optional[list[str]] = None,
         buildx: bool = False,
+        builder: Optional[str] = None,
         config: Optional[Path] = None,
         buildkit: bool = True,
         secrets: Optional[dict[str, Path]] = None,
@@ -610,6 +611,7 @@ class Chalk:
                 expected_success=expected_success,
                 buildkit=buildkit,
                 buildx=buildx,
+                builder=builder,
                 secrets=secrets,
                 provenance=provenance,
                 sbom=sbom,
@@ -628,6 +630,7 @@ class Chalk:
             load=load,
             platforms=platforms,
             buildx=buildx,
+            builder=builder,
             secrets=secrets,
             buildkit=buildkit,
             provenance=provenance,

--- a/tests/functional/entrypoint.sh
+++ b/tests/functional/entrypoint.sh
@@ -41,20 +41,26 @@ if which gpg &> /dev/null; then
     )
 fi
 
-name=insecure_builder
-
-if ! docker buildx inspect $name &> /dev/null; then
+insecure_builder=insecure_builder
+if ! docker buildx inspect $insecure_builder &> /dev/null; then
     docker buildx create \
         --use \
         --config=<(cat $FILEDIR/data/templates/docker/buildkitd.toml | envsubst | tee /dev/stderr) \
-        --name $name \
+        --name $insecure_builder \
         node-amd64 \
         > /dev/null
     docker buildx create \
         --append \
         --config=<(cat $FILEDIR/data/templates/docker/buildkitd.toml | envsubst) \
-        --name $name \
+        --name $insecure_builder \
         node-arm64 \
+        > /dev/null
+fi
+
+empty_builder=empty_builder
+if ! docker buildx inspect $empty_builder &> /dev/null; then
+    docker buildx create \
+        --name $empty_builder \
         > /dev/null
 fi
 

--- a/tests/functional/utils/docker.py
+++ b/tests/functional/utils/docker.py
@@ -40,6 +40,7 @@ class Docker:
         buildx: bool = False,
         secrets: Optional[dict[str, Path]] = None,
         buildkit: bool = True,
+        builder: Optional[str] = None,
         provenance: bool = False,
         sbom: bool = False,
         labels: Optional[dict[str, str]] = None,
@@ -86,6 +87,8 @@ class Docker:
                 raise ValueError("--annotation only works with buildx")
             for k, v in annotations.items():
                 cmd += [f"--annotation={k}={v}"]
+        if builder and buildx:
+            cmd += [f"--builder={builder}"]
         cmd += [str(context or ".")]
         yield cmd, stdin
 
@@ -103,6 +106,7 @@ class Docker:
         load: bool = True,
         platforms: Optional[list[str]] = None,
         buildx: bool = False,
+        builder: Optional[str] = None,
         expected_success: bool = True,
         buildkit: bool = True,
         secrets: Optional[dict[str, Path]] = None,
@@ -126,6 +130,7 @@ class Docker:
             load=load,
             platforms=platforms,
             buildx=buildx,
+            builder=builder,
             secrets=secrets,
             buildkit=buildkit,
             provenance=provenance,


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~~Updated `CHANGELOG.md` if necessary~~

## Issue

possible sefault with empty builder node config

## Description

not all build nodes have a config file associated with them and as such buildkitd.toml might not exist. That doesnt mean the node doesnt exist, it simply means it has no custom config.

For example:

```
docker buildx create test
```

To correctly detect whether a node has a config or not, the container entrypoint/cmd are inspected to find the corresponding `--config` and if present, only then attempts to read the node config. Otherwise empty config is used.

This also surfaced a segfault when using empty config the code was assuming ["registry"] was always present which is not the case.

As the node code now needed to inspect the container args, moved node-related logic to separate nodes.nim therefore allowing it to reference inspect.nim as otherwise would result in circular import as inspect.nim needs exe.nim to make docker subprocess calls.


## Testing

```
➜ maketest test_docker.py::test_build[cwd0-None-False-True-True-empty_builder] -x --pdb
```
