### PR TITLE
feat: object store per key in reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@
 
   ([#500](https://github.com/crashappsec/chalk/pull/500))
 
+- `copy_report_template_keys` built-in function which copies all keys
+  as they are subscribed from one report template to another:
+
+  ```
+  report_template one {
+    key.ONE.use = true
+    key.TWO.use = false
+  }
+  copy_report_template_keys("one", "two")
+  ```
+
+  ([#500](https://github.com/crashappsec/chalk/pull/500))
+
 ## 0.5.4
 
 **Feb 19, 2025**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,40 @@
   the CI build. In most cases it will be the repository but could be
   other resources such as S3 object URI for AWS Code Builds.
   ([#494](https://github.com/crashappsec/chalk/pull/494))
+- Object store which allows to upload specific keys to an object
+  store and reference them in the report vs including full value
+  in the raw report. This allows to both deduplicate
+  some common metadata between builds (e.g. SBOM) as well as make
+  report smaller.
+  See `object_store_config` how to configure the object store.
+  TLDR:
+
+  ```
+  auth_config example {
+    auth: "jwt"
+    token: env("TOKEN")
+  }
+
+  object_store_config example {
+    object_store: "presign"
+    object_store_presign {
+      uri: "https://example.com/objects"
+      read_auth: "example"
+      write_auth: "example"
+    }
+  }
+
+  report_template example {
+    key.EXAMPLE.use: true
+    key.EXAMPLE.object_store: "example"
+    default_object_store {
+      enabled: true
+      object_store: "example"
+    }
+  }
+  ```
+
+  ([#500](https://github.com/crashappsec/chalk/pull/500))
 
 ## 0.5.4
 

--- a/configs/co/object_store.c4m
+++ b/configs/co/object_store.c4m
@@ -1,0 +1,51 @@
+func validate_jwt(token) {
+  if not is_jwt_valid(token) {
+    return "Invalid JWT token for reporting reports back to CrashOverride"
+  }
+  return ""
+}
+
+parameter auth_config.crashoverride_object_store_read.token {
+  shortdoc:  "Crash Override Reading Object Store API token"
+  doc:       "Token interacting with CrashOverride object store"
+  default:   ""
+  validator: func validate_jwt(string) -> string
+}
+
+parameter auth_config.crashoverride_object_store_write.token {
+  shortdoc:  "Crash Override Writing to Object Store API token"
+  doc:       "Token interacting with CrashOverride object store"
+  default:   ""
+  validator: func validate_jwt(string) -> string
+}
+
+parameter object_store_config.crashoverride.object_store_presign.uri {
+  shortdoc: "Object Store API URL"
+  doc:      "Object Store API URL"
+  default:  "https://chalk.crashoverride.run/v0.1/objects"
+}
+
+auth_config crashoverride_object_store_read {
+  ~auth:  "jwt"
+}
+
+auth_config crashoverride_object_store_write {
+  ~auth:  "jwt"
+}
+
+object_store_config crashoverride {
+  ~enabled:      true
+  ~object_store: "presign"
+  object_store_presign {
+    ~read_auth:  "crashoverride_object_store_read"
+    ~write_auth: "crashoverride_object_store_write"
+  }
+}
+
+report_template crashoverride {
+  ~key.SBOM.object_store              = "crashoverride"
+  ~key.SAST.object_store              = "crashoverride"
+  ~key.SECRET_SCANNER.object_store    = "crashoverride"
+  ~key._IMAGE_SBOM.object_store       = "crashoverride"
+  ~key._IMAGE_PROVENANCE.object_store = "crashoverride"
+}

--- a/src/attestation/get.nim
+++ b/src/attestation/get.nim
@@ -6,7 +6,7 @@
 ##
 
 import std/[httpclient, net]
-import ".."/[config, sinks, util]
+import ".."/[config, auth, util]
 
 type Get = ref object of AttestationKeyProvider
   location: string

--- a/src/auth.nim
+++ b/src/auth.nim
@@ -1,0 +1,59 @@
+##
+## Copyright (c) 2023-2025, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+import "."/config
+
+var availableAuthConfigs: Table[string, AuthConfig]
+
+proc getAuthConfigByName*(name: string,
+                          attr: AttrScope = AttrScope(nil),
+                          ): Option[AuthConfig] =
+  if name == "":
+    return none(AuthConfig)
+
+  if name in availableAuthConfigs:
+    return some(availableAuthConfigs[name])
+
+  let
+    attrRoot = if attr != nil: attr else: getChalkScope()
+    section  = "auth_config." & name
+    opts     = OrderedTableRef[string, string]()
+
+  if attrRoot.getObjectOpt(section).isNone():
+    error(section & " is referenced but its missing in the config")
+    return none(AuthConfig)
+
+  let authType = getOpt[string](attrRoot, section & ".auth").getOrElse("")
+  if authType == "":
+    error(section & ".auth is required")
+    return none(AuthConfig)
+
+  let implementationOpt = getAuthImplementation(authType)
+  if implementationOpt.isNone():
+    error("there is no implementation for " & authType & " auth")
+    return none(AuthConfig)
+
+  for k, _ in getObject(attrRoot, section).contents:
+    case k
+    of "auth":
+      continue
+    else:
+      let boxOpt = getOpt[Box](attrRoot, section & "." & k)
+      if boxOpt.isSome():
+        opts[k]  = unpack[string](boxOpt.get())
+      else:
+        error(section & "." & k & " is missing")
+        return none(AuthConfig)
+
+  try:
+    result = configAuth(implementationOpt.get(), name, some(opts))
+  except:
+    error(section & " is misconfigured: " & getCurrentExceptionMsg())
+    return none(AuthConfig)
+
+  if result.isSome():
+    availableAuthConfigs[name] = result.get()

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -457,6 +457,7 @@ const
   chalkC42Spec*       = staticRead(chalkSpecName)
   getoptConfig*       = staticRead(getoptConfName)
   baseConfig*         = staticRead("configs/base_init.c4m") &
+                        staticRead("configs/base_callbacks.c4m") &
                         staticRead("configs/base_keyspecs.c4m") &
                         staticRead("configs/base_plugins.c4m") &
                         staticRead("configs/base_sinks.c4m") &

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -116,6 +116,7 @@ type
   ObjectStoreRef* = ref object
     config*: ObjectStoreConfig
     key*:    string
+    id*:     string
     digest*: string
     query*:  string
 

--- a/src/chalk_common.nim
+++ b/src/chalk_common.nim
@@ -13,13 +13,14 @@
 ## of the dependency tree.
 
 import std/[os, json, streams, tables, options, strutils, sugar, posix,
-            unicode, re, sets]
+            unicode, re, sets, uri]
 import pkg/[nimutils, nimutils/logging, nimutils/managedtmp, con4m]
 export os, json, options, tables, strutils, streams, sugar, nimutils, logging,
        managedtmp, con4m
 
 type
   ChalkDict*    = OrderedTableRef[string, Box]
+  ObjectsDict*  = OrderedTableRef[string, OrderedTableRef[string, ObjectStoreRef]]
 
   ResourceType* = enum
     ResourceFile, ResourceImage, ResourceContainer, ResourcePid
@@ -30,6 +31,7 @@ type
     cachedHash*:    string           ## Cached 'ending' hash
     cachedPreHash*: string           ## Cached 'unchalked' hash
     collectedData*: ChalkDict        ## What we're adding during insertion.
+    objectsData*:   ObjectsDict      ## per object store and key object ref
     extract*:       ChalkDict        ## What we extracted, or nil if no extract.
     cachedMark*:    string           ## Cached chalk mark.
     opFailed*:      bool
@@ -110,6 +112,23 @@ type
     generateKey*:      proc (self: AttestationKeyProvider): AttestationKey
     retrieveKey*:      proc (self: AttestationKeyProvider): AttestationKey
     retrievePassword*: proc (self: AttestationKeyProvider, key: AttestationKey): string
+
+  ObjectStoreRef* = ref object
+    config*: ObjectStoreConfig
+    key*:    string
+    digest*: string
+    query*:  string
+
+  ObjectStore* = ref object of RootRef
+    name*:         string
+    init*:         proc (self: ObjectStore, name: string): ObjectStoreConfig
+    uri*:          proc (self: ObjectStoreConfig, keyRef: ObjectStoreRef): Uri
+    objectExists*: proc (self: ObjectStoreConfig, keyRef: ObjectStoreRef): ObjectStoreRef
+    createObject*: proc (self: ObjectStoreConfig, keyRef: ObjectStoreRef, data: string): ObjectStoreRef
+
+  ObjectStoreConfig* = ref object of RootRef
+    name*:  string
+    store*: ObjectStore
 
   KeyType* = enum KtChalkableHost, KtChalk, KtNonChalk, KtHostOnly
 
@@ -463,24 +482,22 @@ const
   timesTimeFormat*    = "HH:mm:ss'.'fff"
   timesTzFormat*      = "zzz"
   timesIso8601Format* = timesDateFormat & "'T'" & timesTimeFormat & timesTzFormat
+  objectStorePrefix*  = "@"
 
-  # Make sure that ARTIFACT_TYPE fields are consistently named. I'd love
-  # these to be const, but nim doesn't seem to be able to handle that :(
-let
-  artTypeElf*             = pack("ELF")
-  artTypeShebang*         = pack("Unix Script")
-  artTypeZip*             = pack("ZIP")
-  artTypeJAR*             = pack("JAR")
-  artTypeWAR*             = pack("WAR")
-  artTypeEAR*             = pack("EAR")
-  artTypeDockerImage*     = pack("Docker Image")
-  artTypeDockerContainer* = pack("Docker Container")
-  artTypePy*              = pack("Python")
-  artTypePyc*             = pack("Python Bytecode")
-  artTypeMachO*           = pack("Mach-O executable")
+  # Make sure that ARTIFACT_TYPE fields are consistently named
+  artTypeElf*             = "ELF"
+  artTypeZip*             = "ZIP"
+  artTypeJAR*             = "JAR"
+  artTypeWAR*             = "WAR"
+  artTypeEAR*             = "EAR"
+  artTypeDockerImage*     = "Docker Image"
+  artTypeDockerContainer* = "Docker Container"
+  artTypePyc*             = "Python Bytecode"
+  artTypeMachO*           = "Mach-O executable"
 
 var
   hostInfo*               = ChalkDict()
+  objectsData*            = ObjectsDict()
   failedKeys*             = ChalkDict()
   subscribedKeys*         = Table[string, bool]()
   systemErrors*           = seq[string](@[])

--- a/src/chalkjson.nim
+++ b/src/chalkjson.nim
@@ -461,7 +461,8 @@ proc orderKeys*(dict: ChalkDict,
 
   tmp.sort()
   result = @[]
-  for (_, _, key) in tmp: result.add(key)
+  for (_, _, key) in tmp:
+    result.add(key)
 
 # %* from the json module; this basically does any escaping
 # we need, which gives us a JsonNode object, that we then convert

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -14,7 +14,7 @@
 
 import std/[httpclient]
 import pkg/[con4m/st, nimutils/jwt]
-import "."/[config, reporting, sinks, chalkjson, docker/exe]
+import "."/[config, reporting, auth, sinks, chalkjson, docker/exe]
 
 proc getChalkCommand(args: seq[Box], unused: ConfigState): Option[Box] =
   return some(pack(getCommandName()))

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -14,7 +14,7 @@
 
 import std/[httpclient]
 import pkg/[con4m/st, nimutils/jwt]
-import "."/[config, reporting, auth, sinks, chalkjson, docker/exe]
+import "."/[config, reporting, auth, sinks, chalkjson, docker/exe, normalize]
 
 proc getChalkCommand(args: seq[Box], unused: ConfigState): Option[Box] =
   return some(pack(getCommandName()))
@@ -111,6 +111,10 @@ proc memoizeInChalkmark(args: seq[Box], s: ConfigState): Option[Box] =
   selfChalkSetSubKey(memoizeKey, name, value)
   return valueOpt
 
+proc c4mToJson(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
+  let data = args[0]
+  return some(pack(data.boxToJson()))
+
 proc c4mParseJson(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   let
     data = unpack[string](args[0])
@@ -136,8 +140,28 @@ proc c4mParseJsonL(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
     error("Could not parse JSON: " & getCurrentExceptionMsg())
     return none(Box)
 
+proc c4mBinarySha256(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
+  let data = args[0]
+  return some(pack(data.binEncodeItem().sha256Hex()))
+
 proc dockerExe(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   return some(pack(getDockerExeLocation()))
+
+proc canonicalizeTool(args: seq[Box], usued = ConfigState(nil)): Option[Box] =
+  let
+    tool = unpack[string](args[0])
+    data = args[1]
+  let callbackOpt = attrGetOpt[CallbackObj]("tool." & tool & ".canonicalize")
+  if callbackOpt.isNone():
+    trace(tool & ": no canonicalize()")
+    return some(data)
+  let callback = callbackOpt.get()
+  trace(tool & ": canonicalizing with " & $callback)
+  let canonicalized = runCallback(callback, @[data])
+  if canonicalized.isNone():
+    error(tool & ": missing implementation to canonicalize with " & $callback)
+    return some(data)
+  return canonicalized
 
 let chalkCon4mBuiltins* = [
     ("version() -> string",
@@ -236,20 +260,37 @@ This way the function is only computed once.
      """
 Parses JSON string and returns data-struct back.
 """,
-     @["parsing"]),
+     @["json"]),
     ("parse_jsonl(string) -> `x",
      BuiltInFn(c4mParseJsonL),
      """
 Parses JSONl string and returns data-struct back.
 """,
-     @["parsing"]),
+     @["json"]),
+    ("to_json(`x) -> string",
+     BuiltInFn(c4mToJson),
+     """
+Convert to JSON string.
+""",
+     @["json"]),
+    ("binary_sha256(`x) -> string",
+     BuiltInFn(c4mBinarySha256),
+     """
+Returns normalized binary hash of the data.
+""",
+     @["chalk"]),
      ("docker_exe() -> string",
       BuiltInFn(dockerExe),
       """
 Find non-chalked docker executable path.
 """,
       @["chalk"]),
-
+     ("canonicalize_tool(string, `x) -> `x",
+      BuiltInFn(canonicalizeTool),
+      """
+Canonicalize external tool output key.
+""",
+      @["chalk"]),
 ]
 
 let errSinkObj = SinkImplementation(outputFunction: chalkErrSink)

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -181,10 +181,16 @@ proc copyReportTemplateKeys(args: seq[Box], c = ConfigState(nil)): Option[Box] =
   for k in copyFromKeys:
     if not sectionExists(c, copyToSection & "." & k):
       con4mSectionCreate(c, copyToSection & "." & k)
+    let
+      toUsePath = copyFromSection & "." & k & ".use"
+      toUseOpt   = attrGetOpt[bool](toUsePath)
+    if toUseOpt.isNone():
+      error(toUsePath & ": is unkown. copy_report_template_keys() is used before that key is defined. skipping")
+      continue
     con4mAttrSet(
       c,
       copyToSection & "." & k & ".use",
-      pack(attrGet[bool](copyFromSection & "." & k & ".use")),
+      pack(toUseOpt.get()),
       Con4mType(kind: TypeBool),
     )
 

--- a/src/configs/base_callbacks.c4m
+++ b/src/configs/base_callbacks.c4m
@@ -1,0 +1,23 @@
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+# base non-builtin callbacks to get used in keyspecs
+
+func canonicalize_tools(data) {
+ if not typecmp(typeof(data), dict[string, `x]) {
+   error("unsupported type for tool data to canonicalize it")
+   return data
+ }
+ result := {}
+ names  := keys(data)
+ for i from 0 to len(names) {
+   name          := names[i]
+   value         := get(data, name)
+   canonicalized := canonicalize_tool(name, value)
+   result := set(result, name, canonicalized)
+ }
+}

--- a/src/configs/base_callbacks.c4m
+++ b/src/configs/base_callbacks.c4m
@@ -7,17 +7,31 @@
 
 # base non-builtin callbacks to get used in keyspecs
 
-func canonicalize_tools(data) {
- if not typecmp(typeof(data), dict[string, `x]) {
-   error("unsupported type for tool data to canonicalize it")
-   return data
- }
- result := {}
- names  := keys(data)
- for i from 0 to len(names) {
-   name          := names[i]
-   value         := get(data, name)
-   canonicalized := canonicalize_tool(name, value)
-   result := set(result, name, canonicalized)
- }
+func canonicalize_tools(data: dict[string, `x]) {
+  t := typeof(data)
+  if not typecmp(t, dict[string, `x]) {
+    error("unsupported type (" + $(t) + ")for tool data to canonicalize it")
+    return data
+  }
+  result := {}
+  names  := keys(data)
+  for i from 0 to len(names) {
+    name          := names[i]
+    value         := get(data, name)
+    canonicalized := canonicalize_tool(name, value)
+    result := set(result, name, canonicalized)
+  }
+}
+
+func canonicalize_image_sbom(data: dict[string, `x]) {
+  t := typeof(data)
+  if not typecmp(t, dict[string, `x]) {
+    error("unsupported type (" + $(t) + ") for image SBOM data to canonicalize it")
+    return data
+  }
+  result := data
+  # contains uuid
+  result := delete(result, "documentNamespace")
+  # contains timestamp
+  result := delete(result, "creationInfo")
 }

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -3279,6 +3279,7 @@ keyspec _IMAGE_SBOM {
     type:     `x
     standard: true
     since:    "0.4.0"
+    canonicalize: func canonicalize_image_sbom(`x) -> `y
     shortdoc: "Docker image SBOM information"
     doc: """
 Docker SPDX SBOM information created with `docker build --sbom=true`.

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1492,7 +1492,8 @@ keyspec SBOM {
     type:             dict[string, dict[string, `x]]
     standard:         true
     since:            "0.1.0"
-    shortdoc: "SBOM(s) collected at Chalk time"
+    canonicalize:     func canonicalize_tools(dict[string, `x]) -> dict[string, `x]
+    shortdoc:         "SBOM(s) collected at Chalk time"
     doc:              """
 This field is meant to capture any SBOMs associated with a chalking
 (i.e., a chalk mark insertion operation). The value, when provided, is
@@ -1518,6 +1519,7 @@ keyspec SECRET_SCANNER {
     type:             dict[string, dict[string, `x]]
     standard:         true
     since:            "0.5.4"
+    canonicalize:     func canonicalize_tools(dict[string, `x]) -> dict[string, `x]
     shortdoc:         "Secret scanner results collected at Chalk time"
     doc:              """
 This field is meant to capture any secret scanning tool results while
@@ -1563,6 +1565,7 @@ keyspec SAST {
     type:             dict[string, `x]
     standard:         true
     since:            "0.1.0"
+    canonicalize:     func canonicalize_tools(dict[string, `x]) -> dict[string, `x]
     shortdoc: "SAST scan results collected at Chalk time"
     doc:              """
 This field captures any static analysis security tooling reports that

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -315,6 +315,40 @@ This field will be shown when the running command `chalk template [your_report_n
   }
 
   allow key {}
+  allow default_object_store {}
+}
+
+singleton default_object_store {
+  user_def_ok:   true
+  doc: """
+TODO
+"""
+
+  field enabled {
+    type:     bool
+    default:  false
+    doc:      """
+TODO
+"""
+  }
+
+  field object_store {
+    type:      string
+    validator: func object_store_check
+    default:   ""
+    doc:       """
+TODO
+"""
+  }
+
+  field threshold {
+    type:    Size
+    require: false
+    doc:     """
+TODO
+"""
+  }
+
 }
 
 object tool {

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -112,6 +112,15 @@ Used to set the output order. If not provided, this will inherit
 the normalization order from the associated keyspec.
 """
   }
+
+  field object_store {
+    type:      string
+    validator: func object_store_check
+    default:   ""
+    doc:       """
+TODO
+"""
+  }
 }
 
 object mark_template {
@@ -428,7 +437,16 @@ informational statement, you can add the key "error", "warn", or
 If the "error" key is present, this will also be taken as a tool
 failure, and no other keys will be checked.
 """
-   }
+  }
+
+  field canonicalize {
+    type:       func (dict[string, string]) -> dict[string, string]
+    require:    false
+    validator:  func key_canonicalize_check
+    doc:        """
+TODO
+"""
+  }
 
   field doc {
     type:     string
@@ -636,6 +654,15 @@ appear with a 'value' field.
 The normalization order used for signing and hashing metadata.
 This only works for built-in keys; everything else is given the same
 priority and should be sorted alphabetically.
+"""
+  }
+
+  field canonicalize {
+    type:       func (`x) -> `x
+    require:    false
+    validator:  func key_canonicalize_check
+    doc:        """
+TODO
 """
   }
 
@@ -902,6 +929,108 @@ in this section are defined by the `sink` configuration named in this
 field.
 """
   }
+}
+
+object_store_types := ["", "presign"]
+
+object object_store_config {
+  user_def_ok:   true
+  doc: """
+TODO
+"""
+
+  allow object_store_presign
+
+  field enabled {
+    type:    bool
+    default: true
+    doc:     """
+Set to false to leave in the config but disable it.
+"""
+  }
+
+  field object_store {
+    type:       string
+    default:    ""
+    choice:     object_store_types
+    doc:        """
+TODO
+"""
+  }
+
+}
+
+singleton object_store_presign {
+  user_def_ok:   true
+  doc:           """
+TODO
+"""
+
+  field uri {
+    type:     string
+    require:  true
+    shortdoc: "TODO"
+    doc:      """
+TODO
+"""
+  }
+
+  field headers {
+    type:     dict[string, string]
+    default:  {}
+    shortdoc: "TODO"
+    doc:      """
+TODO
+"""
+  }
+
+  field disallow_http {
+    type:     bool
+    default:  false
+    shortdoc: "TODO"
+    doc:      """
+TODO
+"""
+  }
+
+  field timeout {
+    type:     int
+    default:  30000 # some keys are pretty large and need more time to upload
+    shortdoc: "TODO"
+    doc:      """
+TODO
+"""
+  }
+
+  field pinned_cert_file {
+    type:     string
+    default:  ""
+    shortdoc: "TODO"
+    doc:      """
+TODO
+"""
+  }
+
+  field read_auth {
+    type:      string
+    shortdoc:  "TODO"
+    validator: func auth_check
+    default:   ""
+    doc:       """
+TODO
+"""
+  }
+
+  field write_auth {
+    type:      string
+    shortdoc:  "TODO"
+    validator: func auth_check
+    default:   ""
+    doc:       """
+TODO
+"""
+  }
+
 }
 
 object auth {
@@ -2426,6 +2555,7 @@ root {
   allow plugin
   allow sink
   allow sink_config
+  allow object_store_config
   allow auth
   allow auth_config
   allow attestation
@@ -3207,6 +3337,20 @@ func key_callback_check(keyname, callback: func (string) -> `x) {
   return ""
 }
 
+func key_canonicalize_check(keyname, callback: func (`x) -> `x) {
+  result    := ""
+  path      := split(keyname, ".")
+  key_name  := path[1]
+  fieldType := $(attr_get("keyspec." + key_name + ".type", typespec))
+  expected  := to_type("(" + fieldType + ") -> " + fieldType)
+  actual    := typeof(callback)
+  if not typecmp(expected, actual) {
+    return ("In: '" + keyname + "' canonicalize() is of type '" + $(actual) +
+            "', but the key specification requires the type: '" +
+            $(expected) + "'")
+  }
+}
+
 func never_early_check(keyname, val) {
   result := ""
 
@@ -3699,6 +3843,26 @@ func sink_config_check(path) {
      if not conffields.contains(sinkfields[i]) {
        return "sink config is missing required field: '" + sinkfields[i] + "'"
      }
+  }
+}
+
+func auth_check(path, val) {
+  result := ""
+  if val == "" {
+    return # Unconfigured
+  }
+  if not attr_exists("auth_config." + val) {
+    return "No such auth configured: '" + val + "'"
+  }
+}
+
+func object_store_check(path, val) {
+  result := ""
+  if val == "" {
+    return # Unconfigured
+  }
+  if not attr_exists("object_store_config." + val) {
+    return "No such object store configured: '" + val + "'"
   }
 }
 

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -440,9 +440,8 @@ failure, and no other keys will be checked.
   }
 
   field canonicalize {
-    type:       func (dict[string, string]) -> dict[string, string]
+    type:       func (`x) -> `y
     require:    false
-    validator:  func key_canonicalize_check
     doc:        """
 TODO
 """
@@ -658,9 +657,8 @@ priority and should be sorted alphabetically.
   }
 
   field canonicalize {
-    type:       func (`x) -> `x
+    type:       func (`x) -> `y
     require:    false
-    validator:  func key_canonicalize_check
     doc:        """
 TODO
 """
@@ -3335,20 +3333,6 @@ func key_callback_check(keyname, callback: func (string) -> `x) {
   }
 
   return ""
-}
-
-func key_canonicalize_check(keyname, callback: func (`x) -> `x) {
-  result    := ""
-  path      := split(keyname, ".")
-  key_name  := path[1]
-  fieldType := $(attr_get("keyspec." + key_name + ".type", typespec))
-  expected  := to_type("(" + fieldType + ") -> " + fieldType)
-  actual    := typeof(callback)
-  if not typecmp(expected, actual) {
-    return ("In: '" + keyname + "' canonicalize() is of type '" + $(actual) +
-            "', but the key specification requires the type: '" +
-            $(expected) + "'")
-  }
 }
 
 func never_early_check(keyname, val) {

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -118,7 +118,38 @@ the normalization order from the associated keyspec.
     validator: func object_store_check
     default:   ""
     doc:       """
-TODO
+When used, report will omit the key itself but instead will contain a reference
+to an object store. The reference is prefixed with `@`.
+
+For example:
+
+```
+report_template example {
+  key.EXAMPLE.use = true
+  key.EXAMPLE.object_store = "example"
+}
+```
+
+The report can be:
+
+```
+{
+  "@EXAMPLE": "presign+https://example.com/EXAMPLE.1a2b3c?foo=bar"
+}
+```
+
+The reference is an URI with these components:
+
+* object store type (e.g. presign)
+* per object store type its unique identifier URI
+* key name
+* hash of the canonicalized value
+* query string of additional metadata
+
+Object store allows consistent metadata to be reference multiple times
+across multiple reports. For example many repositories do not change
+their SBOM on every build therefore allowing to reference same object
+for multiple reports allows to de-duplicate SBOM data between builds.
 """
   }
 }
@@ -321,14 +352,34 @@ This field will be shown when the running command `chalk template [your_report_n
 singleton default_object_store {
   user_def_ok:   true
   doc: """
-TODO
+Default object store configuration to be used for all keys in the report template.
+Currently only keys larger than specific threshold are objectified.
+
+Object store configuration per key always takes precedence over the
+report template default object store. For example:
+
+```
+object_store_config one {...}
+object_store_config two {...}
+report_template example {
+  key.EXAMPLE.object_store = "one"
+  default_object_store {
+    object_store = "two"
+  }
+}
+```
+
+As `key.EXAMPLE` is explicitly configured with the object store, it will be
+objectified with `one` object store configuration and default object store for
+`EXAMPLE` is completely ignored.
 """
 
   field enabled {
     type:     bool
     default:  false
     doc:      """
-TODO
+Whether default object store should be used in the report template.
+When disabled, none of the keys are going to be objectified.
 """
   }
 
@@ -337,7 +388,8 @@ TODO
     validator: func object_store_check
     default:   ""
     doc:       """
-TODO
+Name of the object store config to use for the report template.
+See `object_store_config`.
 """
   }
 
@@ -345,7 +397,8 @@ TODO
     type:    Size
     require: false
     doc:     """
-TODO
+Threshold when the key in the report template should be objectified.
+This is most useful to avoid sending large keys
 """
   }
 
@@ -477,7 +530,11 @@ failure, and no other keys will be checked.
     type:       func (`x) -> `y
     require:    false
     doc:        """
-TODO
+Callback for canonicalizing tool output to a deterministic value
+which can be used to compute the hash of the value for the object store.
+For example for `SBOM` tool, this should remove all build timestamps
+to allow to recompute the same hash between builds as long as SBOM
+items are the same.
 """
   }
 
@@ -694,7 +751,11 @@ priority and should be sorted alphabetically.
     type:       func (`x) -> `y
     require:    false
     doc:        """
-TODO
+Callback for canonicalizing key output to a deterministic value
+which can be used to compute the hash of the value for the object store.
+For example for `SBOM` tool, this should remove all build timestamps
+to allow to recompute the same hash between builds as long as SBOM
+items are the same.
 """
   }
 
@@ -968,7 +1029,27 @@ object_store_types := ["", "presign"]
 object object_store_config {
   user_def_ok:   true
   doc: """
-TODO
+Chalk collects metadata and sends that metadata to various sinks/destinations.
+Within the context of one build, collected metadata is unique however
+over time various builds might be collecting identical metadata.
+For example most repos do not change their dependencies on every commit
+and therefore most commits will not be changing the repo SBOM.
+As such reporting the same information for each chalk report is wasteful.
+Object store allows a single chalk key value to be stored externally,
+therefore allowing to refer to the same object across multiple reports.
+
+Chalk can be configured with multiple object store configurations.
+Each chalk metadata key per report template is then optionally configured
+which object store it should use. Alternately the all of the report template
+can be configured with a default object store to automatically use an object
+store for large keys going over the threshold size.
+This flexibility allows to send different keys to different object stores.
+For example SBOM data might be sent to one object store but SAST
+data to another.
+
+Currently chalk supports these object store types:
+
+* `presign` - send objects to an API which returns presigned URLs
 """
 
   allow object_store_presign
@@ -977,7 +1058,9 @@ TODO
     type:    bool
     default: true
     doc:     """
-Set to false to leave in the config but disable it.
+Whether the object store should be enabled.
+When disabled, keys configured with this object store will not
+use the object store.
 """
   }
 
@@ -986,7 +1069,18 @@ Set to false to leave in the config but disable it.
     default:    ""
     choice:     object_store_types
     doc:        """
-TODO
+Type of the object store which is being configured.
+Depending on this value, corresponding configuration should be provided
+as a sub-configuration:
+
+```
+object_store_config example {
+  object_store: "presign"
+  object_store_presign {
+    uri: "https://example.com/objects"
+  }
+}
+```
 """
   }
 
@@ -995,71 +1089,113 @@ TODO
 singleton object_store_presign {
   user_def_ok:   true
   doc:           """
-TODO
+Presign object store configuration.
+This object store interacts with an API which is expected to redirect to a presigned URL.
+The API is expected to implement the following endpoints:
+
+* `HEAD <uri>/<key>.<hash>` - check if the object already exists in object store
+* `GET <uri>/<key>.<hash>` - fetch existing object
+* `PUT <uri>/<key>.<hash>` - upload new object
+
+In all cases chalk includes these headers to presign endpoints:
+
+* `Content-Type: application/json`
+* `X-Content-Length` - similar to `Content-Length` but is sent to presigning API
+* `X-Chalk-Digest-Sha256` - raw digest of the uploaded content to check for transmission errors
+* `X-Chalk-Version`
+* `X-Chalk-Action-Id` - same as `_ACTION_ID` which can be used to associate object to original
+  report which created it.
+
+Presign API can return these headers:
+
+* `X-Forward-Headers` - comma-delimited headers which should be forwarded to the redirected URL.
+  This provides generic way to send additional headers such as additional
+  metadata to the object store.
+  This is especially useful when presigned URL cannot be self-contained.
+  For example S3 does not allow to include object metadata in presigned URL
+  and requires sending `X-Amz-Meta-*` headers.
+* `X-Chalk-Object-Query` - additional query string to be included in the object store
+  reference used in the report. For example:
+
+  ```
+  X-Chalk-Object-Query: foo=bar
+  ```
+
+  Will yield object reference:
+
+  ```
+  {
+    "@KEY": "presign+https://example.com/objects/KEY.hash?foo=bar"
+  }
+  ```
 """
 
   field uri {
     type:     string
     require:  true
-    shortdoc: "TODO"
+    shortdoc: "URI of the presign API"
     doc:      """
-TODO
+Base URI of the presign API.
+Object `<key>.<hash>` are appended to the URI when making request for any specific objects.
 """
   }
 
   field headers {
     type:     dict[string, string]
     default:  {}
-    shortdoc: "TODO"
-    doc:      """
-TODO
-"""
+    shortdoc: "Additional headers to send to presign API"
+    doc:      "Additional headers to send to presign API"
   }
 
   field disallow_http {
     type:     bool
     default:  false
-    shortdoc: "TODO"
+    shortdoc: "Disallow http presign API"
     doc:      """
-TODO
+Whenever presign API endpoint is not known ahead of time,
+this can be used to disallow http API and only support TLS requests.
 """
   }
 
   field timeout {
     type:     int
     default:  30000 # some keys are pretty large and need more time to upload
-    shortdoc: "TODO"
+    shortdoc: "Object store timeout in milliseconds"
     doc:      """
-TODO
+Timeout duration for the object store API.
+This timeout is used both for the presign API as well as for the object store uploads.
+If very large keys are expected to be uploaded, larger timeout should be allocated.
 """
   }
 
   field pinned_cert_file {
     type:     string
     default:  ""
-    shortdoc: "TODO"
+    shortdoc: "TLS certificate to validate server with"
     doc:      """
-TODO
+TLS self-signed cert used to validate the TLS connection with the presigned API.
 """
   }
 
   field read_auth {
     type:      string
-    shortdoc:  "TODO"
-    validator: func auth_check
     default:   ""
+    validator: func auth_check
+    shortdoc:  "Auth configuration name for read requests"
     doc:       """
-TODO
+Auth configuration which should be used for making HEAD/GET requests to presigned API.
+See `auth_config` for more details.
 """
   }
 
   field write_auth {
     type:      string
-    shortdoc:  "TODO"
     validator: func auth_check
     default:   ""
+    shortdoc:  "Auth configuration name for write requests"
     doc:       """
-TODO
+Auth configuration which should be used for making PUT requests to presigned API.
+See `auth_config` for more details.
 """
   }
 

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -9,11 +9,12 @@
 
 tool semgrep {
   kind: "sast"
-  get_tool_location:  func find_semgrep(string) -> string
-  attempt_install:    func install_semgrep(string) -> bool
-  get_command_args:   func get_semgrep_args(string) -> string
-  produce_keys:       (func load_semgrep_results(string, int) ->
+  ~get_tool_location:  func find_semgrep(string) -> string
+  ~attempt_install:    func install_semgrep(string) -> bool
+  ~get_command_args:   func get_semgrep_args(string) -> string
+  ~produce_keys:       (func load_semgrep_results(string, int) ->
                                                    dict[string, `x])
