### PR TITLE
fix: heartbeats timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   More about syntax directive
   [here](https://docs.docker.com/reference/dockerfile/#syntax).
   ([#486](https://github.com/crashappsec/chalk/pull/486))
+- Heartbeat reports had older timestamps. Reporting state was cleared
+  before sleeping for the heartbeat which meant that timestamp was
+  always off by the heartbeats interval - default 10 minutes.
+  ([#487](https://github.com/crashappsec/chalk/pull/487))
 
 ## 0.5.3
 

--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -169,8 +169,8 @@ template doHeartbeat(chalkOpt: Option[ChalkObj], pid: Pid, fn: untyped) =
 
   while true:
     sleep(sleepInterval)
-    chalkOpt.doHeartbeatReport()
     clearReportingState()
+    chalkOpt.doHeartbeatReport()
     if fn(pid):
       break
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

heartbeats have incorrect timestamp

## Description

Heartbeat reports had older timestamps. Reporting state was cleared before sleeping for the heartbeat which meant that timestamp was always off by the heartbeats interval - default 10 minutes.

## Testing

Run 

```
./chalk exec -- sleep 300
```

and observe reported timestamp locally.