### PR TITLE
fix: _REPO_TAGS missing all pushed tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- `_REPO_TAGS` did not include all pushed tags when using `buildx build --push`
+  without `--load`.
+  ([#471](https://github.com/crashappsec/chalk/pull/471))
+
 ## 0.5.1
 
 **Jan 17, 2025**


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

`_REPO_TAGS` are missing all tags when using `docker buildx --push`

## Description

In order to reduce registry interactions, only unique repo digests are interacted with however that meant that if the same image was tagged with multiple tags, its tags were lost as the locally loaded RepoTags will be missing all other tags. The fix is simply concatenate all given tags when processing tags.

## Testing

```
➜ maketest test_docker.py::test_multiple_tags --logs -x
```
