### PR TITLE
fix: remove jq build observe dependency

### DIFF
--- a/configs/co/build_observables.c4m
+++ b/configs/co/build_observables.c4m
@@ -1,6 +1,4 @@
 report_template crashoverride {
-  if command_name() == "env" {
-    ~key._X_BUILD_OBSERVABLES.use          = true
-    ~key._X_BUILD_OBSERVABLES.object_store = "crashoverride"
-  }
+  ~key._X_BUILD_OBSERVABLES.use          = true
+  ~key._X_BUILD_OBSERVABLES.object_store = "crashoverride"
 }

--- a/configs/co/build_observables_key.c4m
+++ b/configs/co/build_observables_key.c4m
@@ -5,12 +5,22 @@ keyspec _X_BUILD_OBSERVABLES {
 }
 
 func build_observables(contexts) {
-  observables := "/mnt/curiosity/observables/" + env("GITHUB_RUN_ID") + "-" + env("GITHUB_RUN_ATTEMPT") + "-observables.json"
-  trace("Parsing observables from " + observables)
-  output := strip(run("jq -c -s '.' " + observables))
-  if starts_with(output, "[") {
-    trace("collected build observables output")
-    return parse_json(output)
+  if command_name() != "env" {
+    return
+  }
+  run_id := env("GITHUB_RUN_ID")
+  attempt := env("GITHUB_RUN_ATTEMPT")
+  if run_id == "" or attempt == "" {
+    return
+  }
+  path := "/mnt/curiosity/observables/" + run_id + "-" + attempt + "-observables.json"
+  if not is_file(path) {
+    return
+  }
+  content := read_file(path)
+  if starts_with(content, "[") or starts_with(content, "{") {
+    trace("collected build observables output from " + path)
+    return [parse_json(content)]
   } else {
     trace("empty observables output")
     return


### PR DESCRIPTION
also looks like `command_name()` check wasnt being honored in the template config as the key was subbed during exec so moving check to the callback