### PR TITLE
feat: include full attestation payload in cosign _SIGNATURE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Tech stack plugin is removed and all its associated
   configurations as well as keys.
   ([#352](https://github.com/crashappsec/chalk/pull/352))
+- `_SIGNATURES` now includes full cosign attestation payload
+  instead of just the signature. This allows to externally
+  validate the signature without relying on access to the registry.
+  ([#505](https://github.com/crashappsec/chalk/pull/505))
 
 ### Fixes
 

--- a/src/attestation_api.nim
+++ b/src/attestation_api.nim
@@ -5,7 +5,7 @@
 ## (see https://crashoverride.com/docs/chalk)
 ##
 
-import std/[net, os]
+import std/[net, os, json]
 import "."/[chalkjson, config, selfextract, plugin_api, semver, util]
 import "./attestation"/[embed, get, utils]
 import "./docker"/[ids]
@@ -206,7 +206,9 @@ proc verifyBySigStore(chalk: ChalkObj, key: AttestationKey, image: DockerImage):
     let
       blob = parseJson(res)
       sigs = blob["signatures"]
-    dict["_SIGNATURES"] = sigs.nimJsonToBox()
+      att  = newJArray()
+    att.add(blob)
+    dict["_SIGNATURES"] = att.nimJsonToBox()
     trace("in-toto signatures are: " & $sigs)
     info(spec & ": Successfully validated signature.")
     return (vSignedOk, dict)

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -4421,9 +4421,9 @@ keyspec _SIGNATURES {
     since:            "0.4.0"
     doc:              """
 Digital signatures for artifact.  For build/push operations, this will
-generally represent the digital signatures added as part of the
+generally represent full digital attestation added as part of the
 operation. For extraction operations, it represents a *validated*
-extracted signature.
+extracted full attestation.
 
 In some cases there are multiple signatures such as when pushing
 docker image to multiple registries. Each registry will have a unique


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

cosign payload is not included in the chalk report making it impossible to validate the cosign signatures externally

## Description

This changes shape of `_SIGNATURES` to be the full cosign attestation object vs just the signatures.

## Testing

sign any image locally and check `_SIGNATURES`
