### PR TITLE
feat: _REPO_URLS key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # 3.2.0
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_HUB_PUBLIC_READONLY_TOKEN }}
+
       - name: Prep PWD
         run: |
           mkdir -p ../con4m
@@ -116,6 +122,8 @@ jobs:
           )
         env:
           GITHUB_TOKEN: ${{ steps.org-token.outputs.token }}
+          REGISTRY_PROXY_USERNAME: ${{ github.repository_owner }}
+          REGISTRY_PROXY_PASSWORD: ${{ secrets.DOCKER_HUB_PUBLIC_READONLY_TOKEN }}
         run: |
           make tests_parallel args=""
 
@@ -128,6 +136,8 @@ jobs:
           )
         env:
           GITHUB_TOKEN: ${{ steps.org-token.outputs.token }}
+          REGISTRY_PROXY_USERNAME: ${{ github.repository_owner }}
+          REGISTRY_PROXY_PASSWORD: ${{ secrets.DOCKER_HUB_PUBLIC_READONLY_TOKEN }}
         run: |
           make tests_parallel args="--slow"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,3 +130,8 @@ jobs:
           GITHUB_TOKEN: ${{ steps.org-token.outputs.token }}
         run: |
           make tests_parallel args="--slow"
+
+      - name: Show service logs
+        if: failure()
+        run: |
+          docker compose logs | grep -v health

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
-      - 'server/**'
-      - 'tests/functional/**'
+      - "**.md"
+      - "server/**"
+      - "tests/functional/**"
   pull_request:
     paths-ignore:
-      - '**.md'
-      - 'server/**'
-      - 'tests/functional/**'
+      - "**.md"
+      - "server/**"
+      - "tests/functional/**"
   workflow_dispatch:
 
 permissions:
@@ -47,6 +47,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # 3.2.0
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_HUB_PUBLIC_READONLY_TOKEN }}
 
       - name: Bake images
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
     and the image digest. This key now provides a list of image digests by
     registry and image name.
 
-    #### before
+    **Before**:
 
     ```json
     {
@@ -34,7 +34,7 @@
     }
     ```
 
-    #### now
+    **Now**:
 
     ```json
     {
@@ -73,7 +73,7 @@
     - new `registry` key; the normalized registry uri (domain and optional port)
     - new `name` key; the normalized repo name within the registry
 
-    #### before
+    **Before**:
 
     ```json
     // old format
@@ -85,7 +85,7 @@
     }
     ```
 
-    #### now
+    **Now**:
 
     ```json
     // new format
