### PR TITLE
fix: bump con4m to fix get(dict[k, v]) builtin

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -15,7 +15,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#2404941ff60d06c61fc7c99a2dbbea23717bc4db"
+requires "https://github.com/crashappsec/con4m#139bfc8c2f16f6069cf59daf7f41ef9a2ef60b5e"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~~Updated `CHANGELOG.md` if necessary~~

## Issue

sometimes this error would pop up:

```
 error: object store: failed to canonicalize SAST due to: docker: [embedded config]: 64:39: 
Unhandled error when running builtin call: canonicalize_toolerror is: options.nim(137, 5) `not val.isNil` 
      canonicalized := canonicalize_tool(name, value)
                                        ^
```

## Description

it didnt break anything actively, just was not canonicalizing correctly for the object store hash

## Testing

n/a
