### PR TITLE
fix: support ipv6 docker registry names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
   IO which could possibly fail with OOM. Standard in/out is no longer captured
   for pass-through commands to resolve that.
   ([#514](https://github.com/crashappsec/chalk/pull/514))
+- Support for IPv6 Docker registry references
+  ([#520](https://github.com/crashappsec/chalk/pull/520))
 
 ## 0.5.7
 

--- a/src/docker/ids.nim
+++ b/src/docker/ids.nim
@@ -309,7 +309,13 @@ proc registry*(self: DockerImage): string =
   return parts[0]
 
 proc domain*(self: DockerImage): string =
-  return self.registry.split(':', maxsplit = 1)[0]
+  let
+    registry = self.registry
+    parsed   = parseUri("http://" & registry)
+  if parsed.isIpv6:
+    return "[" & parsed.hostname & "]"
+  else:
+    return parsed.hostname
 
 proc name*(self: DockerImage): string =
   return self.normalize().repo.split('/', maxsplit = 1)[^1]

--- a/tests/unit/test_docker_ids.nim
+++ b/tests/unit/test_docker_ids.nim
@@ -23,6 +23,15 @@ proc main() =
   assertEq(parseImage("foo.com:1234/test:tag"), image("foo.com:1234/test", "tag", ""))
   assertEq(parseImage("127.0.0.1/test:tag"), image("127.0.0.1/test", "tag", ""))
   assertEq(parseImage("127.0.0.1:1234/test:tag"), image("127.0.0.1:1234/test", "tag", ""))
+  assertEq(parseImage("[2001:df8:0:0:0:ab1:0:0]/test"), image("[2001:df8:0:0:0:ab1:0:0]/test", "latest", ""))
+  assertEq(parseImage("[2001:df8:0:0:0:ab1:0:0]/test:tag"), image("[2001:df8:0:0:0:ab1:0:0]/test", "tag", ""))
+  assertEq(parseImage("[2001:df8:0:0:0:ab1:0:0]:1234/test:tag"), image("[2001:df8:0:0:0:ab1:0:0]:1234/test", "tag", ""))
+
+  assertEq(parseImage("[2001:df8:0:0:0:ab1:0:0]/test:tag").registry, "[2001:df8:0:0:0:ab1:0:0]")
+  assertEq(parseImage("[2001:df8:0:0:0:ab1:0:0]/test:tag").domain, "[2001:df8:0:0:0:ab1:0:0]")
+  assertEq(parseImage("[2001:df8:0:0:0:ab1:0:0]:1234/test:tag").registry, "[2001:df8:0:0:0:ab1:0:0]:1234")
+  assertEq(parseImage("[2001:df8:0:0:0:ab1:0:0]:1234/test:tag").domain, "[2001:df8:0:0:0:ab1:0:0]")
+
   assertEq(parseImage("sha256:bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"), image("", "", "bb99ae95b8ce6a10d397d0b8998cfe12ac055baabd917be9e00cd095991b8630"))
 
   assertEq($(parseImage("foo").uri), "https://registry-1.docker.io/v2/library/foo")
@@ -39,8 +48,11 @@ proc main() =
   assertEq($(parseImage("localhost/bar").uri), "http://localhost/v2/bar")
   assertEq($(parseImage("localhost:1234/bar").uri), "http://localhost:1234/v2/bar")
   assertEq($(parseImage("127.0.0.1/bar").uri), "http://127.0.0.1/v2/bar")
-  assertEq($(parseImage("127.0.0.1/bar").uri), "http://127.0.0.1/v2/bar")
   assertEq($(parseImage("127.0.0.1:1234/bar").uri), "http://127.0.0.1:1234/v2/bar")
+  assertEq($(parseImage("1.1.1.1/bar").uri), "https://1.1.1.1/v2/bar")
+  assertEq($(parseImage("1.1.1.1:1234/bar").uri), "https://1.1.1.1:1234/v2/bar")
+  assertEq($(parseImage("[2001:df8:0:0:0:ab1:0:0]/bar").uri), "https://[2001:df8:0:0:0:ab1:0:0]/v2/bar")
+  assertEq($(parseImage("[2001:df8:0:0:0:ab1:0:0]:1234/bar").uri), "https://[2001:df8:0:0:0:ab1:0:0]:1234/v2/bar")
 
   assertEq($(parseImage("localhost/bar").uri(scheme="https://")), "https://localhost/v2/bar")
   assertEq($(parseImage("foo").uri(path = "/manifests/latest")), "https://registry-1.docker.io/v2/library/foo/manifests/latest")


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Referencing ipv6 docker image incorrected parsed some parts of the name

## Description

Docker supports ipv6 image names which chalk wasnt supporting

## Testing

```
➜ make unit-tests args="pattern tests/unit/test_docker_ids.nim"
```
