### PR TITLE
fix: chalk pegging CPU while IO polling for subprocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Chalk Release Notes
 
+## 0.5.8
+
+**July 29, 2025**
+
+### Fixes
+
+- Fixes chalk calling subprocesses no longer polls for subprocess
+  IO with timeout of 0 which caused chalk pegging CPU
+  while polling for IO.
+  ([#550](https://github.com/crashappsec/chalk/pull/550))
+
 ## 0.5.7
 
 **May 22, 2025**
@@ -159,7 +170,6 @@
   ([#471](https://github.com/crashappsec/chalk/pull/471))
 - Requests to AWS API were incorrectly signed due to additional headers
   being included in AWS sigv4. This impacted:
-
   - uploading reports to s3 sink
   - lambda plugin as it could not get caller identity
 
@@ -189,7 +199,6 @@
 - Changes to docker image related fields.
 
   Removed keys:
-
   - `_IMAGE_DIGEST` - there are cases when the image digest is mutated.
     For example `docker pull && docker push` drops all
     manifest annotations resulting in a change to the digest.
@@ -200,7 +209,6 @@
     `_REPO_LIST_DIGESTS` key provides a list of all digests per repository.
 
   Changed keys:
-
   - `_REPO_DIGESTS` previously (and incorrectly) would return the first registry
     and the image digest. This key now provides a list of image digests by
     registry and image name.
@@ -250,7 +258,6 @@
     ```
 
   - `DOCKER_BASE_IMAGES` - sub-keys:
-
     - `name` renamed to `uri`; contains the full repository uri (tag and digest)
     - new `registry` key; the normalized registry uri (domain and optional port)
     - new `name` key; the normalized repo name within the registry
@@ -286,7 +293,6 @@
     been renamed to `uri` and adds the `registry` and `name` keys.
 
   New keys:
-
   - `_REPO_LIST_DIGESTS` - similar to `_REPO_DIGESTS` but enumerates any known
     list digests. Example:
 
@@ -349,7 +355,6 @@
   ```
 
   This also affects all host-level keys in addition to chalk-level keys:
-
   - `DATE_AUTHORED`
   - `DATE_COMMITTED`
   - `DATE_TAGGED`
@@ -420,14 +425,12 @@
   ([#449](https://github.com/crashappsec/chalk/pull/449))
 
 - Docker annotations new keys:
-
   - `DOCKER_ANNOTATIONS` - all `--annotation`s using in `docker build`
   - `_IMAGE_ANNOTATIONS` - found annotations for an image in registry
 
   ([#452](https://github.com/crashappsec/chalk/pull/452))
 
 - Docker base image keys:
-
   - `_OP_ARTIFACT_CONTEXT` - what is the context of the artifact.
     For `docker build` its either `build` or `base`.
   - `DOCKER_BASE_IMAGE_REGISTRY` - just registry of the base image
@@ -483,7 +486,6 @@
 - Changes in embed attestation provider configuration.
   Removed `attestation_key_embed.location` configuration.
   It is replaced with these configurations:
-
   - `attestation_key_embed.filename`
   - `attestation_key_embed.save_path`
   - `attestation_key_embed.get_paths`
@@ -548,7 +550,6 @@
 - `FAILED_KEYS` and `_OP_FAILED_KEYS` - metadata keys
   which chalk could not collect metadata for.
   Each key contains:
-
   - `code` - short identifiable code of a known error
   - `message` - exact encountered error/exception message
   - `description` - human-readable description of the error
@@ -625,7 +626,6 @@
 ### Fixes
 
 - Fixing `ENTRYPOINT` wrapping for empty-like definitions:
-
   - `ENTRYPOINT`
   - `ENTRYPOINT []`
   - `ENTRYPOINT [""]`
@@ -667,7 +667,6 @@
   repository origin and commit id.
   ([#380](https://github.com/crashappsec/chalk/pull/380))
 - New chalk keys:
-
   - `DOCKER_TARGET` - name of the target being built in `Dockerfile`
   - `DOCKER_BASE_IMAGES` - breakdown of all base images across
     all sections of `Dockerfile`
@@ -684,7 +683,6 @@
 
 - A chalk report would previously omit the `_OP_CLOUD_PROVIDER`
   and `_OP_CLOUD_PROVIDER_SERVICE_TYPE` keys when:
-
   - No other instance metadata key (e.g. `_GCP_INSTANCE_METADATA`
     or `_OP_CLOUD_PROVIDER_IP`) was subscribed.
   - The instance metadata service couldn't be reached, or
@@ -829,7 +827,6 @@
 ### New Features
 
 - New chalk keys:
-
   - New key holding GCP project metadata: `_GCP_PROJECT_METADATA`
     ([#311](https://github.com/crashappsec/chalk/pull/31))
 
@@ -852,10 +849,8 @@
 ### New Features
 
 - New chalk keys:
-
   - Keys to identify the origin repository, using
     an identifier provided by the CI/CD system:
-
     - `BUILD_ORIGIN_ID`
     - `BUILD_ORIGIN_KEY`
     - `BUILD_ORIGIN_OWNER_ID`
@@ -870,7 +865,6 @@
 ### Breaking Changes
 
 - Removed chalk keys:
-
   - `_IMAGE_VIRTUAL_SIZE` - deprecated by docker
   - `_IMAGE_LAST_TAG_TIME` - scoped to local daemon and is
     not shared with buildx. Many images report as
@@ -892,7 +886,6 @@
   [#286](https://github.com/crashappsec/chalk/pull/286))
 
 - Changed chalk keys:
-
   - `DOCKER_CHALK_ADDED_TO_DOCKERFILE` - is now a list
     vs a single string
   - `_IMAGE_STOP_SIGNAL` - is now a string vs an int.
@@ -902,7 +895,6 @@
   ([#282](https://github.com/crashappsec/chalk/pull/282))
 
 - Removed configurations:
-
   - `extract.search_base_layers_for_marks` - chalk mark
     is not guaranteed to be top layer in all cases.
     For example it is not top layer without buildx.
@@ -955,7 +947,6 @@
   `--provenance=true` and `--sbom=true`.
   ([#282](https://github.com/crashappsec/chalk/pull/282))
 - New Chalk keys:
-
   - `_IMAGE_COMPRESSED_SIZE` - compressed docker image size
     when collecting image metadata directly from the registry
   - `DOCKER_PLATFORMS` - all platforms used in docker build
@@ -995,7 +986,6 @@
     This allows to report from what repo the report is
     running even if its different from repos of individual
     chalk marks or when there are no chalk marks.
-
     - `_ORIGIN_URI`
     - `_BRANCH`
     - `_TAG`
@@ -1039,7 +1029,6 @@
   ([#286](https://github.com/crashappsec/chalk/pull/286))
 
 - New chalk configurations:
-
   - `docker.arch_binary_locations_path` - path where to
     auto-discover chalk binary locations for docker
     multi-platform builds.
@@ -1097,7 +1086,6 @@
   values related to signing backup service have changed.
 
   Removed attributes:
-
   - `use_signing_key_backup_service`
   - `signing_key_backup_service_url`
   - `signing_key_backup_service_auth_config_name`
@@ -1182,7 +1170,6 @@
 ### New Features
 
 - Chalk can now write two new keys to chalk marks and reports:
-
   - `COMMIT_MESSAGE`: the entire commit message of the most
     recent commit.
   - `TAG_MESSAGE`: the entire tag message of an annotated tag,
@@ -1300,7 +1287,6 @@
 - Adding support for git context for docker build commands.
   ([#86](https://github.com/crashappsec/chalk/pull/86))
 - Adding new git metadata fields about:
-
   - authored commit
   - committer
   - tag
@@ -1363,7 +1349,6 @@
   its own `ENTRYPOINT`. A later release will correctly
   inspect all base images and wrap `ENTRYPOINT` correctly.
 - This release does not support:
-
   - Mac x86_64 builds
   - Linux aarch64 builds
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We currently support the following versions in terms of security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.7   | :white_check_mark: |
-| < 0.5.7 | :x:                |
+| 0.5.8   | :white_check_mark: |
+| < 0.5.8 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -52,7 +52,7 @@
 ##     the more basic per-op stuff such as "_CHALKS" and "ACTION_ID" I did not.
 
 ## CHALK SCHEMA
-chalk_version :=   "0.5.7"
+chalk_version :=   "0.5.8"
 ascii_magic   :=   "dadfedabbadabbed"
 
 # Field starting with an underscore (_) are "system" metadata fields, that

--- a/src/util.nim
+++ b/src/util.nim
@@ -249,14 +249,12 @@ proc runCmdNoOutputCapture*(exe:       string,
                             args:      seq[string],
                             newStdIn = ""): int {.discardable.} =
   let execOutput = runCmdGetEverything(exe, args, newStdIn,
-                                       passthrough = true,
-                                       timeoutUsec = 0) # No timeout
+                                       passthrough = true)
   result = execOutput.getExit()
 
 proc runCmdExitCode*(exe: string, args: seq[string]): int {.discardable } =
   let execOutput = runCmdGetEverything(exe, args,
-                                       passthrough = false,
-                                       timeoutUsec = 0) # No timeout
+                                       passthrough = false)
   result = execOutput.getExit()
 
 type Redacted* = ref object


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Chalk makes some builds slower which utilize all CPU cores.

## Description

Use default switchboard timeout of 1 sec.

## Testing

Run some docker builds which have go build in them
