### PR TITLE
fix: incorrect DOCKER_COPY_IMAGES for COPY --from=<index>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## On the `main` branch
 
+### Fixes
+
+- Incorrect base image for `DOCKER_COPY_IMAGES` when using stage index
+  (e.g. `COPY --from=<index>`).
+  ([#479](https://github.com/crashappsec/chalk/pull/479))
+
 ## 0.5.2
 
 **Jan 28, 2025**

--- a/src/docker/dockerfile.nim
+++ b/src/docker/dockerfile.nim
@@ -8,7 +8,7 @@
 ## Dockerfile parsing
 
 import std/[algorithm, sequtils, unicode]
-import ".."/config
+import ".."/[config, util]
 import "."/[ids]
 
 # RUN and COPY accept << and <<-
@@ -1068,6 +1068,8 @@ proc formatCopyImage(ctx: DockerInvocation, copy: CopyInfo): ChalkDict =
   let image =
     if copy.frm in ctx.dfSectionAliases:
       ctx.getBaseDockerSection(ctx.dfSectionAliases[copy.frm]).image
+    elif isUInt(copy.frm) and parseInt(copy.frm) < len(ctx.dfSections):
+      ctx.getBaseDockerSection(ctx.dfSections[parseInt(copy.frm)]).image
     else:
       parseImage(copy.frm, defaultTag = "")
   result = ChalkDict()

--- a/src/util.nim
+++ b/src/util.nim
@@ -499,6 +499,13 @@ proc isInt*(i: string): bool =
   except:
     return false
 
+proc isUInt*(i: string): bool =
+  try:
+    discard parseUInt(i)
+    return true
+  except:
+    return false
+
 proc splitBy*(s: string, sep: string, default: string = ""): (string, string) =
   let parts = s.split(sep, maxsplit = 1)
   if len(parts) == 2:

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -536,6 +536,7 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
             FROM one as five
             COPY --from=nginx:1.27.0@sha256:97b83c73d3165f2deb95e02459a6e905f092260cd991f4c4eae2f192ddb99cbe /usr/sbin/nginx /nginx
             COPY --from=one /bin/sh /sh
+            COPY --from=0 /bin/ls /ls
 
             FROM scratch as six
 
@@ -795,6 +796,17 @@ def test_base_images(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
                     "digest": ANY,
                     "src": ["/bin/sh"],
                     "dest": "/sh",
+                },
+                {
+                    "from": "0",
+                    "uri": re.compile("alpine@sha256:"),
+                    "repo": "alpine",
+                    "registry": "registry-1.docker.io",
+                    "name": "library/alpine",
+                    "tag": MISSING,
+                    "digest": ANY,
+                    "src": ["/bin/ls"],
+                    "dest": "/ls",
                 },
             ],
             "": [


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

`DOCKER_COPY_IAMGES` has incorrect base image

## Description

It was not parsing whenever `--from` provided a stage index, not its alias. In docker you can pass either:

```dockerfile
FROM alpine AS one
FROM alpine AS two
COPY --from=one /foo /bar
COPY --from=0 /foo /bar
```

## Testing

```
➜ maketest test_docker.py::test_base_images --pdb --logs
```