+  ~canonicalize:       func canonicalize_semgrep(`x) -> `x
   semgrep_config_profile: "auto"
   semgrep_format:         "sarif"
   semgrep_metrics:        "on"
@@ -165,4 +166,20 @@ func load_semgrep_results(out: string, code) {
   }
 
   return { "SAST" : parse_json(out) }
+}
+
+func canonicalize_semgrep(data: dict[string, `v]) {
+  result := data
+  result := delete(result, "version")
+  var runs: list[dict[string, `r]]
+  runs := get(result, "runs")
+  for i from 0 to len(runs) {
+    irun := runs[i]
+    # tool lists tool metadata such as which rule-sets were scanned
+    # which is not deterministic as it depends on the semgrep version
+    # as well as which flags were passed in
+    irun := delete(irun, "tool")
+    runs := set(runs, i, irun)
+  }
+  result := set(result, "runs", runs)
 }

--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -14,6 +14,7 @@ tool syft {
   ~get_command_args:   func get_syft_args(string) -> string
   ~produce_keys:       (func extract_syft_sbom(string, int) ->
                                                    dict[string, `x])
+  ~canonicalize:      func canonicalize_syft(`x) -> `x
   syft_exe_dir:       "/tmp"
   syft_installer:     "https://raw.githubusercontent.com/anchore/syft/main/install.sh"
   syft_container:     "anchore/syft"
@@ -139,4 +140,12 @@ func extract_syft_sbom(out: string, code) {
   }
 
   return { "SBOM" : parse_json(out) }
+}
+
+func canonicalize_syft(data: dict[string, `v]) {
+  result := data
+  result := delete(result, "version")
+  result := delete(result, "serialNumber")
+  # includes timestamp as well as component versions which are not deterministic
+  result := delete(result, "metadata")
 }

