### PR TITLE
feat: report chalkmark chalked date on exec

### DIFF
--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -27,7 +27,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.DATE_CHALKED.use                               = false
   ~key.TIME_CHALKED.use                               = false
   ~key.TZ_OFFSET_WHEN_CHALKED.use                     = false
-  ~key.DATETIME_WHEN_CHALKED.use                      = false
+  ~key.DATETIME_WHEN_CHALKED.use                      = true
   ~key.EARLIEST_VERSION.use                           = false
   ~key.HOST_SYSNAME_WHEN_CHALKED.use                  = false
   ~key.HOST_NODENAME_WHEN_CHALKED.use                 = false
@@ -160,7 +160,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key._INSTANCE_LOCAL_IPV6.use                = false
   ~key._INSTANCE_LOCAL_IPV6_PREFIX_LEN.use     = false
   ~key.CHALK_ID.use                            = true
-  ~key.TIMESTAMP_WHEN_CHALKED.use              = false
+  ~key.TIMESTAMP_WHEN_CHALKED.use              = true
   ~key.CHALK_PTR.use                           = false
   ~key.PATH_WHEN_CHALKED.use                   = true
   ~key.PATH_WITHIN_ZIP.use                     = true


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~Updated `CHANGELOG.md` if necessary~

## Issue

Sometimes when exec is processed before build, build datetime is not known yet

## Description

The key was already part of the mark template:

https://github.com/crashappsec/chalk/blob/962a9b6698f2107234058746b6284a9027faec88/src/configs/base_chalk_templates.c4m#L263-L264

We just werent posting it in the report template.


