### PR TITLE
fix: honor color setting in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,10 @@
 
   ([#543](https://github.com/crashappsec/chalk/pull/543))
 
+- Chalk `color` configuration is now honored for logs.
+  Previously it was only honored for chalk pager outputs.
+  ([#549](https://github.com/crashappsec/chalk/pull/549))
+
 ## 0.5.7
 
 **May 22, 2025**

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -15,7 +15,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#2649271e193cabdbf36a8a385c902b1e5635d8d7"
+requires "https://github.com/crashappsec/con4m#abae0aaafc683d75cc04d00e720326e6c19790b1"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 

--- a/src/chalk.nim
+++ b/src/chalk.nim
@@ -36,8 +36,6 @@ when isMainModule:
   loadAllConfigs()         # confload.nim
   recursionCheck()         # norecurse.nim
   setupManagedTemp()       # utils/files.nim
-  if isatty(1) == 0:
-    setShowColor(false)
   limitFDCacheSize(attrGet[int]("cache_fd_limit"))
 
   # Wait for this warning until after configs load.

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -42,14 +42,15 @@ proc getExeVersion(args: seq[Box], unused: ConfigState): Option[Box] =
 proc logBase(ll: string, args: seq[Box], s: ConfigState): Option[Box] =
   let
     msg      = unpack[string](args[0])
-    color    = s.attrLookup("color").get()
-    llevel   = s.attrLookup("log_level").get()
-
+    color    = s.attrLookup("color")
+    llevel   = s.attrLookup("log_level")
 
   # We probably don't need to check and set this every time. However,
   # the value CAN change across stacks.
-  setShowColor(unpack[bool](color))
-  setLogLevel(unpack[string](llevel))
+  if color.isSome():
+    setShowColor(unpack[bool](color.get()))
+  if llevel.isSome():
+    setLogLevel(unpack[string](llevel.get()))
 
   log(ll, msg)
 

--- a/src/configs/ioconfig.c4m
+++ b/src/configs/ioconfig.c4m
@@ -33,12 +33,16 @@ if not using_tty() {
   color: false
   custom_report.terminal_chalk_time.enabled: false
   custom_report.terminal_other_op.enabled: false
+  trace("tty: chalk is running without TTY. Disabling color output and terminal custom reports.")
 } elif env_exists("NO_COLOR") {
   color: false
+  trace("tty: NO_COLOR disables colors")
 } elif env("TERM") == "dumb" {
   color: false
+  trace("tty: TERM=dump disables colors")
 } else {
   color: true
+  trace("tty: chalk is running with TTY")
 }
 
 if skip_summary_report {


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

even when setting `color: false`, logs still contained color ansi codes for the log level prefixes like `error:`. 

fixes https://github.com/crashappsec/chalk/issues/297

## Description

underlying issue was in nimutils https://github.com/crashappsec/nimutils/pull/92

## Testing

```
✗ docker run  --rm -v ./chalk:/chalk alpine /chalk --log-level=trace version
```

ensure colors do not appear without `-t` flag to docker
