### PR TITLE
feat: VCS_MISSING_FILES key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## On the `main` branch
 
+### New Features
+
+- `VCS_MISSING_FILES` key. It lists all files tracked by version control
+  however missing on disk while chalking an artifact.
+  ([#509](https://github.com/crashappsec/chalk/pull/509))
+
 ## 0.5.5
 
 **Apr 15, 2025**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Chalk Release Notes
 
-## On the `main` branch
+## 0.5.6
+
+**Apr 30, 2025**
 
 ### New Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We currently support the following versions in terms of security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.5   | :white_check_mark: |
-| < 0.5.5 | :x:                |
+| 0.5.6   | :white_check_mark: |
+| < 0.5.6 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -74,6 +74,7 @@ or vice versa.
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
+  key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
@@ -182,6 +183,7 @@ mark_template mark_large {
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
+  key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1191,6 +1191,19 @@ the artifact was chalked.
 """
 }
 
+keyspec VCS_MISSING_FILES {
+    kind:             ChalkTimeArtifact
+    type:             list[string]
+    standard:         true
+    since:            "0.5.6"
+    shortdoc:         "Which files are in VCS but are missing on disk"
+    doc:              """
+Reports names of files which are in VCS but are missing on disk during chalk operation.
+If there are missing files, this might indicate CI process is mutating the repo
+before chalking an artifact.
+"""
+}
+
 keyspec BUILD_ORIGIN_URI {
     kind:             ChalkTimeHost
     type:             string

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -95,7 +95,7 @@ plugin vctl_git {
                       "AUTHOR", "DATE_AUTHORED", "TIMESTAMP_AUTHORED",
                       "COMMITTER", "DATE_COMMITTED", "TIMESTAMP_COMMITTED", "COMMIT_MESSAGE",
                       "TAG", "TAG_SIGNED", "TAGGER", "DATE_TAGGED", "TIMESTAMP_TAGGED",
-                      "TAG_MESSAGE", "VCS_DIR_WHEN_CHALKED"]
+                      "TAG_MESSAGE", "VCS_DIR_WHEN_CHALKED", "VCS_MISSING_FILES"]
     post_run_keys:   ["_COMMIT_ID", "_COMMIT_SIGNED",
                       "_BRANCH", "_ORIGIN_URI",
                       "_AUTHOR", "_DATE_AUTHORED", "_TIMESTAMP_AUTHORED",

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -95,6 +95,7 @@ report and subtract from it.
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
+  key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
@@ -700,6 +701,7 @@ doc: """
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
+  key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
@@ -1188,6 +1190,7 @@ container.
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
+  key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
@@ -1674,6 +1677,7 @@ and keep the run-time key.
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.VCS_DIR_WHEN_CHALKED.use                = true
+  key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -206,6 +206,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.PACKAGE_URI.use                         = true
   ~key.CODE_OWNERS.use                         = true
   ~key.VCS_DIR_WHEN_CHALKED.use                = true
+  ~key.VCS_MISSING_FILES.use                   = true
   ~key.BUILD_ID.use                            = true
   ~key.BUILD_COMMIT_ID.use                     = true
   ~key.BUILD_URI.use                           = true

--- a/tests/functional/test_git.py
+++ b/tests/functional/test_git.py
@@ -58,6 +58,8 @@ def test_repo(
         if not empty
         else ""
     )
+    dummy = tmp_data_dir / "dummy"
+    dummy.write_text("hello")
     git = (
         Git(tmp_data_dir, sign=sign)
         .init(remote=remote, branch="foo/bar")
@@ -70,6 +72,7 @@ def test_repo(
         git.pack()
     if symbolic_ref:
         git.symbolic_ref(f"refs/tags/foo/{random_hex}-2")
+    dummy.unlink()
     artifact = copy_files[0]
     result = chalk_copy.insert(artifact)
     assert result.mark.has(
@@ -88,6 +91,7 @@ def test_repo(
         TAG_MESSAGE=(tag_message if (sign or annotate) and not empty else MISSING),
         ORIGIN_URI=remote or "local",
         VCS_DIR_WHEN_CHALKED=str(tmp_data_dir),
+        VCS_MISSING_FILES=[dummy.name],
     )
     assert result.report.has(
         _ORIGIN_URI=remote or "local",


### PR DESCRIPTION
this can allow to catch cases when the build is done on a mutated repo which is missing files tracked by git

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

SBOM does not find any deps during a build even though a repo has `requirements.txt`.

## Description

This key reports all files already tracked in git but are missing on disk during a build which can help to troubleshoot cases where the build does not match a state of git.

## Testing

```
➜ maketest test_git.py::test_repo
```
