### PR TITLE
refactor: switch to openssl buf2hexstr()

### DIFF
--- a/src/utils/certs.c
+++ b/src/utils/certs.c
@@ -39,17 +39,12 @@ char *
 convert_ASN1STRING(ASN1_BIT_STRING *s)
 {
     int            l      = ASN1_STRING_length(s);
-    // each byte is 2 hex plus colon or last char NULL
-    char          *result = calloc(l * 3, 1);
-    unsigned char *data   = ASN1_STRING_get0_data(s);
-    char          *cur    = result;
-
-    for (int i = 0; i < l - 1; i++) {
-        sprintf(cur, "%02x:", data[i]);
-        cur += 3;
-    }
-    sprintf(cur, "%02x", data[l - 1]);
-
+    unsigned char *ptr    = ASN1_STRING_get0_data(s);
+    unsigned char *tmp    = OPENSSL_buf2hexstr(ptr, l);
+    // as we need to free() the key-values, we copy hex string via strdup()
+    // as otherwise openssl pointer needs to be freed with OPENSSL_free()
+    unsigned char *result = strdup(tmp);
+    OPENSSL_free(tmp);
     return result;
 }
 

--- a/tests/functional/test_cert.py
+++ b/tests/functional/test_cert.py
@@ -16,7 +16,7 @@ from .utils.log import get_logger
 
 logger = get_logger()
 
-COLON_HEX = re.compile(r"^([0-9a-f]{2}:)*([0-9a-f]{2})$")
+COLON_HEX = re.compile(r"^([0-9a-fA-F]{2}:)*([0-9a-fA-F]{2})$")
 
 
 def test_cert(


### PR DESCRIPTION
old implementation wasnt complicated but might as well use openssl utils...
