### PR TITLE
fix: remove jq build observe dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,8 @@
 - Reporting all IMDSv2 errors in `FAILED_KEYS` or `_OP_FAILED_KEYS`.
   ([#519](https://github.com/crashappsec/chalk/pull/519))
 - Adds `zip.inject_binary` config and `--inject-binary-into-zip` CLI flag to
-  the `chalk insert` command as part of chalk's AWS Lambda support ([#498](https://github.com/crashappsec/chalk/pull/498))
+  the `chalk insert` command as part of chalk's AWS Lambda support
+  ([#498](https://github.com/crashappsec/chalk/pull/498))
 
 ### Fixes
 
@@ -123,6 +124,11 @@
   Otherwise it is omitted and instead ``DOCKERFILE_PATH_WITHIN_VCTL` is
   reports relative `Dockerfile` path to the remote git context repository.
   ([#523](https://github.com/crashappsec/chalk/pull/523))
+- When any key in confspec fails, error is ignored which allows
+  all other confspec keys to be collected. Any single error used to
+  throw global exception which prevented all other keys from being collected
+  including required keys like `_ACTION_ID`.
+  ([#536](https://github.com/crashappsec/chalk/pull/536))
 
 ## 0.5.7
 

--- a/src/plugins/conffile.nim
+++ b/src/plugins/conffile.nim
@@ -24,14 +24,17 @@ proc scanForWork(kt: auto, opt: Option[ChalkObj], args: seq[Box]): ChalkDict =
     if attrGet[int](v & ".kind") != int(kt): continue
     if not isSubscribedKey(k):
       continue
-    let valueOpt = attrGetOpt[Box](v & ".value")
-    let callbackOpt = attrGetOpt[CallbackObj](v & ".callback")
-    if valueOpt.isSome():
-      result.setIfNeeded(k, valueOpt.get())
-    elif callbackOpt.isSome():
-      let cbOpt = runCallback(callbackOpt.get(), args)
-      if cbOpt.isSome():
-        result.setIfNeeded(k, cbOpt.get())
+    try:
+      let valueOpt = attrGetOpt[Box](v & ".value")
+      let callbackOpt = attrGetOpt[CallbackObj](v & ".callback")
+      if valueOpt.isSome():
+        result.setIfNeeded(k, valueOpt.get())
+      elif callbackOpt.isSome():
+        let cbOpt = runCallback(callbackOpt.get(), args)
+        if cbOpt.isSome():
+          result.setIfNeeded(k, cbOpt.get())
+    except:
+      error("conffile: " & k & " ignoring error: " & getCurrentExceptionMsg())
 
 proc confGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
   return scanForWork(KtChalkableHost, none(ChalkObj),


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

some reports were missing `_ACTION_ID`

## Description

ensures all conffile keys are reportable




