### PR TITLE
feat: DOCKERFILE_PATH stdin for docker build git context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@
   ([#514](https://github.com/crashappsec/chalk/pull/514))
 - Support for IPv6 Docker registry references
   ([#520](https://github.com/crashappsec/chalk/pull/520))
+- `DOCKERFILE_PATH` was always reported as `:stdin:` when using docker git
+  context, regardless if `Dockerfile` was actually read from `stdin`.
+  It will only report `:stdin:` now when reading `Dockerfile` from `stdin`.
+  Otherwise it is omitted and instead ``DOCKERFILE_PATH_WITHIN_VCTL` is
+  reports relative `Dockerfile` path to the remote git context repository.
+  ([#523](https://github.com/crashappsec/chalk/pull/523))
 
 ## 0.5.7
 

--- a/src/types.nim
+++ b/src/types.nim
@@ -447,6 +447,7 @@ type
       metadataFilePath*:      string
       metadataFile*:          JsonNode
       dockerFileLoc*:         string # can be :stdin:
+      vctlDockerFileLoc*:     string # path within version control
       inDockerFile*:          string
       addedPlatform*:         OrderedTableRef[string, seq[string]]
       addedInstructions*:     seq[string]

--- a/src/utils/files.nim
+++ b/src/utils/files.nim
@@ -151,6 +151,6 @@ proc getRelativePathBetween*(fromPath: string, toPath: string) : string =
   ## path of the file's `toPath`. Return nothing if its outside the project root,
   ## if `toPath` is an empty string or, if Dockerfile contents was passed via stdin.
   result = toPath.relativePath(fromPath)
-  if result.startsWith("..") or result == "" or result.endsWith(stdinIndicator):
+  if result.startsWith("..") or result == "" or result == stdinIndicator:
     trace("File is ephemeral or not contained within VCS project")
     return ""


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

`DOCKERFILE_PATH` is always reported as `:stdin:` when using remote git context.

## Description

Report correct `DOCKERFILE_PATH` for remote git contexts

## Testing

```
➜ maketest 'test_docker.py::test_git_context' -x --pdb --slow --logs
```

tests:--slow
