### PR TITLE
fix: honoring --platform for base image pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- For `docker build`, `--platform` was not honored when pinning base images.
+  ([#468](https://github.com/crashappsec/chalk/pull/468))
+- `_REPO_URLS` was not extracting `org.opencontainers.image.url` annotation
+  correctly.
+  ([#468](https://github.com/crashappsec/chalk/pull/468))
+
 ## 0.5.0
 
 **Jan 08, 2025**

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -134,7 +134,9 @@ proc pinBuildSectionBaseImages*(ctx: DockerInvocation) =
     if s.image.isPinned():
       continue
     try:
-      let manifest = fetchManifestForImage(s.image, ctx.platforms)
+      let
+        platforms = s.platformsOrDefault(ctx.platforms)
+        manifest  = fetchManifestForImage(s.image, platforms)
       s.image = manifest.asImage().withTag(s.image.tag)
     except RegistryResponseError:
       trace("docker: could not pin " & $s.image & " due to: " & getCurrentExceptionMsg())
@@ -334,10 +336,11 @@ proc launchDockerSubscan(ctx:     DockerInvocation,
   trace("docker: subscan complete.")
 
 proc collectBaseImage(chalk: ChalkObj, ctx: DockerInvocation, section: DockerFileSection) =
+  let platform = section.platformOrDefault(chalk.platform)
   trace("docker: collecting chalkmark from base image " &
-        $section.image & " for " & $chalk.platform)
+        $section.image & " for " & $platform)
   try:
-    let baseChalkOpt = scanImage(section.image, platform = chalk.platform)
+    let baseChalkOpt = scanImage(section.image, platform = platform)
     if baseChalkOpt.isNone():
       trace("docker: base image could not be scanned")
       return

--- a/src/docker/collect.nim
+++ b/src/docker/collect.nim
@@ -226,8 +226,8 @@ proc collectImageFrom(chalk:    ChalkObj,
       let
         manifest  = fetchImageManifest(repo, platform)
         imageRepo = manifest.asImageRepo(tag = repo.tag)
-        url       = annotations{"org.opencontainers.image.url"}.getStr(repo.url())
       annotations.update(manifest.annotations)
+      let url = annotations{"org.opencontainers.image.url"}.getStr(repo.url())
       chalk.repos[repo.repo] = imageRepo + chalk.repos.getOrDefault(repo.repo)
       layers = @[]
       for layer in manifest.layers:

--- a/src/docker/dockerfile.nim
+++ b/src/docker/dockerfile.nim
@@ -946,8 +946,21 @@ proc evalAndExtractDockerfile*(ctx: DockerInvocation, args: Table[string, string
       "Did not find any build sections in Dockerfile (no FROM directive)"
     )
 
+proc platformOrDefault*(self: DockerFileSection, default: DockerPlatform): DockerPlatform =
+  if self.platform != nil:
+    return self.platform
+  return default
+
+proc platformsOrDefault*(self: DockerFileSection, default: seq[DockerPlatform]): seq[DockerPlatform] =
+  if self.platform != nil:
+    return @[self.platform]
+  return default
+
 proc asFrom*(self: DockerFileSection): string =
-  result = "FROM " & $self.image
+  result = "FROM "
+  if self.platform != nil:
+    result &= "--platform=" & $self.platform & " "
+  result &= $self.image
   if self.alias != "":
     result &= " AS " & self.alias
 

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -506,13 +506,14 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
             FROM alpine as one
             FROM alpine as oneduplicate
 
+            FROM alpine
             FROM ubuntu:24.04 as two
             COPY --from=docker /usr/local/bin/docker /docker
             COPY --from=busybox:latest /bin/busybox /busybox
 
-            FROM busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7 as three
+            FROM --platform=linux/arm64 busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7 as three
 
-            FROM nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe as four
+            FROM --platform=linux/amd64 nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe as four
 
             FROM one as five
             COPY --from=nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe /usr/sbin/nginx /nginx
@@ -579,6 +580,7 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
                     "COMMIT_ID": ANY,
                     "_IMAGE_CREATION_DATETIME": Iso8601(),
                     "ORIGIN_URI": "https://github.com/nginxinc/docker-nginx.git",
+                    "DOCKER_PLATFORM": "linux/amd64",
                     "_REPO_DIGESTS": {
                         "registry-1.docker.io": {
                             "library/nginx": ANY,
@@ -594,6 +596,31 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
                     "_REPO_URLS": {
                         "registry-1.docker.io": {
                             "library/nginx": "https://hub.docker.com/_/nginx"
+                        }
+                    },
+                },
+                {
+                    "_IMAGE_ID": ANY,
+                    "METADATA_ID": MISSING,
+                    "COMMIT_ID": ANY,
+                    "_IMAGE_CREATION_DATETIME": Iso8601(),
+                    "ORIGIN_URI": "https://github.com/docker-library/busybox.git",
+                    "DOCKER_PLATFORM": re.compile(r"^linux/arm64"),
+                    "_REPO_DIGESTS": {
+                        "registry-1.docker.io": {
+                            "library/busybox": ANY,
+                        }
+                    },
+                    # even though tag is specified in dockerfile, its pinning to digest
+                    # and tag is outdated after new release
+                    "_REPO_TAGS": IfExists(
+                        {
+                            "registry-1.docker.io": MISSING,
+                        }
+                    ),
+                    "_REPO_URLS": {
+                        "registry-1.docker.io": {
+                            "library/busybox": "https://github.com/docker-library/busybox"
                         }
                     },
                 },


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

some build are taking much much longer to run with 0.5.0

for example https://github.com/zaproxy/zaproxy/actions/runs/12799538079/job/35702879563 is ~3h vs normal 20min.

thank you @psiinon for the report

## Description

there are cases where the base image platform might not match the build target platform where chalk was not honoring it

for example for multi-platform builds:

```
FROM --platform=linux/amd64 ubuntu AS builder
RUN build.sh

FROM scratch
COPY --from=builder /app /app
```

If the app build is arch-agnostic (e.g. Java), sometimes its much faster for multi-platform builds to pin the builder to specific platform however chalk was not honoring the `--platform` when pinning the base image.

Also fixing a minor `_REPO_URLS` incorrectly sourcing image annotation.


## Testing

```
➜ maketest test_docker.py::test_base_images --pdb --logs
```
