### PR TITLE
fix: autocomplete was overwriting rc files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Incorrect base image for `DOCKER_COPY_IMAGES` when using stage index
   (e.g. `COPY --from=<index>`).
   ([#479](https://github.com/crashappsec/chalk/pull/479))
+- Installing shell autocompletion script was wiping bash/zsh rc files.
+  ([#480](https://github.com/crashappsec/chalk/pull/480))
 
 ## 0.5.2
 


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

fix https://github.com/crashappsec/chalk/issues/478

## Description

While installing autocomplete script, it was overwriting rc files as nims `fmReadWrite`:

> fmReadWrite, ## Open the file for read and write access.
>              ## If the file does not exist, it will be
>              ## created. Existing files will be cleared!

Reading file first now before explicitly appending to existing file content

## Testing

Run `chalk version` and check how it modifies rc files
