### PR TITLE
feat: remove raw secrets from trufflehog report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,6 @@
   making normalization not very relevant.
   ([#542](https://github.com/crashappsec/chalk/pull/542))
 - Chalk removes raw secrets as reported by trufflehog and instead:
-
   - ensures `Redacted` is always present
   - adds `RawHash` to allow to distinguish between raw secret values
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,13 @@
   It sends the value as reported by the CI/CD system as over time
   new triggers are added which chalk would normalize to therefore
   making normalization not very relevant.
-  ([#540](https://github.com/crashappsec/chalk/pull/540))
+  ([#542](https://github.com/crashappsec/chalk/pull/542))
+- Chalk removes raw secrets as reported by trufflehog and instead:
+
+  - ensures `Redacted` is always present
+  - adds `RawHash` to allow to distinguish between raw secret values
+
+  ([#543](https://github.com/crashappsec/chalk/pull/543))
 
 ## 0.5.7
 

--- a/src/configs/secretscannerconfig.c4m
+++ b/src/configs/secretscannerconfig.c4m
@@ -170,7 +170,36 @@ func load_trufflehog_results(out: string, code) {
   }
 
   # trufflehog returns jsonl
-  return { "SECRET_SCANNER" : parse_jsonl(out) }
+  var jsonl: list[dict[string, `i]]
+  jsonl := parse_jsonl(out)
+  for i from 0 to len(jsonl) {
+    item := jsonl[i]
+    var raw: string
+    var redacted: string
+    raw := get(item, "Raw")
+    raw_hash := ""
+    redacted := get(item, "Redacted")
+    if raw != "" {
+      raw_hash := sha256(raw)
+      if redacted == "" {
+        redacted := slice(raw, 0, 4) + "<redacted>"
+      }
+    }
+    # chalk removes raw secrets for security but instead
+    # adds RawHash to allow to distinguish between secret values
+    # as well as ensures Redacted is always present
+    item := delete(item, "Raw")
+    item := delete(item, "RawV2")
+    item := set(item, "RawHash", raw_hash)
+    item := set(item, "Redacted", redacted)
+    jsonl := set(jsonl, i, item)
+  }
+
+  # return type must be dict[string, `x] but in order
+  # to loop over jsonl above, it needs to be a list
+  # so for now doing double json dance to normalize type
+  # as there is no native cast in con4m
+  return { "SECRET_SCANNER" : parse_json(to_json(jsonl)) }
 }
 
 func canonicalize_trufflehog(data: list[`x]) {

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -1145,6 +1145,10 @@ export AWS_SESSION_TOKEN={AWS_SESSION_TOKEN}
                     }
                 },
                 "DetectorName": re.compile(r"^AWS"),
+                "Raw": MISSING,
+                "RawV2": MISSING,
+                "RawHash": re.compile(r"[0-9a-f]{64}"),
+                "Redacted": re.compile(r".+"),
             },
         ],
     }


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

trufflehog report includes actual secret values which are reported by chalk

## Description

drop raw secrets from trufflehog reports but report the raw secret hash for allowing to dedup secrets on the backend

## Testing

```
➜ aws_creds maketest test_plugins.py::test_trufflehog[True] --logs --pdb
```
