### PR TITLE
fix: check buildkit frontend version to determine context arg compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   on `hello.py`. Now chalk will compute nearest `git` repository
   and run external tools on it instead.
   ([#485](https://github.com/crashappsec/chalk/pull/485))
+- When `Dockerfile` specifies syntax directive, chalk checks buildkit
+  frontend version compatibility as older frontends do not support
+  `--build-context` CLI argument. Passing the flag would fail the
+  wrapped build and chalk would fallback to vanilla docker build.
+  More about syntax directive
+  [here](https://docs.docker.com/reference/dockerfile/#syntax).
+  ([#486](https://github.com/crashappsec/chalk/pull/486))
 
 ## 0.5.3
 

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -155,7 +155,7 @@ type
     default*: Option[LineToken]
     error*:   string
     plus*:    bool
-    minus*:   bool  #
+    minus*:   bool
 
   LineTokenType* = enum ltOther, ltWord, ltQuoted, ltSpace
 
@@ -402,6 +402,7 @@ type
       # parsed dockerfile
       dfSections*:            seq[DockerFileSection]
       dfSectionAliases*:      OrderedTable[string, DockerFileSection]
+      dfDirectives*:          OrderedTableRef[string, string]
 
     of DockerCmd.push:
       foundImage*:            string

--- a/src/docker/cmdline.nim
+++ b/src/docker/cmdline.nim
@@ -264,6 +264,7 @@ proc extractDockerCommand*(self: DockerInvocation): DockerCmd =
     self.extractSecrets()
     # set any other non-automatically initialized attributes to avoid segfaults
     self.addedPlatform = newOrderedTable[string, seq[string]]()
+    self.dfDirectives  = newOrderedTable[string, string]()
   of DockerCmd.push:
     self.extractImage()
     self.extractAllTags()

--- a/src/semver.nim
+++ b/src/semver.nim
@@ -24,7 +24,7 @@ proc parseVersion*(version: string): Version =
     patch  = 0
     suffix = ""
   let
-    name     = version.strip(chars={'V', 'v'}, trailing=false).strip(chars={',', '.', '-', '+'})
+    name     = version.strip(chars={'V', 'v'}, trailing=false).strip(chars={',', '.', '-', '+', '/'})
     sections = name.split({'-', '+'}, maxsplit=1)
     parts    = sections[0].split('.')
   case len(parts):
@@ -87,7 +87,7 @@ proc normalize*(self: Version): string =
   return s
 
 proc getVersionFromLine*(line: string): Version =
-  for word in line.splitWhitespace():
+  for word in line.split(seps = Whitespace + {'/', ','}):
     if '.' in word:
       try:
         return parseVersion(word)

--- a/tests/functional/data/dockerfiles/valid/sample_3/Dockerfile
+++ b/tests/functional/data/dockerfiles/valid/sample_3/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:experimental
 FROM alpine as base
 FROM base
 RUN adduser -D testuser

--- a/tests/unit/test_semver.nim
+++ b/tests/unit/test_semver.nim
@@ -45,6 +45,20 @@ proc main() =
   doAssert parseVersion("0.1") >= parseVersion("0.1")
   doAssert parseVersion("0.1.0") >= parseVersion("0.1")
 
+  doAssert $(getVersionFromLine(
+    "/bin/dockerfile-frontend " &
+    "github.com/moby/buildkit/frontend/dockerfile/cmd/dockerfile-frontend " &
+    "dockerfile/1.2.1-labs " &
+    "bf5e780c5e125bb97942ead83ff3c20705e8e8c9"
+  )) == "1.2.1-labs"
+  doAssert $(getVersionFromLine(
+    "github.com/docker/buildx 0.19.2 1fc5647dc281ca3c2ad5b451aeff2dce84f1dc49"
+  )) == "0.19.2"
+  doAssert $(getVersionFromLine(
+    "Docker version 27.3.1, build ce1223035a"
+  )) == "27.3.1"
+
+
 static:
   main()
 main()


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Builds which specify frontend can sometimes fallback due to incompatible `--build-arg`

## Description


Not all older frontends support `--build-arg` and sometimes they do no specify the version as part of the syntax directive. For example:

```
# syntax: docker/dockerfile:experimental
```

Chalk cannot infer anything about the meaning of `experimental` as its not pinned to any version. Therefore we call the dockerfile frontend container and check its actual version.
This is possibly not as efficient even if the version is specified however that would also require some heuristics. For example:

```
# syntax: docker/dockerfile:1
```

As `1` can change over time it might not be clear which syntax should actually be honored. Therefore it is probably a lot simpler to simply ask it what version it is instead of possibly error-prone version detection heuristics.


## Testing

```
➜ maketest test_docker.py::test_build -x
```
