### PR TITLE
fix: dont normalize BUILD_TRIGGER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Symlink behavior can now be different between chalking/non-chalking
   operations. As such:
-
   - renamed `symlink_behavior` -> `symlink_behavior_chalking` config
   - renamed `--symlink-behavior` -> `--chalk-symlink-behavior` CLI flags
   - added `symlink_behavior_non_chalking` config
@@ -22,7 +21,6 @@
 
 - X509 Certificate codec which can parse PEM/DER files and report
   metadata keys about the certificate:
-
   - `_X509_VERSION`
   - `_X509_SUBJECT`
   - `_X509_SUBJECT_SHORT`
@@ -79,7 +77,6 @@
 
   Certificate behavior can be customized via `certs` configuration block
   which includes following configs:
-
   - `certs.filter_method`
   - `certs.always_scan_paths`
   - `certs.scan_no_extension`
@@ -99,12 +96,10 @@
 - Asynchronous metadata collection after `chalk exec` with
   new `postexec` report.
   Currently it:
-
   - watches when known artifacts are accessed by chalk exec
     (by default watches for cert usage)
 
   This added these configurations:
-
   - `docker.prep_postexec`
   - `exec.postexec.run`
   - `exec.postexec.nice`
@@ -321,7 +316,6 @@
   ([#471](https://github.com/crashappsec/chalk/pull/471))
 - Requests to AWS API were incorrectly signed due to additional headers
   being included in AWS sigv4. This impacted:
-
   - uploading reports to s3 sink
   - lambda plugin as it could not get caller identity
 
@@ -351,7 +345,6 @@
 - Changes to docker image related fields.
 
   Removed keys:
-
   - `_IMAGE_DIGEST` - there are cases when the image digest is mutated.
     For example `docker pull && docker push` drops all
     manifest annotations resulting in a change to the digest.
@@ -362,7 +355,6 @@
     `_REPO_LIST_DIGESTS` key provides a list of all digests per repository.
 
   Changed keys:
-
   - `_REPO_DIGESTS` previously (and incorrectly) would return the first registry
     and the image digest. This key now provides a list of image digests by
     registry and image name.
@@ -412,7 +404,6 @@
     ```
 
   - `DOCKER_BASE_IMAGES` - sub-keys:
-
     - `name` renamed to `uri`; contains the full repository uri (tag and digest)
     - new `registry` key; the normalized registry uri (domain and optional port)
     - new `name` key; the normalized repo name within the registry
@@ -448,7 +439,6 @@
     been renamed to `uri` and adds the `registry` and `name` keys.
 
   New keys:
-
   - `_REPO_LIST_DIGESTS` - similar to `_REPO_DIGESTS` but enumerates any known
     list digests. Example:
 
@@ -511,7 +501,6 @@
   ```
 
   This also affects all host-level keys in addition to chalk-level keys:
-
   - `DATE_AUTHORED`
   - `DATE_COMMITTED`
   - `DATE_TAGGED`
@@ -582,14 +571,12 @@
   ([#449](https://github.com/crashappsec/chalk/pull/449))
 
 - Docker annotations new keys:
-
   - `DOCKER_ANNOTATIONS` - all `--annotation`s using in `docker build`
   - `_IMAGE_ANNOTATIONS` - found annotations for an image in registry
 
   ([#452](https://github.com/crashappsec/chalk/pull/452))
 
 - Docker base image keys:
-
   - `_OP_ARTIFACT_CONTEXT` - what is the context of the artifact.
     For `docker build` its either `build` or `base`.
   - `DOCKER_BASE_IMAGE_REGISTRY` - just registry of the base image
@@ -645,7 +632,6 @@
 - Changes in embed attestation provider configuration.
   Removed `attestation_key_embed.location` configuration.
   It is replaced with these configurations:
-
   - `attestation_key_embed.filename`
   - `attestation_key_embed.save_path`
   - `attestation_key_embed.get_paths`
@@ -710,7 +696,6 @@
 - `FAILED_KEYS` and `_OP_FAILED_KEYS` - metadata keys
   which chalk could not collect metadata for.
   Each key contains:
-
   - `code` - short identifiable code of a known error
   - `message` - exact encountered error/exception message
   - `description` - human-readable description of the error
@@ -787,7 +772,6 @@
 ### Fixes
 
 - Fixing `ENTRYPOINT` wrapping for empty-like definitions:
-
   - `ENTRYPOINT`
   - `ENTRYPOINT []`
   - `ENTRYPOINT [""]`
@@ -829,7 +813,6 @@
   repository origin and commit id.
   ([#380](https://github.com/crashappsec/chalk/pull/380))
 - New chalk keys:
-
   - `DOCKER_TARGET` - name of the target being built in `Dockerfile`
   - `DOCKER_BASE_IMAGES` - breakdown of all base images across
     all sections of `Dockerfile`
@@ -846,7 +829,6 @@
 
 - A chalk report would previously omit the `_OP_CLOUD_PROVIDER`
   and `_OP_CLOUD_PROVIDER_SERVICE_TYPE` keys when:
-
   - No other instance metadata key (e.g. `_GCP_INSTANCE_METADATA`
     or `_OP_CLOUD_PROVIDER_IP`) was subscribed.
   - The instance metadata service couldn't be reached, or
@@ -991,7 +973,6 @@
 ### New Features
 
 - New chalk keys:
-
   - New key holding GCP project metadata: `_GCP_PROJECT_METADATA`
     ([#311](https://github.com/crashappsec/chalk/pull/31))
 
@@ -1014,10 +995,8 @@
 ### New Features
 
 - New chalk keys:
-
   - Keys to identify the origin repository, using
     an identifier provided by the CI/CD system:
-
     - `BUILD_ORIGIN_ID`
     - `BUILD_ORIGIN_KEY`
     - `BUILD_ORIGIN_OWNER_ID`
@@ -1032,7 +1011,6 @@
 ### Breaking Changes
 
 - Removed chalk keys:
-
   - `_IMAGE_VIRTUAL_SIZE` - deprecated by docker
   - `_IMAGE_LAST_TAG_TIME` - scoped to local daemon and is
     not shared with buildx. Many images report as
@@ -1054,7 +1032,6 @@
   [#286](https://github.com/crashappsec/chalk/pull/286))
 
 - Changed chalk keys:
-
   - `DOCKER_CHALK_ADDED_TO_DOCKERFILE` - is now a list
     vs a single string
   - `_IMAGE_STOP_SIGNAL` - is now a string vs an int.
@@ -1064,7 +1041,6 @@
   ([#282](https://github.com/crashappsec/chalk/pull/282))
 
 - Removed configurations:
-
   - `extract.search_base_layers_for_marks` - chalk mark
     is not guaranteed to be top layer in all cases.
     For example it is not top layer without buildx.
@@ -1117,7 +1093,6 @@
   `--provenance=true` and `--sbom=true`.
   ([#282](https://github.com/crashappsec/chalk/pull/282))
 - New Chalk keys:
-
   - `_IMAGE_COMPRESSED_SIZE` - compressed docker image size
     when collecting image metadata directly from the registry
   - `DOCKER_PLATFORMS` - all platforms used in docker build
@@ -1157,7 +1132,6 @@
     This allows to report from what repo the report is
     running even if its different from repos of individual
     chalk marks or when there are no chalk marks.
-
     - `_ORIGIN_URI`
     - `_BRANCH`
     - `_TAG`
@@ -1201,7 +1175,6 @@
   ([#286](https://github.com/crashappsec/chalk/pull/286))
 
 - New chalk configurations:
-
   - `docker.arch_binary_locations_path` - path where to
     auto-discover chalk binary locations for docker
     multi-platform builds.
@@ -1259,7 +1232,6 @@
   values related to signing backup service have changed.
 
   Removed attributes:
-
   - `use_signing_key_backup_service`
   - `signing_key_backup_service_url`
   - `signing_key_backup_service_auth_config_name`
@@ -1344,7 +1316,6 @@
 ### New Features
 
 - Chalk can now write two new keys to chalk marks and reports:
-
   - `COMMIT_MESSAGE`: the entire commit message of the most
     recent commit.
   - `TAG_MESSAGE`: the entire tag message of an annotated tag,
@@ -1462,7 +1433,6 @@
 - Adding support for git context for docker build commands.
   ([#86](https://github.com/crashappsec/chalk/pull/86))
 - Adding new git metadata fields about:
-
   - authored commit
   - committer
   - tag
@@ -1525,7 +1495,6 @@
   its own `ENTRYPOINT`. A later release will correctly
   inspect all base images and wrap `ENTRYPOINT` correctly.
 - This release does not support:
-
   - Mac x86_64 builds
   - Linux aarch64 builds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,11 @@
 - Not all containers have `root` user. When needing to switch to `root`
   in wrapped `Dockerfile` now using `USER 0:0` which should exist at all times.
   ([#539](https://github.com/crashappsec/chalk/pull/539))
+- Chalk does not attempt to normalize `BUILD_TRIGGER` CI/CD metadata key.
+  It sends the value as reported by the CI/CD system as over time
+  new triggers are added which chalk would normalize to therefore
+  making normalization not very relevant.
+  ([#540](https://github.com/crashappsec/chalk/pull/540))
 
 ## 0.5.7
 

--- a/src/plugins/ciCodeBuild.nim
+++ b/src/plugins/ciCodeBuild.nim
@@ -48,13 +48,7 @@ proc codeBuildGetChalkTimeHostInfo(self: Plugin): ChalkDict {.cdecl.} =
 
   if CODEBUILD_WEBHOOK_TRIGGER != "":
     let event = CODEBUILD_WEBHOOK_TRIGGER.split("/")[0]
-    case event
-    of "tag":
-      result.setIfNeeded("BUILD_TRIGGER", "tag")
-    of "branch", "pr":
-      result.setIfNeeded("BUILD_TRIGGER", "push")
-    else:
-      result.setIfNeeded("BUILD_TRIGGER", "other: " & event)
+    result.setIfNeeded("BUILD_TRIGGER", event)
 
   if CODEBUILD_INITIATOR != "":
     result.setIfNeeded("BUILD_CONTACT", @[CODEBUILD_INITIATOR])

--- a/src/plugins/ciGithub.nim
+++ b/src/plugins/ciGithub.nim
@@ -90,19 +90,10 @@ proc githubGetChalkTimeHostInfo(self: Plugin): ChalkDict {.cdecl.} =
       warn("github: could not fetch repo info: " & getCurrentExceptionMsg())
 
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
-  if GITHUB_EVENT_NAME != "" and GITHUB_REF_TYPE != "":
-    if GITHUB_EVENT_NAME == "push" and GITHUB_REF_TYPE == "tag":
-      result.setIfNeeded("BUILD_TRIGGER", "tag")
-    elif GITHUB_EVENT_NAME == "push":
-      result.setIfNeeded("BUILD_TRIGGER", "push")
-    elif GITHUB_EVENT_NAME == "workflow_dispatch":
-      result.setIfNeeded("BUILD_TRIGGER", "manual")
-    elif GITHUB_EVENT_NAME == "workflow_call":
-      result.setIfNeeded("BUILD_TRIGGER", "external")
-    elif GITHUB_EVENT_NAME == "schedule":
-      result.setIfNeeded("BUILD_TRIGGER", "schedule")
-    else:
-      result.setIfNeeded("BUILD_TRIGGER", "other: " & GITHUB_EVENT_NAME)
+  if GITHUB_EVENT_NAME == "push" and GITHUB_REF_TYPE == "tag":
+    result.setIfNeeded("BUILD_TRIGGER", "tag")
+  else:
+    result.setIfNeeded("BUILD_TRIGGER", GITHUB_EVENT_NAME)
 
   if GITHUB_ACTOR != "": result.setIfNeeded("BUILD_CONTACT", @[GITHUB_ACTOR])
 

--- a/src/plugins/ciGitlab.nim
+++ b/src/plugins/ciGitlab.nim
@@ -44,7 +44,7 @@ proc gitlabGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.}  =
   result.setIfNeeded("BUILD_ORIGIN_OWNER_ID", GITLAB_NAMESPACE_ID)
   result.setIfNeeded("BUILD_ORIGIN_URI",      GITLAB_PROJECT_URL)
 
-  # https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules
+  # https://docs.gitlab.com/ci/jobs/job_rules/#ci_pipeline_source-predefined-variable
   result.setIfNeeded("BUILD_TRIGGER", GITLAB_EVENT_NAME)
 
   # Lots of potential 'user' vars to pick from here, long term will likely

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -196,7 +196,7 @@ def test_codebuild_git(copy_files: list[Path], chalk: Chalk, server_imds: str):
         {
             "BUILD_ID": "arn:aws:codebuild:region-ID:account-ID:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19EXAMPLE",
             "BUILD_COMMIT_ID": "ffac537e6cbbf934b08745a378932722df287a53",
-            "BUILD_TRIGGER": "push",
+            "BUILD_TRIGGER": "branch",
             "BUILD_CONTACT": ["username"],
             "BUILD_URI": "https://aws/build",
             "BUILD_ORIGIN_URI": "https://github.com/octocat/repo",
@@ -224,7 +224,7 @@ def test_codebuild_s3(copy_files: list[Path], chalk: Chalk, server_imds: str):
         {
             "BUILD_ID": "arn:aws:codebuild:region-ID:account-ID:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19EXAMPLE",
             "BUILD_COMMIT_ID": MISSING,
-            "BUILD_TRIGGER": "push",
+            "BUILD_TRIGGER": "branch",
             "BUILD_CONTACT": ["username"],
             "BUILD_URI": "https://aws/build",
             "BUILD_ORIGIN_URI": "s3://bucket/object?versionId=version",


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

`BUILD_TRIGGER` shows up as `other:pull_request` in github builds

## Description

no real benefit normalizing the value if the triggers are added over time

## Testing

```
maketest test_plugins.py::test_github
```
