### PR TITLE
feat: add serverless config

### DIFF
--- a/configs/serverless.c4m
+++ b/configs/serverless.c4m
@@ -1,0 +1,2 @@
+# inject the chalk binary into zip archives by default
+zip.inject_binary: true

--- a/src/plugins/codecZip.nim
+++ b/src/plugins/codecZip.nim
@@ -148,7 +148,7 @@ proc zipScan*(self: Plugin, loc: string): Option[ChalkObj] {.cdecl.} =
         chalk.marked  = false
 
     if chalkBinary in cache.onDisk.contents:
-      info("chalk binary exists. removing it.")
+      info("Chalk binary exists, removing it.")
       tryOrBail:
         removeFile(joinPath(hashD, chalkBinary))
 
@@ -239,7 +239,7 @@ proc zipHandleWrite*(self: Plugin, chalk: ChalkObj, encoded: Option[string])
   let injectBinary = attrGet[bool]("zip.inject_binary")
   if injectBinary:
     try:
-      info(chalk.name & ": inserting binary into zip archive")
+      info(chalk.name & ": Inserting binary into zip archive")
       insertChalkBinaryIntoZip(chalk)
     except:
       error(chalk.name & ": failed to insert chalk binary due to: " & getCurrentExceptionMsg())


### PR DESCRIPTION
Configures the `chalk insert` command to insert the chalk binary by default

<!-- Please ensure you have done the following steps: -->

- [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ ] Filled out the template to a useful degree
- [ ] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

## Testing

<!-- What are the steps needed to test this PR? -->

```bash
./chalk load ./configs/serverless.c4m
info:  Autocomplete file exists but is missing chalkmark. Updating.
info:  Installed bash auto-completion file to: /home/heatmiser/.local/share/bash_completion/completions/chalk.bash
info:  Attempting to load module from: ./configs/serverless.c4m


 Configuring Component: /home/heatmiser/Projects/CO/chalk/configs/serverless
 Finished configuration for /home/heatmiser/Projects/CO/chalk/configs/serverless
info:  [testing config]: Validating configuration.
info:  [testing config]: Configuration successfully validated.
info:  Configuration replaced in binary: /home/heatmiser/Projects/CO/chalk/chalk
info:  /home/heatmiser/.local/chalk/chalk.log: Open (sink conf='default_out')
info:  Full chalk report appended to: ~/.local/chalk/chalk.log

```
