### PR TITLE
feat: certs filtering behavior configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,19 @@
   - `_X509_NOT_AFTER`
   - `_X509_EXTRA_EXTENSIONS`
 
+  Certificate behavior can be customized via `certs` configuration block
+  which includes following configs:
+
+  - certs.filter_method
+  - certs.scan_no_extension
+  - certs.scan_extensions
+  - certs.ignore_filenames
+  - certs.ignore_prefixes
+  - certs.ignore_extensions
+
   ([#515](https://github.com/crashappsec/chalk/pull/515),
-  [#521](https://github.com/crashappsec/chalk/pull/521))
+  [#521](https://github.com/crashappsec/chalk/pull/521),
+  [#522](https://github.com/crashappsec/chalk/pull/522))
 
 - `_OP_ARTIFACT_PATH_WITHIN_VCTL` key which indicates path of the file
   in the git repo.

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -15,7 +15,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#1be7501e56827a341372baf4c403af899a7f1578"
+requires "https://github.com/crashappsec/con4m#32ee1da1b76372b688129b0d27e2a44fe94e1ff7"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 

--- a/src/configs/base_init.c4m
+++ b/src/configs/base_init.c4m
@@ -35,6 +35,8 @@ cloud_provider {
 
 network { }
 
+certs { }
+
 attestation {
   attestation_key_embed { }
   attestation_key_get { }

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2319,6 +2319,189 @@ final report, if the monitored process has exited.
   }
 }
 
+certs_filter_methods := ["blacklist", "whitelist"]
+
+singleton certs {
+  user_def_ok:   false
+  doc: """
+Configuration how certs codec behaves and looks for certificates.
+"""
+
+  field filter_method {
+    type:    string
+    default: "whitelist"
+    choice:  certs_filter_methods
+    doc:     """
+Method how files are filtered before attempting to look for a cert.
+Can be either `whitelist` or `blacklist`.
+
+Whitelist honors all `scan_*` configurations:
+* `scan_no_extension`
+* `scan_extensions`
+
+Blacklist honors all `ignore_*` configurations:
+* `ignore_filenames`
+* `ignore_prefixes`
+* `ignore_extensions`
+"""
+  }
+
+  field scan_no_extension {
+    type:    bool
+    default: true
+    doc:     """
+In whitelist mode, whether to scan files for certs when the filename has no extension.
+"""
+  }
+
+  field scan_extensions {
+    type:    list[string]
+    default: [
+              "0", # used in /etc/ssl/certs
+              "cer",
+              "cert",
+              "crt",
+              "der",
+              "key",
+              "pem"
+             ]
+    doc:     """
+In whitelist mode, whether to scan files for certs when the filename has one of the given extensions.
+"""
+  }
+
+  field ignore_filenames {
+    type:    list[string]
+    default: [
+              ".editorconfig",
+              ".eslintignore",
+              ".eslintrc",
+              ".git",
+              ".gitattributes",
+              ".gitkeep",
+              ".keep",
+              ".npmignore",
+              ".nvmrc",
+              ".nycrc",
+              ".prettierrc",
+              ".yarnignore",
+              "AUTHORS",
+              "CHANGELOG",
+              "CODEOWNERS",
+              "Makefile",
+              "NOTICE"
+             ]
+    doc:     """
+In blacklist mode, names of files to ignore to look certs in.
+"""
+  }
+
+  field ignore_prefixes {
+    type:    list[string]
+    default: [
+              "Dockerfile",
+              "LICENSE"
+             ]
+    doc:     """
+In blacklist mode, prefixes of filenames to ignore to look certs in.
+"""
+  }
+
+  field ignore_extensions {
+    type:    list[string]
+    default: [
+              "a",
+              "asm",
+              "bash",
+              "bat",
+              "c",
+              "cc",
+              "cjs",
+              "coffee",
+              "cpp",
+              "cs",
+              "css",
+              "csv",
+              "cts",
+              "ctx",
+              "docx",
+              "ejs",
+              "env",
+              "envrc",
+              "flow",
+              "gif",
+              "go",
+              "graphql",
+              "gz",
+              "h",
+              "hbs",
+              "html",
+              "ico",
+              "ini",
+              "ipynb",
+              "java",
+              "jpeg",
+              "jpg",
+              "js",
+              "json",
+              "jsonl",
+              "jst",
+              "jsx",
+              "kt",
+              "lock",
+              "log",
+              "lua",
+              "m",
+              "map",
+              "markdown",
+              "md",
+              "mdown",
+              "mdx",
+              "mjs",
+              "mts",
+              "mtx",
+              "nim",
+              "o",
+              "otf",
+              "php",
+              "pl",
+              "png",
+              "ps1",
+              "py",
+              "pyc",
+              "r",
+              "rb",
+              "rs",
+              "scss",
+              "sh",
+              "snap",
+              "so",
+              "sql",
+              "svg",
+              "swift",
+              "tar",
+              "text",
+              "toml",
+              "ts",
+              "tsx",
+              "ttf",
+              "txt",
+              "vue",
+              "wasm",
+              "woff",
+              "woff2",
+              "xml",
+              "yaml",
+              "yml",
+              "zip"
+              ]
+    doc: """
+In blacklist mode, file extensions to ignore to look certs in.
+"""
+ }
+
+}
+
 singleton env_config {
   user_def_ok:   false
   doc: """
@@ -2780,6 +2963,7 @@ root {
   allow cloud_provider
   allow git
   allow network
+  allow certs
 
   shortdoc: "Chalk Configuration Options"
 

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -42,6 +42,8 @@ const
                      }.toTable()
 
 proc chalkErrSink*(msg: string, cfg: SinkConfig, t: Topic, arg: StringTable) =
+  if inSubscan():
+    return
   let errObject = getErrorObject()
   if not isChalkingOp() or errObject.isNone():
     systemErrors.add(msg)

--- a/src/subscan.nim
+++ b/src/subscan.nim
@@ -41,11 +41,11 @@ proc runChalkSubScan*(location: seq[string],
     setLogLevel(llError)
 
   let runtime = getChalkRuntime()
+  result = pushCollectionCtx()
   try:
     if suspendHost:
       suspendHostCollection()
     runtime.con4mAttrSet("recursive", pack(true))
-    result                = pushCollectionCtx()
     case cmd
     # if someone is doing 'docker' recursively, we look
     # at the file system instead of a docker file.
@@ -63,6 +63,7 @@ proc runChalkSubScan*(location: seq[string],
 
     setCommandName(oldCmd)
     setArgs(oldArgs)
+    trace("subscan: found " & $len(result.allChalks) & " artifacts")
     trace("Subscan done. Restored command name to: " & oldCmd)
     runtime.con4mAttrSet("recursive", pack(oldRecursive))
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Certs subscan adds a lot of overhead to builds

## Description

allows to blacklist/whitelist files for cert checks

also bumps con4m to bring much more efficient FS walk from nimutils

## Testing

n/a
