### PR TITLE
feat: adding EXTERNAL_TOOL_DURATION key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
   always off by the heartbeats interval - default 10 minutes.
   ([#487](https://github.com/crashappsec/chalk/pull/487))
 
+### New Features
+
+- `EXTERNAL_TOOL_DURATION` key which reports external tool duration
+  for each invocation.
+  ([#488](https://github.com/crashappsec/chalk/pull/488))
+
 ## 0.5.3
 
 **Feb 3, 2025**

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1499,6 +1499,22 @@ collecting this information.
 """
 }
 
+keyspec EXTERNAL_TOOL_DURATION {
+    kind:             ChalkTimeArtifact
+    type:             dict[string, dict[string, int]]
+    standard:         true
+    since:            "0.5.4"
+    shortdoc:         "Duration of each external tool invocation in ms"
+    doc:              """
+Duration how long in ms each external tool invocation took.
+The value is grouped by:
+
+* external tool name
+* execution context
+* duration
+"""
+}
+
 keyspec INFERRED_TECH_STACKS {
     kind:             ChalkTimeArtifact
     type:             `x

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -106,6 +106,7 @@ report and subtract from it.
   key.EMBEDDED_CHALK.use                      = true
   key.EMBEDDED_TMPDIR.use                     = true
   key.CLOUD_METADATA_WHEN_CHALKED.use         = true
+  key.EXTERNAL_TOOL_DURATION.use              = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
   key.ERR_INFO.use                            = true
@@ -503,6 +504,7 @@ doc: """
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
   key.TENANT_ID_WHEN_CHALKED.use              = true
+  key.EXTERNAL_TOOL_DURATION.use              = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
   key._ACTION_ID.use                          = true
@@ -708,6 +710,7 @@ doc: """
   key.EMBEDDED_CHALK.use                      = true
   key.EMBEDDED_TMPDIR.use                     = true
   key.CLOUD_METADATA_WHEN_CHALKED.use         = true
+  key.EXTERNAL_TOOL_DURATION.use              = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
   key.ERR_INFO.use                            = true
@@ -1011,6 +1014,7 @@ container.
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
   key.TENANT_ID_WHEN_CHALKED.use              = true
+  key.EXTERNAL_TOOL_DURATION.use              = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
 
@@ -1193,6 +1197,7 @@ container.
   key.EMBEDDED_CHALK.use                      = true
   key.EMBEDDED_TMPDIR.use                     = true
   key.CLOUD_METADATA_WHEN_CHALKED.use         = true
+  key.EXTERNAL_TOOL_DURATION.use              = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
   key.ERR_INFO.use                            = true
@@ -1678,6 +1683,7 @@ and keep the run-time key.
   key.EMBEDDED_CHALK.use                      = true
   key.EMBEDDED_TMPDIR.use                     = true
   key.CLOUD_METADATA_WHEN_CHALKED.use         = true
+  key.EXTERNAL_TOOL_DURATION.use              = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
   key.ERR_INFO.use                            = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -222,6 +222,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.EMBEDDED_CHALK.use                      = true
   ~key.EMBEDDED_TMPDIR.use                     = true
   ~key.CLOUD_METADATA_WHEN_CHALKED.use         = true
+  ~key.EXTERNAL_TOOL_DURATION.use              = true
   ~key.SBOM.use                                = true
   ~key.SAST.use                                = true
   ~key.ERR_INFO.use                            = true

--- a/tests/functional/data/configs/composable/valid/sast/enable_sast.c4m
+++ b/tests/functional/data/configs/composable/valid/sast/enable_sast.c4m
@@ -7,9 +7,11 @@ report_template.terminal_insert.key.SAST.use: true
 
 # `chalk insert` uses the mark_default template.
 mark_template.mark_default.key.SAST.use: true
+mark_template.mark_default.key.EXTERNAL_TOOL_DURATION.use: true
 
 # `chalk docker build` uses the `minimal` template.
 mark_template.minimal.key.SAST.use: true
+mark_template.minimal.key.EXTERNAL_TOOL_DURATION.use: true
 
 tool.semgrep.semgrep_config_profile: "rule.yaml"
 

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -915,6 +915,11 @@ def test_semgrep(
 
     # expected sast output with custom rule
     report_sast_data = {
+        "EXTERNAL_TOOL_DURATION": {
+            "semgrep": {
+                str(tmp_data_dir): int,
+            },
+        },
         "SAST": {
             "semgrep": {
                 "runs": [
@@ -962,9 +967,14 @@ def test_semgrep(
                     }
                 ],
             }
-        }
+        },
     }
     mark_sast_data = {
+        "EXTERNAL_TOOL_DURATION": {
+            "semgrep": {
+                str(tmp_data_dir / "hello.sh"): int,
+            },
+        },
         "SAST": {
             "semgrep": {
                 "runs": [
@@ -984,7 +994,7 @@ def test_semgrep(
                     }
                 ],
             }
-        }
+        },
     }
 
     insert = chalk.insert(


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Description

To help analyze whats the overhead of the tool, report its duration as a separate key

## Testing

```
➜ maketest test_plugins.py::test_semgrep --pdb
```