--- a/src/configs/secretscannerconfig.c4m
+++ b/src/configs/secretscannerconfig.c4m
@@ -8,12 +8,13 @@
 ## Builtin Secret Scanning tool implementation(s).
 
 tool trufflehog {
-  kind: "secret_scanner"
-  get_tool_location:  func find_trufflehog(string) -> string
-  attempt_install:    func install_trufflehog(string) -> bool
-  get_command_args:   func get_trufflehog_args(string) -> string
-  produce_keys:       (func load_trufflehog_results(string, int) ->
+  ~kind: "secret_scanner"
+  ~get_tool_location:  func find_trufflehog(string) -> string
+  ~attempt_install:    func install_trufflehog(string) -> bool
+  ~get_command_args:   func get_trufflehog_args(string) -> string
+  ~produce_keys:       (func load_trufflehog_results(string, int) ->
                                                    dict[string, `x])
+  ~canonicalize:       func canonicalize_trufflehog(`x) -> `y
   trufflehog_config:         ""
   trufflehog_format_flags:   "--json --no-github-actions"
   trufflehog_other_flags:    ""
@@ -170,4 +171,18 @@ func load_trufflehog_results(out: string, code) {
 
   # trufflehog returns jsonl
   return { "SECRET_SCANNER" : parse_jsonl(out) }
+}
+
+func canonicalize_trufflehog(data: list[`x]) {
+  var canonicalized: dict[string, `t]
+  canonicalized := {}
+  # there are no obvious keys to sort trufflehog output
+  # so we compute binary hash of each item and use that
+  # as a dict key which will produce deterministic result
+  # as dict keys are sorted during normalization
+  for i from 0 to len(data) {
+    item := data[i]
+    canonicalized := set(canonicalized, binary_sha256(item), item)
+  }
+  return canonicalized
 }

--- a/src/normalize.nim
+++ b/src/normalize.nim
@@ -35,7 +35,7 @@ proc u64ToStr(i: uint64): string =
 proc floatToStr(f: float): string =
   result = newStringOfCap(sizeof(float)+1)
 
-proc binEncodeItem(self: Box): string
+proc binEncodeItem*(self: Box): string
 
 proc binEncodeStr(s: string): string =
   return "\x01" & u32ToStr(uint32(len(s))) & s
@@ -77,7 +77,7 @@ proc binEncodeObj(self: Box): string =
     error("non-null objects cannot be normalized")
     unreachable
 
-proc binEncodeItem(self: Box): string =
+proc binEncodeItem*(self: Box): string =
   case self.kind
   of MkBool:  return binEncodeBool(unpack[bool](self))
   of MkInt:   return binEncodeInt(unpack[uint64](self))

--- a/src/object_store/api.nim
+++ b/src/object_store/api.nim
@@ -1,0 +1,101 @@
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+import std/[tables, uri]
+import ".."/[config]
+import "."/[presign]
+
+let objectStores = {
+  presignObjectStore.name: presignObjectStore,
+}.toTable()
+
+var objectStoreConfigs: Table[string, ObjectStoreConfig]
+
+proc getObjectStoreConfigByName(name: string): ObjectStoreConfig =
+  if name in objectStoreConfigs:
+    return objectStoreConfigs[name]
+
+  let
+    configSection  = "object_store_config." & name
+    storeTypeSection = configSection & ".object_store"
+
+  if not sectionExists(configSection):
+    raise newException(ValueError, configSection & " is referenced but its missing in the config")
+
+  let storeType = attrGet[string](storeTypeSection)
+  if storeType == "":
+    raise newException(ValueError, configSection & " is referenced but its missing in the config")
+
+  let store = objectStores[storeType]
+  result = store.init(store, name)
+  objectStoreConfigs[name] = result
+
+proc newObjectStoreRef*(self: ObjectStoreConfig, k: string, data: string): ObjectStoreRef =
+  return ObjectStoreRef(
+    config: self,
+    key:    k,
+    digest: data.sha256Hex(),
+  )
+
+proc `$`(self: ObjectStoreRef): string =
+  var uri = self.config.store.uri(self.config, self)
+  if self.query != "":
+    var queries = newSeq[(string, string)]()
+    for k, v in decodeQuery(uri.query):
+      queries.add((k, v))
+    for k, v in decodeQuery(self.query):
+      queries.add((k, v))
+    uri.query = encodeQuery(queries)
+  result = $uri
+
+proc objectifyByTemplate*(collectedData: ChalkDict,
+                          objectsData: ObjectsDict,
+                          temp: string,
+                          ): ChalkDict =
+  result = ChalkDict()
+  for k, v in collectedData:
+    let
+      path            = temp & ".key." & k & ".object_store"
+      storeConfigName = attrGetOpt[string](path).get("")
+    # there is no object store for this key. use original value
+    if storeConfigName == "":
+      result[k] = v
+      continue
+    # object store is explicitly disabled. use original value
+    let enabled = attrGetOpt[bool]("object_store_config." & storeConfigName & ".enabled").get(false)
+    if not enabled:
+      result[k] = v
+      continue
+    let objectRefs = objectsData.mgetOrPut(storeConfigName, newOrderedTable[string, ObjectStoreRef]())
+    # key was already objectified before. use existing ref
+    if k in objectRefs:
+      result[objectStorePrefix & k] = pack($(objectRefs[k]))
+      continue
+    let
+      storeConfig = getObjectStoreConfigByName(storeConfigName)
+      data        = $v # TODO this is WRONG
+      lookupRef   = newObjectStoreRef(storeConfig, k, data)
+    var storeRef: ObjectStoreRef
+    try:
+      trace("object store: looking up key in object store: " & $lookupRef)
+      storeRef = storeConfig.store.objectExists(storeConfig, lookupRef)
+      if storeRef == nil:
+        try:
+          trace("object store: creating key in object store: " & $lookupRef)
+          storeRef = storeConfig.store.createObject(storeConfig, lookupRef, data)
+        except:
+          error("object store: could not upload object " & $lookupRef & " due to: " & getCurrentExceptionMsg())
+          dumpExOnDebug()
+    except:
+      error("object store: could not lookup existing object " & $lookupRef & " due to: " & getCurrentExceptionMsg())
+      dumpExOnDebug()
+    if storeRef != nil:
+      objectRefs[k] = storeRef
+      result[objectStorePrefix & k] = pack($storeRef)
+    else:
+      error("object store: could not either lookup existing or upload object for " & k)
+      result[k] = v

--- a/src/object_store/api.nim
+++ b/src/object_store/api.nim
@@ -66,7 +66,6 @@ proc canonicalizeKey(key: string, data: Box): Box =
   trace("object store: canonicalizing " & key & " with " & $callback)
   try:
     let canonicalized = runCallback(callback, @[data])
-    #let canonicalized = runCallback("keyspec." & key & ".canonicalize", @[data])
     if canonicalized.isNone():
       error("object store: missing implementation to canonicalize " & key & " for " & $callback)
       return data

--- a/src/object_store/api.nim
+++ b/src/object_store/api.nim
@@ -38,6 +38,7 @@ proc newObjectStoreRef*(self: ObjectStoreConfig, k: string, data: string): Objec
   return ObjectStoreRef(
     config: self,
     key:    k,
+    id:     data.sha256Hex(),
     digest: data.sha256Hex(),
   )
 

--- a/src/object_store/presign.nim
+++ b/src/object_store/presign.nim
@@ -1,0 +1,175 @@
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+import std/[tables, options, uri, httpclient, sequtils]
+import ".."/[config, auth, util]
+
+type
+  ObjectStorePresign = ref object of ObjectStoreConfig
+    uri*:            string
+    headers*:        HttpHeaders
+    disallowHttp*:   bool
+    timeout*:        int
+    pinnedCertFile*: string
+    readAuth*:       AuthConfig
+    writeAuth*:      AuthConfig
+
+proc getConfig[T](name: string, field: string): T =
+  return attrGet[T]("object_store_config." & name & ".object_store_presign." & field)
+
+proc init(self: ObjectStore, name: string): ObjectStoreConfig =
+  let
+    readAuthName  = getConfig[string](name, "read_auth")
+    readAuthOpt   = getAuthConfigByName(readAuthName)
+    writeAuthName = getConfig[string](name, "write_auth")
+    writeAuthOpt  = getAuthConfigByName(writeAuthName)
+  if readAuthName != "" and readAuthOpt.isNone():
+    raise newException(ValueError, "read auth config '" & readAuthName & "' is missing")
+  if writeAuthName != "" and writeAuthOpt.isNone():
+    raise newException(ValueError, "write auth config '" & writeAuthName & "' is missing")
+  let
+    headers = getConfig[TableRef[string, string]](name, "headers")
+    config  = ObjectStorePresign(
+      name:           name,
+      store:          self,
+      headers:        newHttpHeaders(headers.pairs().toSeq()),
+      uri:            getConfig[string](name, "uri"),
+      disallowHttp:   getConfig[bool](  name, "disallow_http"),
+      timeout:        getConfig[int](   name, "timeout"),
+      pinnedCertFile: getConfig[string](name, "pinned_cert_file"),
+      readAuth:       readAuthOpt.get(nil),
+      writeAuth:      writeAuthOpt.get(nil),
+    )
+  return ObjectStoreConfig(config)
+
+proc url(this: ObjectStoreConfig, keyRef: ObjectStoreRef): Uri =
+  let self = ObjectStorePresign(this)
+  result = parseUri(self.uri)
+  result.path.removeSuffix('/')
+  result.path = result.path & "/" & keyRef.key & "." & keyRef.digest
+
+proc fqn(this: ObjectStoreConfig, keyRef: ObjectStoreRef): Uri =
+  let self = ObjectStorePresign(this)
+  result = self.url(keyRef)
+  result.scheme = self.store.name & "+" & result.scheme
+
+proc request(self:           ObjectStorePresign,
+             keyRef:         ObjectStoreRef,
+             auth:           AuthConfig,
+             httpMethod:     HttpMethod,
+             body:           string,
+             ): (Response, ObjectStoreRef) =
+  var signHeaders = newHttpHeaders(@[
+    ("Content-Type", "application/json"),
+    ("X-Content-Length", $len(body)),
+    ("X-Chalk-Version", getChalkExeVersion()),
+    # TODO expose better API for action id interaction
+    ("X-Chalk-Action-Id", unpack[string](hostInfo["_ACTION_ID"])),
+  ]).update(self.headers)
+  if auth != nil:
+    signHeaders = auth.implementation.injectHeaders(auth, signHeaders)
+
+  let url = self.url(keyRef)
+  trace("object store: " & $httpMethod & " " & $url)
+  # for the sign request, we do not want to send full request payload as:
+  # * we expect a redirect response
+  # * server might not accept large requests (hence presigning)
+  # * no need to waste bandwidth
+  # and will only send it to the returned signed URL
+  # which is why we disallow redirects here via maxRedirects
+  # NOTE this assumes that the endpoint immediately returns presigned URL
+  let signResponse = safeRequest(url               = self.url(keyRef),
+                                 timeout           = self.timeout,
+                                 headers           = signHeaders,
+                                 disallowHttp      = self.disallowHttp,
+                                 pinnedCert        = self.pinnedCertFile,
+                                 httpMethod        = httpMethod,
+                                 retries           = 2,
+                                 firstRetryDelayMs = 100,
+                                 maxRedirects      = 0,
+                                 raiseWhenAbove    = 400)
+  trace("object store: " & $httpMethod & " " & $url & " -> " & $signResponse.code)
+
+  if signResponse.code notin [Http302, Http307]:
+    trace("object store: " & signResponse.body())
+    raise newException(ValueError, "Presign requires 302/307 redirect but received: " & signResponse.status)
+
+  if not signResponse.headers.hasKey("location"):
+    raise newException(ValueError, "Presign edirect Location header missing")
+
+  let uri = parseUri(signResponse.headers["location"])
+  if uri.scheme == "":
+    trace("object store: " & $uri)
+    raise newException(ValueError, "Presign edirect Location header needs to be absolute URL")
+
+  var
+    names   = newSeq[string]()
+    headers = newHttpHeaders(@[
+      ("Content-Type", "application/json"),
+      ("Content-Length", $len(body)),
+    ])
+  if signResponse.headers.hasKey("x-forward-headers"):
+    names = signResponse.headers["x-forward-headers"].strip().split(',')
+    for i in names:
+      let name = i.strip()
+      if signResponse.headers.hasKey(name):
+        headers[name] = signResponse.headers[name]
+
+  trace("object store: " & $httpMethod & " @" & uri.hostname & " (" & $len(body) & "bytes) forwarding: " & $names)
+  let response = safeRequest(url               = uri,
+                             headers           = headers,
+                             timeout           = self.timeout,
+                             disallowHttp      = self.disallowHttp,
+                             pinnedCert        = self.pinnedCertFile,
+                             httpMethod        = httpMethod,
+                             body              = body,
+                             retries           = 2,
+                             firstRetryDelayMs = 100,
+                             raiseWhenAbove    = 500)
+  trace("object store: " & $httpMethod & " @" & $uri.hostname & " (" & $len(body) & "bytes) -> " & $response.code)
+
+  let updatedRef = deepCopy(keyRef)
+  updatedRef.query = signResponse.headers.getOrDefault("x-chalk-object-query")
+  return (response, updatedRef)
+
+proc objectExists(this: ObjectStoreConfig, keyRef: ObjectStoreRef): ObjectStoreRef =
+  let
+    self = ObjectStorePresign(this)
+    (response, updatedRef) = self.request(
+      keyRef,
+      auth       = self.readAuth,
+      httpMethod = HttpHead,
+      body       = "",
+    )
+  if response.code.is2xx():
+    return updatedRef
+  elif response.code == Http404:
+    return nil
+  else:
+    raise newException(ValueError, $response.code & " " & response.body())
+
+proc createObject(this: ObjectStoreConfig, keyRef: ObjectStoreRef, data: string): ObjectStoreRef =
+  let
+    self = ObjectStorePresign(this)
+    (response, updatedRef) = self.request(
+      keyRef,
+      auth       = self.writeAuth,
+      httpMethod = HttpPut,
+      body       = data,
+    )
+  if response.code.is2xx():
+    return updatedRef
+  else:
+    raise newException(ValueError, $response.code & " " & response.body())
+
+let presignObjectStore* = ObjectStore(
+  name:         "presign",
+  init:         init,
+  uri:          fqn,
+  objectExists: objectExists,
+  createObject: createObject,
+)

--- a/src/object_store/presign.nim
+++ b/src/object_store/presign.nim
@@ -50,7 +50,7 @@ proc url(this: ObjectStoreConfig, keyRef: ObjectStoreRef): Uri =
   let self = ObjectStorePresign(this)
   result = parseUri(self.uri)
   result.path.removeSuffix('/')
-  result.path = result.path & "/" & keyRef.key & "." & keyRef.digest
+  result.path = result.path & "/" & keyRef.key & "." & keyRef.id
 
 proc fqn(this: ObjectStoreConfig, keyRef: ObjectStoreRef): Uri =
   let self = ObjectStorePresign(this)
@@ -66,6 +66,7 @@ proc request(self:           ObjectStorePresign,
   var signHeaders = newHttpHeaders(@[
     ("Content-Type", "application/json"),
     ("X-Content-Length", $len(body)),
+    ("X-Chalk-Digest-Sha256", keyRef.digest),
     ("X-Chalk-Version", getChalkExeVersion()),
     # TODO expose better API for action id interaction
     ("X-Chalk-Action-Id", unpack[string](hostInfo["_ACTION_ID"])),

--- a/src/plugins/codecElf.nim
+++ b/src/plugins/codecElf.nim
@@ -131,13 +131,13 @@ proc elfHandleWrite*(codec: Plugin,
 
 proc elfGetChalkTimeArtifactInfo*(codec: Plugin, chalk: ChalkObj):
                                 ChalkDict {.cdecl.} =
-  result                      = ChalkDict()
-  result["ARTIFACT_TYPE"]     = artTypeElf
+  result = ChalkDict()
+  result.setIfNeeded("ARTIFACT_TYPE", artTypeElf)
 
 proc elfGetRunTimeArtifactInfo*(codec: Plugin, chalk: ChalkObj, ins: bool):
                               ChalkDict {.cdecl.} =
-  result                      = ChalkDict()
-  result["_OP_ARTIFACT_TYPE"] = artTypeElf
+  result = ChalkDict()
+  result.setIfNeeded("_OP_ARTIFACT_TYPE", artTypeElf)
 
 proc loadCodecElf*() =
   newCodec("elf",

--- a/src/plugins/codecFallbackElf.nim
+++ b/src/plugins/codecFallbackElf.nim
@@ -107,13 +107,13 @@ proc fbGetUnchalkedHash*(self: Plugin, chalk: ChalkObj):
 
 proc fbGetChalkTimeArtifactInfo*(self: Plugin, chalk: ChalkObj):
                                 ChalkDict {.cdecl.} =
-  result                      = ChalkDict()
-  result["ARTIFACT_TYPE"]     = artTypeElf
+  result = ChalkDict()
+  result.setIfNeeded("ARTIFACT_TYPE", artTypeElf)
 
 proc fbGetRunTimeArtifactInfo*(self: Plugin, chalk: ChalkObj, ins: bool):
                               ChalkDict {.cdecl.} =
-  result                      = ChalkDict()
-  result["_OP_ARTIFACT_TYPE"] = artTypeElf
+  result = ChalkDict()
+  result.setIfNeeded("_OP_ARTIFACT_TYPE", artTypeElf)
 
 proc loadCodecFallbackElf*() =
   newCodec("elf_last_resort",

--- a/src/plugins/codecMacOs.nim
+++ b/src/plugins/codecMacOs.nim
@@ -258,13 +258,13 @@ proc macHandleWrite*(self: Plugin, chalk: ChalkObj, enc: Option[string])
 
 proc macGetChalkTimeArtifactInfo*(self: Plugin, chalk: ChalkObj):
                                 ChalkDict {.cdecl.} =
-  result                  = ChalkDict()
-  result["ARTIFACT_TYPE"] = artTypeMachO
+  result = ChalkDict()
+  result.setIfNeeded("ARTIFACT_TYPE", artTypeMachO)
 
 proc macGetRunTimeArtifactInfo*(self: Plugin, chalk: ChalkObj, ins: bool):
                               ChalkDict {.cdecl.} =
-  result                      = ChalkDict()
-  result["_OP_ARTIFACT_TYPE"] = artTypeMachO
+  result = ChalkDict()
+  result.setIfNeeded("_OP_ARTIFACT_TYPE", artTypeMachO)
 
 proc loadCodecMacOs*() =
   newCodec("macos",

--- a/src/plugins/codecPythonPyc.nim
+++ b/src/plugins/codecPythonPyc.nim
@@ -77,13 +77,13 @@ proc pycGetUnchalkedHash*(self: Plugin, chalk: ChalkObj):
 
 proc pycGetChalkTimeArtifactInfo*(self: Plugin, chalk: ChalkObj):
                                 ChalkDict {.cdecl.} =
-  result                  = ChalkDict()
-  result["ARTIFACT_TYPE"] = artTypePyc
+  result = ChalkDict()
+  result.setIfNeeded("ARTIFACT_TYPE", artTypePyc)
 
 proc pycGetRunTimeArtifactInfo*(self:  Plugin, chalk: ChalkObj, ins: bool):
                               ChalkDict {.cdecl.} =
-  result                      = ChalkDict()
-  result["_OP_ARTIFACT_TYPE"] = artTypePyc
+  result = ChalkDict()
+  result.setIfNeeded("_OP_ARTIFACT_TYPE", artTypePyc)
 
 proc loadCodecPythonPyc*() =
   newCodec("python_pyc",

--- a/src/plugins/codecZip.nim
+++ b/src/plugins/codecZip.nim
@@ -221,22 +221,28 @@ proc zipGetChalkTimeArtifactInfo*(self: Plugin, obj: ChalkObj):
 
   let extension = obj.fsRef.splitFile().ext.toLowerAscii()
 
-  result["ARTIFACT_TYPE"] = case extension
-                                of ".jar": artTypeJAR
-                                of ".war": artTypeWAR
-                                of ".ear": artTypeEAR
-                                else:      artTypeZip
+  result.setIfNeeded(
+    "ARTIFACT_TYPE",
+    case extension
+    of ".jar": artTypeJAR
+    of ".war": artTypeWAR
+    of ".ear": artTypeEAR
+    else:      artTypeZip
+  )
 
 proc zipGetRunTimeArtifactInfo*(self: Plugin, obj: ChalkObj, ins: bool):
        ChalkDict {.cdecl.} =
   result        = ChalkDict()
   let extension = obj.fsRef.splitFile().ext.toLowerAscii()
 
-  result["_OP_ARTIFACT_TYPE"] = case extension
-                            of ".jar": artTypeJAR
-                            of ".war": artTypeWAR
-                            of ".ear": artTypeEAR
-                            else:      artTypeZip
+  result.setIfNeeded(
+    "_OP_ARTIFACT_TYPE",
+    case extension
+    of ".jar": artTypeJAR
+    of ".war": artTypeWAR
+    of ".ear": artTypeEAR
+    else:      artTypeZip
+  )
 
 proc zitemGetChalkTimeArtifactInfo*(self: Plugin, obj: ChalkObj):
        ChalkDict {.cdecl.} =

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -18,20 +18,35 @@ var
   startTime*     = getTime().utc # gives absolute wall time
   monoStartTime* = getMonoTime() # used for computing diffs
 
+proc getChalkConfigState(): ConfigState =
+  con4mRuntime.configState
+
 proc getChalkScope*(): AttrScope =
-  con4mRuntime.configState.attrs
+  getChalkConfigState().attrs
+
+proc sectionExists*(c: ConfigState, s: string): bool =
+  c.attrs.getObjectOpt(s).isSome()
 
 proc sectionExists*(s: string): bool =
-  getChalkScope().getObjectOpt(s).isSome()
+  sectionExists(getChalkConfigState(), s)
+
+proc attrGet*[T](c: ConfigState, fqn: string): T =
+  get[T](c.attrs, fqn)
 
 proc attrGet*[T](fqn: string): T =
-  get[T](getChalkScope(), fqn)
+  attrGet[T](getChalkConfigState(), fqn)
+
+proc attrGetOpt*[T](c: ConfigState, fqn: string): Option[T] =
+  getOpt[T](c.attrs, fqn)
 
 proc attrGetOpt*[T](fqn: string): Option[T] =
-  getOpt[T](getChalkScope(), fqn)
+  attrGetOpt[T](getChalkConfigState(), fqn)
+
+proc attrGetObject*(c: ConfigState, fqn: string): AttrScope =
+  getObject(c.attrs, fqn)
 
 proc attrGetObject*(fqn: string): AttrScope =
-  getObject(getChalkScope(), fqn)
+  attrGetObject(getChalkConfigState(), fqn)
 
 iterator getChalkSubsections*(s: string): string =
   ## Walks the contents of the given chalk config section, and yields the
@@ -48,15 +63,25 @@ proc con4mAttrSet*(ctx: ConfigState, fqn: string, value: Box) =
   ## attribute isn't already set, use the other `con4mAttrSet` overload instead.
   doAssert attrSet(ctx, fqn, value).code == errOk
 
+proc con4mAttrSet*(c: ConfigState, fqn: string, value: Box, attrType: Con4mType) =
+  ## Sets the value of the `fqn` attribute to `value`, raising `AssertionDefect`
+  ## if unsuccessful.
+  ##
+  ## This proc may be used if the attribute is not already set.
+  doAssert attrSet(c.attrs, fqn, value, attrType).code == errOk
+
 proc con4mAttrSet*(fqn: string, value: Box, attrType: Con4mType) =
   ## Sets the value of the `fqn` attribute to `value`, raising `AssertionDefect`
   ## if unsuccessful.
   ##
   ## This proc may be used if the attribute is not already set.
-  doAssert attrSet(getChalkScope(), fqn, value, attrType).code == errOk
+  con4mAttrSet(getChalkConfigState(), fqn, value, attrType)
+
+proc con4mSectionCreate*(c: ConfigState, fqn: string) =
+  discard attrLookup(c.attrs, fqn.split('.'), ix = 0, op = vlSecDef)
 
 proc con4mSectionCreate*(fqn: string) =
-  discard attrLookup(getChalkScope(), fqn.split('.'), ix = 0, op = vlSecDef)
+  con4mSectionCreate(con4mRuntime.configState, fqn)
 
 # This is for when we're doing a `conf load`.  We force silence, turning off
 # all logging of merit.

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -80,6 +80,7 @@ proc clearReportingState*() =
   monoStartTime   = getMonoTime()
   ctxStack        = @[CollectionCtx()]
   hostInfo        = ChalkDict()
+  objectsData     = ObjectsDict()
   subscribedKeys  = Table[string, bool]()
   systemErrors    = @[]
   failedKeys      = ChalkDict()
@@ -194,6 +195,7 @@ proc newChalk*(name:         string            = "",
                     repos:         newOrderedTable[string, DockerImageRepo](),
                     containerId:   containerId,
                     collectedData: ChalkDict(),
+                    objectsData:   ObjectsDict(),
                     opFailed:      false,
                     resourceType:  resourceType,
                     extract:       extract,

--- a/tests/functional/data/configs/composable/valid/sboms/enable_sboms.c4m
+++ b/tests/functional/data/configs/composable/valid/sboms/enable_sboms.c4m
@@ -8,6 +8,11 @@ mark_template.mark_default.key.SBOM.use: true
 # `chalk docker build` uses the `minimal` template.
 mark_template.minimal.key.SBOM.use: true
 
+if env_exists("OBJECT_STORE") {
+  report_template.insertion_default.key.SBOM.object_store = "server"
+  report_template.insertion_default.key._IMAGE_SBOM.object_store = "server"
+}
+
 if env("EXTERNAL_TOOL_USE_DOCKER") != "False" {
   tool.syft.syft_prefer_docker = true
 } else {

--- a/tests/functional/poetry.lock
+++ b/tests/functional/poetry.lock
@@ -693,6 +693,53 @@ files = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.7"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
+    {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.13,<0.15"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -1790,4 +1837,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "425e49d11dfb8c44179ca01a4a64a84373235a56a9eeddbf9cb787cb1dda7b1e"
+content-hash = "fd41f02a5dd71519104b6e6cd8b608d365d3fbebb29bba299e5944201f2c85e1"

--- a/tests/functional/pyproject.toml
+++ b/tests/functional/pyproject.toml
@@ -27,6 +27,7 @@ requests = "^2.32.3"
 sqlalchemy = "^2.0.15"
 structlog = "^25.1.0"
 uvicorn = "^0.34.0"
+httpx = "^0.28.1"
 
 [tool.poetry.group.neovim.dependencies]
 mypy = {version = "^1.14.1", optional = true}

--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -5,6 +5,14 @@ custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false
 custom_report.terminal_other_op.use_when: ["extract", "delete", "exec", "env", "heartbeat"]
 
+object_store_config server {
+  enabled = env_exists("OBJECT_STORE")
+  object_store = "presign"
+  object_store_presign {
+    uri = env("OBJECT_STORE")
+  }
+}
+
 report_template insertion_default {
   key._OP_EXIT_CODE.use     = true
   key._CHALK_RUN_TIME.use   = true


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Chalk reports can be very large which send duplicate data across builds (e.g. sbom).

## Description

Instead of reporting raw value in the report template, each key could be uploaded to an object store and its reference be included in the report. This allows to deduplicate large keys independently to object store and then refer the same object across reports.

To use it object store needs to be configured:

```
object_store_config foo {
  object_store: "presign"
  object_store_presign {
    uri: "http://localhost:8080/v0.1/objects"
  }
}
```

Then per report template the object store can be used for specific keys:

```
report_template foo {
  key.SBOM.object_store = "foo"
}
```

Currently only `presign` object store is implemented however the infrastructure is ready to add more object stores in the future such as `s3`, `file`, etc.

## Testing

```
➜ maketest test_plugins.py::test_syft_docker --pdb --logs
```

## TODO

- [x] doc updates
- [x] tests
- [x] handle race conditions