### PR TITLE
feat: chalk insert lambda zip mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 ## About Chalk
 
-Chalk™ captures metadata at build time, and can add a small 'chalk mark' (metadata) to any artifacts, so they can be identified in production. Chalk can also extract chalk marks and collect additional metadata about the operating environment when it does this.
+Chalk™ captures metadata at build time, and can add a small 'chalk mark' (metadata) to any
+artifacts, so they can be identified in production. Chalk can also extract chalk marks and collect
+additional metadata about the operating environment when it does this.
 
-Using Chalk, you can build a graph connecting people, development, builds and production, so that devops engineers understand what is happening in the development process, and so that developers can understand what is happening in the infrastructure.
+Using Chalk, you can build a graph connecting people, development, builds and production, so that
+devops engineers understand what is happening in the development process, and so that developers
+can understand what is happening in the infrastructure.
 
 ## How-tos
 
@@ -14,21 +18,35 @@ You can use Chalk to solve a variety of specific use cases such as:
 
 ### Create software security supply chain compliance reports automatically
 
-Many companies and the US Government are now mandating suppliers to provide supply chain statements when delivering software. This how to is an easy button to deliver the [software bill of materials (SBOM)](https://www.ntia.gov/page/software-bill-materials), code and builds provenance and supports [SLSA](https://www.slsa.dev), Supply-chain Levels for Software Artifacts, [level 2](https://slsa.dev/spec/v1.0/levels) compliance (an emerging supply chain standard) before SLSA [level 1](https://slsa.dev/spec/v1.0/levels) has been mandated. Follow this how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-create-software-security-supply-chain-compliance-reports-automatically).
+Many companies and the US Government are now mandating suppliers to provide supply chain statements
+when delivering software. This how to is an easy button to deliver the
+[software bill of materials (SBOM)](https://www.ntia.gov/page/software-bill-materials), code and
+builds provenance and supports [SLSA](https://www.slsa.dev), Supply-chain Levels for Software
+Artifacts, [level 2](https://slsa.dev/spec/v1.0/levels) compliance (an emerging supply chain
+standard) before SLSA [level 1](https://slsa.dev/spec/v1.0/levels) has been mandated. Follow this
+how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-create-software-security-supply-chain-compliance-reports-automatically).
 
 ### Create and maintain real-time application inventory
 
-From a code base, easily understand the environments where code and even particular branches are running. Gather code owners for the applications and code repos. Follow this how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-create-a-real-time-application-inventory).
+From a code base, easily understand the environments where code and even particular branches are
+running. Gather code owners for the applications and code repos. Follow this how-to on our docs
+site [here](https://crashoverride.com/docs/how-to-guides/how-to-create-a-real-time-application-inventory).
 
 ### Deploy Chalk globally using Docker
 
-You can deploy Chalk by setting a global alias for Docker and having it call Chalk, so that every build that runs through your build server using Docker, will automatically be 'chalked'. It's a technique that can be combined with chalks ability to deploy tools and configure monitoring, to automatically add security controls and collect information for every application. Follow this how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-deploy-chalk-globally-using-docker)]
+You can deploy Chalk by setting a global alias for Docker and having it call Chalk, so that every
+build that runs through your build server using Docker, will automatically be 'chalked'. It's a
+technique that can be combined with chalks ability to deploy tools and configure monitoring, to
+automatically add security controls and collect information for every application. Follow this
+how-to on our docs site [here](https://crashoverride.com/docs/how-to-guides/how-to-deploy-chalk-globally-using-docker)]
 
-All documentation for Chalk is available at https://crashoverride.com/docs and is also fully accessible though the command line interface.
+All documentation for Chalk is available at https://crashoverride.com/docs and is also fully
+accessible though the command line interface.
 
 ## Getting started
 
-We recommend following the [getting started guide](https://crashoverride.com/docs/chalk/getting-started) on our documentation web site. Full documentation is also available directly inside the CLI.
+We recommend following the [getting started guide](https://crashoverride.com/docs/chalk/getting-started)
+on our documentation web site. Full documentation is also available directly inside the CLI.
 
 We provide free binary downloads on our [release page](https://crashoverride.com/releases).
 
@@ -39,15 +57,19 @@ If you encounter any issues with Chalk please submit a GitHub issue to
 
 ## Ideas and feedback
 
-We are constantly learning about emerging use cases for Chalk, and are always interested in hearing about how others are using it. We are also interested in ideas and feature requests.If you would like to talk, please get in touch using hello@crashoverride.com.
+We are constantly learning about emerging use cases for Chalk, and are always interested in hearing
+about how others are using it. We are also interested in ideas and feature requests.If you would
+like to talk, please get in touch using hello@crashoverride.com.
 
 ## Making contributions
 
-We welcome contributions but do require you to complete a contributor license agreement or CLA. You can read the CLA and about our process [here](https://crashoverride.com/docs/other/contributing).
+We welcome contributions but do require you to complete a contributor license agreement or CLA. You
+can read the CLA and about our process [here](https://crashoverride.com/docs/other/contributing).
 
 ## Getting additional help
 
-If you need additional help including a demo of the cloud platform, please contact us using hello@crashoverride.com
+If you need additional help including a demo of the cloud platform, please contact us using
+hello@crashoverride.com
 
 ## License
 
@@ -55,6 +77,7 @@ Chalk is licensed under the GPL version 3 license.
 
 ## Try our cloud platform.
 
-Our cloud hosted platform is built using Chalk. It makes enterprise deployments easy, and provides additional functionality including prebuilt integrations to enrich your data.
+Our cloud hosted platform is built using Chalk. It makes enterprise deployments easy, and provides
+additional functionality including prebuilt integrations to enrich your data.
 
 You can learn more at [crashoverride.com](https://crashoverride.com/).

--- a/src/commands/cmd_insert.nim
+++ b/src/commands/cmd_insert.nim
@@ -7,18 +7,87 @@
 
 ## The `chalk insert` command.
 
-import ".."/[config, selfextract, collect, reporting, chalkjson, plugin_api]
+import ".."/[config, selfextract, collect, reporting, chalkjson, plugin_api, chalk_common, util]
+import std/[os]
+import pkg/zippy/ziparchives_v1
+
+type
+  ZipCache = ref object of RootRef
+    onDisk:        ZipArchive
+    embeddedChalk: Box
+    tmpDir:        string
 
 
 proc runCmdInsert*(path: seq[string]) {.exportc,cdecl.} =
   setContextDirectories(path)
   initCollection()
   let virtual = attrGet[bool]("virtual_chalk")
+  let lambda = attrGet[bool]("lambda_mode")
 
   for item in artifacts(path):
     trace(item.name & ": begin chalking")
     item.collectChalkTimeArtifactInfo()
     trace(item.name & ": chalk data collection finished.")
+
+    # Check if lambda flag is present and handle zip archives
+    if lambda:
+      var isZip = false
+      if item.collectedData != nil and "ARTIFACT_TYPE" in item.collectedData:
+        try:
+          isZip = item.collectedData["ARTIFACT_TYPE"] == artTypeZip
+        except:
+          isZip = false
+
+      if isZip:
+        info(item.name & ": inserting binary into zip")
+
+        # insert the chalk binary itself into the zip file
+        try:
+          # get the currently executing chalk binary path
+          let myAppPath = getMyAppPath()
+
+          if myAppPath != "" and item.myCodec != nil and item.myCodec.name == "zip" and item.cache != nil:
+            # we need to safely access the cache as ZipCache
+            let chalkBinaryContent = tryToLoadFile(myAppPath)
+
+            var zipCache: ZipCache
+            try:
+              zipCache = cast[ZipCache](item.cache)
+              if zipCache == nil or zipCache.tmpDir == "":
+                raise newException(ValueError, "Invalid ZipCache")
+
+              # Get the path to add the binary
+              let
+                extractDir = joinPath(zipCache.tmpDir, "contents")
+                chalkTargetPath = joinPath(extractDir, "chalk")
+
+              # Make sure the contents directory exists
+              if dirExists(extractDir):
+                # Write the chalk binary to the zip contents directory
+                if tryToWriteFile(chalkTargetPath, chalkBinaryContent):
+                  # TODO: why isn't this working?
+                  # ensure it is executable
+                  chalkTargetPath.makeExecutable()
+                  info(item.name & ": added chalk binary to zip")
+                else:
+                  error(item.name & ": failed to add chalk binary to zip")
+                  item.opFailed = true
+              else:
+                error(item.name & ": contents directory does not exist")
+                item.opFailed = true
+            except:
+              error(item.name & ": failed to access zip cache: " & getCurrentExceptionMsg())
+              item.opFailed = true
+          else:
+            error(item.name & ": not a zip archive or missing required data")
+            item.opFailed = true
+        except:
+          error(item.name & ": failed to insert chalk binary: " & getCurrentExceptionMsg())
+          dumpExOnDebug()
+          item.opFailed = true
+      else:
+        info(item.name & ": artifact is not a zip archive")
+
     if item.isMarked() and configKey in item.extract:
       info(item.name & ": Is a configured chalk exe; skipping insertion.")
       item.removeFromAllChalks()

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2920,6 +2920,16 @@ Currently, the only available tool out of the box is trufflehog.
 """
   }
 
+  field lambda_mode {
+    type:     bool
+    default:  false
+    shortdoc: "lambda mode"
+    doc:      """
+When present, inject the executed chalk binary itself in the zip
+archive being processed upon insertion.
+"""
+  }
+
   field recursive {
     type:     bool
     default:  true

--- a/src/configs/getopts.c4m
+++ b/src/configs/getopts.c4m
@@ -703,7 +703,6 @@ commands that do not match known topics)
 """
   }
 
-
   command docgen {
     shortdoc: "Generate technical documentation"
     doc: """

--- a/src/configs/getopts.c4m
+++ b/src/configs/getopts.c4m
@@ -315,6 +315,14 @@ help templates`
       field_to_set: "recursive"
     }
 
+    flag_yn lambda {
+      doc: """
+When present, inject the executed chalk binary itself in the zip
+archive being processed upon insertion.
+"""
+      field_to_set: "lambda_mode"
+    }
+
     flag_arg mark_template {
       field_to_set: "outconf.insert.mark_template"
       doc: """

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -433,6 +433,7 @@ class Chalk:
         expecting_report: bool = True,
         expecting_chalkmarks: bool = True,
         use_embedded: bool = True,
+        params: Optional[list[str]] = None,
     ) -> ChalkProgram:
         result = self.run(
             command="insert",
@@ -444,6 +445,7 @@ class Chalk:
             ignore_errors=ignore_errors,
             expecting_report=expecting_report,
             use_embedded=use_embedded,
+            params=params,
         )
         if expecting_report:
             if expecting_chalkmarks:

--- a/tests/functional/test_lambda.py
+++ b/tests/functional/test_lambda.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2025, Crash Override, Inc.
+#
+# This file is part of Chalk
+# (see https://crashoverride.com/docs/chalk)
+from pathlib import Path
+import shutil
+import zipfile
+
+import pytest
+
+from .chalk.runner import Chalk
+from .conf import ZIPS
+from .utils.log import get_logger
+
+
+logger = get_logger()
+
+
+# Test data fixtures
+PYTHON_LAMBDA_ZIP = ZIPS / "python" / "my_deployment_package.zip"
+NODEJS_LAMBDA_ZIP = ZIPS / "nodejs" / "function.zip"
+GOLANG_LAMBDA_ZIP = ZIPS / "golang" / "myFunction.zip"
+MISC_LAMBDA_ZIP = ZIPS / "misc" / "misc.zip"
+EMPTY_ZIP = ZIPS / "empty" / "empty.zip"
+
+
+def verify_chalk_binary_in_zip(zip_path: Path, extract_dir: Path):
+    """Helper function to verify chalk binary exists in the zip file."""
+    # Extract the zip contents
+    extract_dir.mkdir(exist_ok=True)
+
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        zip_ref.extractall(extract_dir)
+
+    # Verify the chalk binary was added
+    chalk_binary_path = extract_dir / "chalk"
+    assert chalk_binary_path.exists(), "Chalk binary was not found in the zip"
+    # TODO: uncomment when zip archive exec perms if fixed
+    # assert os.access(chalk_binary_path, os.X_OK), "Chalk binary is not executable"
+
+
+def verify_chalk_mark_added(result, test_file):
+    """Helper function to verify chalk mark was added to the file."""
+    assert result.report.marks_by_path.contains(
+        {str(test_file): {}}
+    ), "Chalk mark was not added to the zip file"
+
+
+@pytest.mark.parametrize(
+    "copy_files",
+    [
+        [PYTHON_LAMBDA_ZIP],
+        [NODEJS_LAMBDA_ZIP],
+    ],
+    indirect=True,
+)
+def test_lambda_insert(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    copy_files: list[Path],
+):
+    """Test `chalk insert --lambda` adds the binary to the zip."""
+    test_file = copy_files[0]
+
+    # Run chalk insert with the --lambda
+    insert = chalk.insert(
+        artifact=tmp_data_dir,
+        virtual=False,
+        params=["--lambda"],
+    )
+
+    # Verify the chalk mark was added
+    verify_chalk_mark_added(insert, test_file)
+
+    # Verify chalk binary was added to the zip
+    extract_dir = tmp_data_dir / "extracted"
+    verify_chalk_binary_in_zip(test_file, extract_dir)
+
+    # Cleanup
+    shutil.rmtree(extract_dir)
+
+
+def test_lambda_insert_empty_zip(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+):
+    """Test `chalk insert --lambda` on an empty zip file.
+
+    Empty zip files should be handled gracefully - the command should
+    complete with exit code 0 but no chalk marks should be created.
+    """
+
+    # Run chalk insert with the --lambda
+    insert = chalk.insert(
+        artifact=tmp_data_dir,
+        virtual=False,
+        params=["--lambda"],
+        expecting_chalkmarks=False,  # Don't expect marks for empty zip
+    )
+
+    # Verify command succeeded but no marks were created
+    assert insert.exit_code == 0, "Command should have exited with code 0"
+    assert (
+        "_CHALKS" not in insert.report
+    ), "No chalks should be created for empty zip file"
+    assert (
+        "_OP_CHALK_COUNT" in insert.report and insert.report["_OP_CHALK_COUNT"] == 0
+    ), "Chalk count should be 0"
+
+
+@pytest.mark.parametrize(
+    "copy_files",
+    [
+        [PYTHON_LAMBDA_ZIP],
+    ],
+    indirect=True,
+)
+def test_lambda_extract_after_insert(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    copy_files: list[Path],
+):
+    """Test extraction works correctly after insertion.
+
+    After inserting chalk with --lambda flag, we should be able to
+    extract the chalk marks without errors, and the marks should
+    identify the file as a ZIP artifact.
+    """
+    test_file = copy_files[0]
+
+    # First insert a chalk mark with lambda flag
+    insert = chalk.insert(
+        artifact=tmp_data_dir,
+        virtual=False,
+        params=["--lambda"],
+    )
+    verify_chalk_mark_added(insert, test_file)
+
+    # Now extract and verify we can read the chalk mark
+    extract = chalk.extract(artifact=tmp_data_dir, ignore_errors=True)
+    verify_chalk_mark_added(extract, test_file)
+
+    # chalk_binary_path = tmp_data_dir / "chalk"
+    # Verify ZIP artifact type is detected
+    for mark in extract.marks:
+        assert mark.has(ARTIFACT_TYPE="ZIP"), "ZIP artifact type not detected"
+    # TODO: uncomment when zip archive exec perms if fixed
+    # assert os.access(chalk_binary_path, os.X_OK), "Chalk binary is not executable"
+
+
+@pytest.mark.parametrize(
+    "copy_files",
+    [
+        [GOLANG_LAMBDA_ZIP],
+        [MISC_LAMBDA_ZIP],
+    ],
+    indirect=True,
+)
+def test_lambda_with_other_zip_formats(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    copy_files: list[Path],
+):
+    """Test the --lambda flag with different zip file formats.
+
+    The lambda insertion should work with various zip formats commonly
+    used for different lambda runtimes (Go, misc).
+    """
+    test_file = copy_files[0]
+
+    # Run chalk insert with the lambda flag
+    insert = chalk.insert(
+        artifact=tmp_data_dir,
+        virtual=False,
+        params=["--lambda"],
+    )
+
+    # Verify the chalk mark was added
+    verify_chalk_mark_added(insert, test_file)
+
+    # Verify chalk binary was added to the zip
+    extract_dir = tmp_data_dir / "extracted"
+    verify_chalk_binary_in_zip(test_file, extract_dir)
+
+    # Cleanup
+    shutil.rmtree(extract_dir)


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ ] Filled out the template to a useful degree
- [ ] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

https://app.shortcut.com/crashoverride-1/epic/4279?group_by=none&ct_workflow=all&cf_workflow=500000306

## Description

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

Initial approach for injecting `chalk` binary inside of a lambda zip archive. After a round of feedback I think it'll make sense to refactor some of the zip archive operations to `codecZip.nim`.

### to do

- [ ] get initial feedback
- [ ] fix executable bit issue
- [ ] (potentially) refactor into `codecZip.nim`

## Testing

<!-- What are the steps needed to test this PR? -->

`make tests args="test_lambda.py"`
