### PR TITLE
fix: METADATA_ID in docker push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Chalk Release Notes
 
-## On the `main` branch
+## 0.5.7
+
+**May 22, 2025**
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Chalk Release Notes
 
+## On the `main` branch
+
+### Fixes
+
+- `docker push` of chalked image in CI will report different `METADATA_ID`
+  than what is in the chalkmark.
+  This was a regression in 0.5.5 which was fixing another bug.
+  ([#516](https://github.com/crashappsec/chalk/pull/516))
+
 ## 0.5.6
 
 **Apr 30, 2025**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We currently support the following versions in terms of security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.6   | :white_check_mark: |
-| < 0.5.6 | :x:                |
+| 0.5.7   | :white_check_mark: |
+| < 0.5.7 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#c73f45643205e8c50af1592eb8bca6999a060ba2"
+requires "https://github.com/crashappsec/con4m#7329856cf1f0a37abc3592e75d6d86bcb38643f3"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -11,7 +11,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#0487d36db4432a800138d4f69ee94bc98d881493"
+requires "https://github.com/crashappsec/con4m#c73f45643205e8c50af1592eb8bca6999a060ba2"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 

--- a/src/chalkjson.nim
+++ b/src/chalkjson.nim
@@ -490,12 +490,18 @@ proc forcePrivateKeys() =
   var toForce: seq[string]
 
   for k in getChalkSubsections("keyspec"):
-    if k.startswith("$"):
+    if k.startsWith("$"):
       toForce.add(k)
 
   forceChalkKeys(toForce)
 
 proc getChalkMark*(obj: ChalkObj): ChalkDict =
+  # we already have exact chalkmark so use it
+  # as otherwise we might compute different keys
+  # for example if the chalk template config has changed
+  if obj.cachedMark != "":
+    return obj.cachedMark.extractOneChalkJson(obj.name)
+
   let templ = getMarkTemplate()
   trace("Creating mark using template: " & templ)
 
@@ -513,5 +519,5 @@ proc getChalkMarkAsStr*(obj: ChalkObj): string =
   let mark = obj.getChalkMark()
   result = mark.toJson()
   obj.cachedMark = result
-  if not result.startswith("""{ "MAGIC" :"""):
+  if not result.startsWith("""{ "MAGIC" :"""):
     error("MAGIC not provided; mark is invalid.")

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -52,7 +52,7 @@
 ##     the more basic per-op stuff such as "_CHALKS" and "ACTION_ID" I did not.
 
 ## CHALK SCHEMA
-chalk_version :=   "0.5.7-dev"
+chalk_version :=   "0.5.7"
 ascii_magic   :=   "dadfedabbadabbed"
 
 # Field starting with an underscore (_) are "system" metadata fields, that

--- a/src/normalize.nim
+++ b/src/normalize.nim
@@ -63,7 +63,6 @@ proc binEncodeTable(self: ChalkDict, ignore: seq[string] = @[]): string =
   for k, v in self.sortedPairs():
     if k in ignore:
       continue
-    echo("!!chalkmark!! ", k, "=", $v)
     encoded  &= binEncodeStr(k) & binEncodeItem(v)
     count += 1
   return "\x05" & u32ToStr(uint32(count)) & encoded
@@ -93,6 +92,4 @@ proc normalizeChalk*(dict: ChalkDict): string =
   # signs things actually being written out.  We skip MAGIC, SIGNATURE
   # and SIGN_PARAMS.
   let ignoreList = attrGet[seq[string]]("ignore_when_normalizing")
-  echo("<<<<")
   result = binEncodeTable(dict, ignoreList)
-  echo(">>>>")

--- a/src/normalize.nim
+++ b/src/normalize.nim
@@ -63,6 +63,7 @@ proc binEncodeTable(self: ChalkDict, ignore: seq[string] = @[]): string =
   for k, v in self.sortedPairs():
     if k in ignore:
       continue
+    echo("!!chalkmark!! ", k, "=", $v)
     encoded  &= binEncodeStr(k) & binEncodeItem(v)
     count += 1
   return "\x05" & u32ToStr(uint32(count)) & encoded
@@ -92,4 +93,6 @@ proc normalizeChalk*(dict: ChalkDict): string =
   # signs things actually being written out.  We skip MAGIC, SIGNATURE
   # and SIGN_PARAMS.
   let ignoreList = attrGet[seq[string]]("ignore_when_normalizing")
-  return binEncodeTable(dict, ignoreList)
+  echo("<<<<")
+  result = binEncodeTable(dict, ignoreList)
+  echo(">>>>")

--- a/src/object_store/api.nim
+++ b/src/object_store/api.nim
@@ -71,7 +71,7 @@ proc canonicalizeKey(key: string, data: Box): Box =
       return data
     return canonicalized.get()
   except:
-    error("object store: failed to canonicalize " & key & " due to:" & getCurrentExceptionMsg())
+    error("object store: failed to canonicalize " & key & " due to: " & getCurrentExceptionMsg())
     dumpExOnDebug()
     return data
 

--- a/src/util.nim
+++ b/src/util.nim
@@ -432,7 +432,9 @@ proc merge*(self: ChalkDict, other: ChalkDict, deep = false): ChalkDict {.discar
   result = self
   for k, v in other:
     if k in self and self[k].kind == MkSeq and v.kind == MkSeq:
-      self[k] &= v
+      for i in v:
+        if i notin self[k]:
+          self[k].add(i)
     elif k in self and self[k].kind == MkTable and v.kind == MkTable:
       let
         mine   = unpack[ChalkDict](self[k])

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -684,10 +684,18 @@ class Chalk:
                 pass
         return image_hash, result
 
-    def docker_push(self, image: str, buildkit: bool = True):
+    def docker_push(
+        self,
+        image: str,
+        buildkit: bool = True,
+        env: Optional[dict[str, str]] = None,
+    ):
         return self.run(
             params=["docker", "push", image],
-            env=Docker.build_env(buildkit=buildkit),
+            env={
+                **Docker.build_env(buildkit=buildkit),
+                **(env or {}),
+            },
         )
 
     def docker_pull(self, image: str):

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -1292,6 +1292,13 @@ def test_build_and_push(
     name = f"{test_file}_{random_hex}"
     tag_base = f"{registry}/{name}"
     tag = f"{tag_base}:latest"
+    env = {
+        "CI": "true",
+        "GITHUB_SHA": "abc",
+        # generates BUILD_CONTACT which is a list
+        # which can break METADATA_ID computation between build/push
+        "GITHUB_ACTOR": "octocat",
+    }
 
     image_id, build_result = chalk.docker_build(
         dockerfile=DOCKERFILES / test_file / "Dockerfile",
@@ -1300,6 +1307,7 @@ def test_build_and_push(
         tag=tag,
         push=push,
         run_docker=buildkit,  # legacy builder doesnt allow to build empty image
+        env=env,
     )
 
     push_result = build_result
@@ -1308,7 +1316,7 @@ def test_build_and_push(
         assert build_result.mark.has(
             _IMAGE_LAYERS=MISSING,
         )
-        push_result = chalk.docker_push(tag, buildkit=buildkit)
+        push_result = chalk.docker_push(tag, buildkit=buildkit, env=env)
 
     image_digest, _ = Docker.with_image_digest(build_result)
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

In CI:

```
docker build ..
docker push ..
```

`docker push` will report incorrect `METADATA_ID` as its computation will have incorrect `BUILD_CONTACT` key as its key in the collected data will be merged twice hence have duplicate entries

## Description

Resolving it by both:

* better `.merge` implementation doesnt duplicate array items
* whenever chalkmark is already cached (for already chalked artifacts), its used as-is for chalkmark `ChalkDict` computation instead of again collecting only the keys in the chalk template.

## Testing

```
➜ maketest test_docker.py::test_build_and_push[valid/empty-10.10.20.30:5044-False-True-False]
```
