### PR TITLE
ci: allowing to trigger tests adhoc

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ on:
       - "*.nimble"
       # ignore docs not to waste CI minutes
       - "!src/docs/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -30,6 +31,7 @@ permissions:
 
 env:
   SSH_KEY: ${{ secrets.SSH_KEY }}
+  AWS_REGION: us-east-1
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~~Updated `CHANGELOG.md` if necessary~~

## Issue

It was not possible to trigger new test run in CI