@@ -120,18 +120,33 @@
     }
     ```
 
+  - `_REPO_URLS` - similar to `_REPO_DIGESTS` but shows human-accessible URL,
+    if known as per OCI image annotation or computed for Docker Hub images.
+    Example:
+
+    ```json
+    {
+      "_REPO_URLS": {
+        "registry-1.docker.io": {
+          "library/alpine": "https://hub.docker.com/_/alpine"
+        }
+      }
+    }
+    ```
+
   **NOTE:** All `_REPO_*` keys normalize registry to its canonical domain. For
   example, docker hub is normalized to `registry-1.docker.io`. Additionally, all
   image names are normalized to how they are stored in the registry. Note
   `library/` prefix for `alpine` in the example above.
 
   ([#450](https://github.com/crashappsec/chalk/pull/450),
-  [#453](https://github.com/crashappsec/chalk/pull/453))
+  [#453](https://github.com/crashappsec/chalk/pull/453),
+  [#464](https://github.com/crashappsec/chalk/pull/464))
 
 - Git time-related fields are now reported in ISO-8601 format whereas
   previously it was reporting using default git format.
 
-  Before:
+  **Before**:
 
   ```json
   {
@@ -141,7 +156,7 @@
   }
   ```
 
-  Now:
+  **Now**:
 
   ```json
   {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,8 +229,11 @@ services:
     ports:
       - "5047:5047"
     environment:
+      - REGISTRY_LOG_LEVEL=debug
       - REGISTRY_HTTP_ADDR=0.0.0.0:5047
       - REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io
+      - REGISTRY_PROXY_USERNAME=${REGISTRY_PROXY_USERNAME:-}
+      - REGISTRY_PROXY_PASSWORD=${REGISTRY_PROXY_PASSWORD:-}
     networks:
       - chalk
     healthcheck:

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -2882,6 +2882,7 @@ keyspec _IMAGE_CREATION_DATETIME {
     doc: """
 The DATETIME formatted string for the reported container image
 creation time.
+The value from docker should be in ISO-8601 format.
 """
 }
 
@@ -4322,6 +4323,38 @@ For example:
       "library/alpine": [
         "1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a"
       ]
+    }
+  }
+}
+```
+"""
+}
+
+keyspec _REPO_URLS {
+    kind:             RunTimeArtifact
+    type:             dict[string, dict[string, string]]
+    standard:         true
+    since:            "0.1.0"
+    doc: """
+User-accessible URLs for the image, if known per registry.
+Chalk knows how to construct URLs for these registries:
+
+* Docker Hub
+
+Alternatively this is populated from OCI annotation `org.opencontainers.image.url`.
+The structure is as follows:
+
+* normalized registry name (domain and port if any)
+* repository name
+* URL as provided by an annotation
+
+For example:
+
+```json
+{
+  "_REPO_DIGESTS": {
+    "registry-1.docker.io": {
+      "library/alpine": "https://hub.docker.com/_/alpine"
     }
   }
 }

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -342,6 +342,7 @@ report and subtract from it.
   key._INSTANCE_IPV6_GATEWAY.use              = true
   key._INSTANCE_MAC.use                       = true
   key._INSTANCE_NETWORKS.use                  = true
+  key._REPO_URLS.use                          = true
   key._REPO_TAGS.use                          = true
   key._REPO_DIGESTS.use                       = true
   key._REPO_LIST_DIGESTS.use                  = true
@@ -941,6 +942,7 @@ doc: """
   key._INSTANCE_MAC.use                       = true
   key._INSTANCE_NETWORKS.use                  = true
   key._STORE_URI.use                          = true
+  key._REPO_URLS.use                          = true
   key._REPO_TAGS.use                          = true
   key._REPO_DIGESTS.use                       = true
   key._REPO_LIST_DIGESTS.use                  = true
@@ -1422,6 +1424,7 @@ container.
   key._INSTANCE_MAC.use                       = true
   key._INSTANCE_NETWORKS.use                  = true
   key._STORE_URI.use                          = true
+  key._REPO_URLS.use                          = true
   key._REPO_TAGS.use                          = true
   key._REPO_DIGESTS.use                       = true
   key._REPO_LIST_DIGESTS.use                  = true
@@ -1906,6 +1909,7 @@ and keep the run-time key.
   key._INSTANCE_MAC.use                       = true
   key._INSTANCE_NETWORKS.use                  = true
   key._STORE_URI.use                          = true
+  key._REPO_URLS.use                          = true
   key._REPO_TAGS.use                          = true
   key._REPO_DIGESTS.use                       = true
   key._REPO_LIST_DIGESTS.use                  = true
@@ -2100,6 +2104,7 @@ running insert commands.
   key._VIRTUAL.use                            = true
   key._CURRENT_HASH.use                       = true
   key._IMAGE_ID.use                           = true
+  key._REPO_URLS.use                          = true
   key._REPO_TAGS.use                          = true
   key._REPO_DIGESTS.use                       = true
   key._REPO_LIST_DIGESTS.use                  = true
@@ -2203,6 +2208,7 @@ running commands that do NOT insert chalk marks.
   key._IMAGE_ID.use                           = true
   key._INSTANCE_CONTAINER_ID.use              = true
   key._INSTANCE_NAME.use                      = true
+  key._REPO_URLS.use                          = true
   key._REPO_TAGS.use                          = true
   key._REPO_DIGESTS.use                       = true
   key._REPO_LIST_DIGESTS.use                  = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -451,6 +451,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key._INSTANCE_MAC.use                       = true
   ~key._INSTANCE_NETWORKS.use                  = true
   ~key._STORE_URI.use                          = true
+  ~key._REPO_URLS.use                          = true
   ~key._REPO_TAGS.use                          = true
   ~key._REPO_DIGESTS.use                       = true
   ~key._REPO_LIST_DIGESTS.use                  = true

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -30,7 +30,7 @@ from .conf import (
     REGISTRY_TLS_INSECURE,
     ROOT,
 )
-from .utils.dict import ANY, MISSING, Contains, IfExists, Length, Values
+from .utils.dict import ANY, MISSING, Contains, IfExists, Iso8601, Length, Values
 from .utils.docker import Docker
 from .utils.git import Git
 from .utils.log import get_logger
@@ -522,6 +522,8 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
 
             FROM {image}:latest as seven
 
+            FROM crashappsec/chalk as chalk
+
             FROM $BASE
             COPY --from=four /usr/sbin/nginx /nginx
             """
