### PR TITLE
feat: network.tcp_socket_statuses config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
 
   ([#500](https://github.com/crashappsec/chalk/pull/500))
 
+- `network.tcp_socket_statuses` configuration which allows to filter
+  TCP sockets with specific statuses to be reported in `_OP_TCP_SOCKET_INFO`.
+  ([#504](https://github.com/crashappsec/chalk/pull/504))
+
 ## 0.5.4
 
 **Feb 19, 2025**

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2707,6 +2707,13 @@ By default partial traceroute runs for public cloudflare IP `1.1.1.1`.
     hidden:  true
     doc:     "Timeout to use in ms for each hop in partial traceroute"
   }
+
+  field tcp_socket_statuses {
+    type:    list[string]
+    default: ["LISTEN", "ESTABLISHED"]
+    hidden:  true
+    doc:     "Which TCP socket connect statuses to include in _OP_TCP_SOCKET_INFO"
+  }
 }
 
 root {

--- a/tests/functional/data/configs/netstats.c4m
+++ b/tests/functional/data/configs/netstats.c4m
@@ -1,0 +1,5 @@
+network.tcp_socket_statuses = ["LISTEN", "ESTABLISHED"]
+report_template insertion_default {
+  key._OP_TCP_SOCKET_INFO.use = true
+  key._OP_UDP_SOCKET_INFO.use = true
+}


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

we would like to send subset of tcp sockets in heartbeats

## Description

this allows to filter TCP sockets with what statuses are reported in _OP_TCP_SOCKET_INFO as in most cases WAIT sockets are not super interesting...

## Testing

```
➜ maketest test_plugins.py::test_network --pdb
```
