### PR TITLE
feat: X509_SUBJECT/ISSUER are fully parsed objects

### DIFF
--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -6238,7 +6238,7 @@ https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.1
 
 keyspec _X509_SUBJECT {
     kind:             RunTimeArtifact
-    type:             string
+    type:             dict[string, string]
     standard:         true
     since:            "0.5.8"
     shortdoc:         "Identity certificate is bound to"
@@ -6426,7 +6426,7 @@ https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9
 
 keyspec _X509_ISSUER {
     kind:             RunTimeArtifact
-    type:             string
+    type:             dict[string, string]
     standard:         true
     since:            "0.5.8"
     shortdoc:         "Subject of the CA which minted the cert"

--- a/tests/functional/test_cert.py
+++ b/tests/functional/test_cert.py
@@ -36,12 +36,16 @@ def test_cert(
                 {
                     "_OP_ARTIFACT_PATH": re.compile(r"/cacert.pem$"),
                     "_X509_SIGNATURE": COLON_HEX,
-                    "_X509_SUBJECT": "/C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert Global Root CA",
+                    "_X509_SUBJECT": {
+                        "commonName": "DigiCert Global Root CA",
+                    },
                 },
                 {
                     "_OP_ARTIFACT_ENV_VAR_NAME": "CO_CERT",
                     "_X509_SIGNATURE": COLON_HEX,
-                    "_X509_SUBJECT": "/CN=tls.chalk.local",
+                    "_X509_SUBJECT": {
+                        "commonName": "tls.chalk.local",
+                    },
                 },
             ]
         )

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -492,7 +492,9 @@ def test_subscan(chalk: Chalk, server_cert: Path, random_hex: str):
     assert build.artifacts_by_path.contains(
         {
             str(server_cert): {
-                "_X509_SUBJECT": "/CN=tls.chalk.local",
+                "_X509_SUBJECT": {
+                    "commonName": "tls.chalk.local",
+                },
                 "_OP_ARTIFACT_PATH_WITHIN_VCTL": str(
                     server_cert.relative_to(TESTS.parent.parent)
                 ),


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~~Updated `CHANGELOG.md` if necessary~~

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

instead of a single string for the subject/issuer fields, report it as structured parsed data

they show up as:

```
        "_X509_SUBJECT": {
          "commonName": "crashoverride.run"
        },
        "_X509_ISSUER": {
          "commonName": "Amazon RSA 2048 M03",
          "countryName": "US",
          "organizationName": "Amazon"
        },
```

## Testing

```
➜ maketest test_cert.py
```