@@ -551,6 +553,7 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
                     "_IMAGE_ID": ANY,
                     "METADATA_ID": MISSING,
                     "COMMIT_ID": ANY,
+                    "_IMAGE_CREATION_DATETIME": Iso8601(),
                     "ORIGIN_URI": "https://git.launchpad.net/cloud-images/+oci/ubuntu-base",
                     "_REPO_DIGESTS": {
                         "registry-1.docker.io": {
@@ -564,11 +567,17 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
                             }
                         }
                     },
+                    "_REPO_URLS": {
+                        "registry-1.docker.io": {
+                            "library/ubuntu": "https://hub.docker.com/_/ubuntu"
+                        }
+                    },
                 },
                 {
                     "_IMAGE_ID": ANY,
                     "METADATA_ID": MISSING,
                     "COMMIT_ID": ANY,
+                    "_IMAGE_CREATION_DATETIME": Iso8601(),
                     "ORIGIN_URI": "https://github.com/nginxinc/docker-nginx.git",
                     "_REPO_DIGESTS": {
                         "registry-1.docker.io": {
@@ -582,6 +591,28 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
                             "registry-1.docker.io": MISSING,
                         }
                     ),
+                    "_REPO_URLS": {
+                        "registry-1.docker.io": {
+                            "library/nginx": "https://hub.docker.com/_/nginx"
+                        }
+                    },
+                },
+                {
+                    "_IMAGE_ID": ANY,
+                    "METADATA_ID": ANY,
+                    "COMMIT_ID": ANY,
+                    "_IMAGE_CREATION_DATETIME": Iso8601(),
+                    "ORIGIN_URI": "https://github.com/crashappsec/chalk",
+                    "_REPO_DIGESTS": {
+                        "registry-1.docker.io": {
+                            "crashappsec/chalk": ANY,
+                        }
+                    },
+                    "_REPO_URLS": {
+                        "registry-1.docker.io": {
+                            "crashappsec/chalk": "https://hub.docker.com/r/crashappsec/chalk"
+                        }
+                    },
                 },
             ]
         ),

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -22,6 +22,7 @@ logger = get_logger()
 
 
 @pytest.mark.flaky(max_runs=5)
+@pytest.mark.exclusive
 @pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
 def test_network(copy_files: list[Path], chalk: Chalk):
     bin_path = copy_files[0]

--- a/tests/functional/utils/dict.py
+++ b/tests/functional/utils/dict.py
@@ -9,11 +9,22 @@ from datetime import datetime
 from typing import Any, Callable, Iterable, Optional, cast
 
 
-ANY = object()
-MISSING = object()
+class Repr:
+    def __init__(self, name: str):
+        self.name = name
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+ANY = Repr("ANY")
+MISSING = Repr("MISSING")
 
 
 class Iso8601:
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
     def __eq__(self, other: Any):
         if isinstance(other, datetime):
             return True


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary


## Description

report repo URL whenever possible or compute it for Docker Hub. chalk can add support for more registries in the future.

also populating image creating timestamp from the OCI annotation to report more metadata about non-chalked base images


## Testing

```
➜ maketest test_docker.py::test_base_images --pdb --logs
```
