### PR TITLE
fix: smaller elf parsing memory utilization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@ docker
 docker-compose*
 server
 tests
+nimble.develop
+nimble.paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,10 @@
   Previously it was only honored for chalk pager outputs.
   ([#549](https://github.com/crashappsec/chalk/pull/549))
 
+- Better error handling when receiving different in-toto attestation
+  for docker images.
+  ([#552](https://github.com/crashappsec/chalk/pull/552)
+
 ## 0.5.8
 
 **July 29, 2025**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@
   Now it is used in all chalk operations.
   ([#515](https://github.com/crashappsec/chalk/pull/515))
 
+- Heartbeat configurations moved from `exec.heartbeat_*` configs to
+  separate configuration singleton `exec.heartbeat.*`.
+  - `exec.heartbeat.run`
+  - `exec.heartbeat.rate`
+  - `exec.heartbeat.rlimit`
+  - `exec.heartbeat.nice`
+
+  ([#552](https://github.com/crashappsec/chalk/pull/552)
+
 ### New Features
 
 - X509 Certificate codec which can parse PEM/DER files and report
@@ -102,6 +111,7 @@
   This added these configurations:
   - `docker.prep_postexec`
   - `exec.postexec.run`
+  - `exec.postexec.fork`
   - `exec.postexec.nice`
   - `exec.postexec.access_watch.prep_tmp_path`
   - `exec.postexec.access_watch.initial_poll_time`
@@ -110,7 +120,8 @@
   - `exec.postexec.access_watch.scan_paths`
 
   ([#539](https://github.com/crashappsec/chalk/pull/539),
-  [#548](https://github.com/crashappsec/chalk/pull/548))
+  [#548](https://github.com/crashappsec/chalk/pull/548),
+  [#552](https://github.com/crashappsec/chalk/pull/552))
 
 - `_OP_ARTIFACT_ACCESSED` key which indicates whether the artifact
   was accessed during chalk operation.

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ endif
 # when no source files change, recopy the backup
 # to get back to original compiled binary
 $(BINARY).bck: $(SOURCES)
+ifneq "$(TMUX)" ""
+	reset
+	tmux clear-history
+endif
 	$(DOCKER) nimble -y $(CHALK_BUILD)
 	mv $(BINARY) $@
 	cp $@ $(BINARY)

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -53,4 +53,4 @@ task performance, "Get a build that adds execution profiling support":
   exec "nimble build --profiler:on --stackTrace:on -d:cprofiling"
 
 task memprofile, "Get a build that adds memory profiling to the binary":
-  exec "nimble build --profiler:off --stackTrace:on -d:memProfiler -d:cprofiling"
+  exec "nimble build --define:debug --profiler:off --stackTrace:on -d:memProfiler -d:cprofiling"

--- a/configs/co/heartbeat2.c4m
+++ b/configs/co/heartbeat2.c4m
@@ -1,0 +1,33 @@
+parameter exec.heartbeat.run {
+  default:  true
+  shortdoc: "Enable heartbeat reports"
+  doc:      "Whether to send periodic heartbeat reports"
+}
+# TODO add duration parameter with libcon4m
+# currently parameters cannot be of Duration type
+exec.heartbeat.rate = <<10 minutes>>
+
+# disable heartbeats in lambda as lambda cannot run on arbitrary schedule
+if env_exists("AWS_LAMBDA_FUNCTION_NAME") and env_exists("AWS_LAMBDA_FUNCTION_VERSION") {
+  exec.heartbeat.run = false
+}
+
+parameter sink_config.crashoverride_heartbeats.uri {
+  shortdoc: "Reporting URL where to send heartbeat reports"
+  doc:      "Reporting URL where to send heartbeat reports"
+  default:  "https://chalk.crashoverride.run/v0.1/report/heartbeats"
+}
+
+sink_config crashoverride_heartbeats {
+  ~enabled:         true
+  ~sink:            "post"
+  ~priority:        999998
+  ~auth:            "crashoverride_reporting"
+}
+
+custom_report crashoverride_heartbeats {
+  ~enabled:         true
+  ~report_template: "heartbeat"
+  ~sink_configs:    ["crashoverride_heartbeats"]
+  ~use_when:        ["heartbeat"]
+}

--- a/configs/use_heartbeats.c4m
+++ b/configs/use_heartbeats.c4m
@@ -25,5 +25,5 @@ sec_as_f := (heartbeat_minute_frequency - float(minutes)) * 60.0
 sec      := int(sec_as_f)
 
 duration := Duration($(minutes) + " min " + $(sec) + " sec")
-exec.heartbeat: true
-exec.heartbeat_rate: duration
+exec.heartbeat.run: true
+exec.heartbeat.rate: duration

--- a/src/commands/cmd_version.nim
+++ b/src/commands/cmd_version.nim
@@ -11,6 +11,7 @@ import ".."/[
   attestation/utils,
   config,
   docker/exe,
+  plugin_api,
   types,
   utils/semver,
 ]
@@ -30,6 +31,8 @@ proc runCmdVersion*() =
     cosign = getCosignVersion()
 
   cells.add(@["Chalk Version", getChalkExeVersion()])
+  if selfChalk != nil:
+    cells.add(@["Chalk ID", selfChalk.callGetChalkId()])
   cells.add(@["Commit ID", getChalkCommitId()])
   cells.add(@["Build OS", hostOS])
   cells.add(@["Build CPU", hostCPU])

--- a/src/configs/base_init.c4m
+++ b/src/configs/base_init.c4m
@@ -12,6 +12,7 @@ func get_args(key) { return command_argv(); }
 
 exec {
   search_path: array_add(split(env("PATH"), ":"), ["."])
+  heartbeat {}
   postexec {
     access_watch {}
   }

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -52,7 +52,7 @@
 ##     the more basic per-op stuff such as "_CHALKS" and "ACTION_ID" I did not.
 
 ## CHALK SCHEMA
-chalk_version :=   "0.5.9-dev"
+chalk_version :=   "0.6.0-dev"
 ascii_magic   :=   "dadfedabbadabbed"
 
 # Field starting with an underscore (_) are "system" metadata fields, that
@@ -2438,7 +2438,7 @@ keyspec _OP_ARTIFACT_ACCESSED {
     type:             bool
     standard:         true
     system:           true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Whether artifact was accessed during chalk operation"
     doc:              """
 During chalk exec, whether the artifact was accessed.
@@ -2451,7 +2451,7 @@ keyspec _OP_ARTIFACT_ENV_VAR_NAME {
     type:             string
     standard:         true
     system:           true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Env var name where artifact was found during the current operation"
     doc:              """
 Name of the env var for a given artifact, in the environment local for
@@ -2464,7 +2464,7 @@ keyspec _OP_ARTIFACT_PATH_WITHIN_VCTL {
     type:             string
     standard:         true
     system:           false
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Path of the artifact within the repo"
     doc:              """
 Path of the artifact relative to the version control repo.
@@ -6234,7 +6234,7 @@ keyspec _X509_VERSION {
     kind:             RunTimeArtifact
     type:             int
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "X509 Certificate Version"
     doc: """
 This field describes the version of the encoded certificate.  When
@@ -6253,7 +6253,7 @@ keyspec _X509_SUBJECT {
     kind:             RunTimeArtifact
     type:             dict[string, string]
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Identity certificate is bound to"
     doc: """
 The subject field identifies the entity associated with the public
@@ -6284,7 +6284,7 @@ keyspec _X509_SUBJECT_SHORT {
     kind:             RunTimeArtifact
     type:             dict[string, string]
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Identity certificate is bound to"
     doc: """
 The subject field identifies the entity associated with the public
@@ -6315,7 +6315,7 @@ keyspec _X509_SUBJECT_ALTERNATIVE_NAME {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Alternate identities certificate is bound to"
     doc: """
 The subject alternative name extension allows identities to be bound
@@ -6341,7 +6341,7 @@ keyspec _X509_SERIAL {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate serial number"
     doc: """
 The serial number MUST be a positive integer assigned by the CA to
@@ -6367,7 +6367,7 @@ keyspec _X509_KEY {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate public key"
     doc: """
 Content of the public key.
@@ -6378,7 +6378,7 @@ keyspec _X509_KEY_TYPE {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate public key type"
     doc: """
 Certificate public key type - RSA, DSA, etc
@@ -6389,7 +6389,7 @@ keyspec _X509_KEY_SIZE {
     kind:             RunTimeArtifact
     type:             int
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate public key size"
     doc: """
 Cryptographic size of the public key
@@ -6400,7 +6400,7 @@ keyspec _X509_KEY_USAGE {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate key usage restrictions"
     doc: """
 The key usage extension defines the purpose (e.g., encipherment,
@@ -6421,7 +6421,7 @@ keyspec _X509_SIGNATURE {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate signature"
     doc: """
 Certificate signature in hex
@@ -6432,7 +6432,7 @@ keyspec _X509_SIGNATURE_TYPE {
     kind:             RunTimeArtifact
     type:             int
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate signature size"
     doc: """
 Type of the certificate signature - sha1, sha256, etc
@@ -6443,7 +6443,7 @@ keyspec _X509_EXTENDED_KEY_USAGE {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Purpose for the certificate usage (e.g. TLS)"
     doc: """
 This extension indicates one or more purposes for which the certified
@@ -6459,7 +6459,7 @@ keyspec _X509_BASIC_CONSTRAINTS {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "CA certificate indication"
     doc: """
 The basic constraints extension identifies whether the subject of the
@@ -6474,7 +6474,7 @@ keyspec _X509_ISSUER {
     kind:             RunTimeArtifact
     type:             dict[string, string]
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Subject of the CA which minted the cert"
     doc: """
 The issuer field identifies the entity that has signed and issued the
@@ -6491,7 +6491,7 @@ keyspec _X509_ISSUER_SHORT {
     kind:             RunTimeArtifact
     type:             dict[string, string]
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Subject of the CA which minted the cert"
     doc: """
 The issuer field identifies the entity that has signed and issued the
@@ -6508,7 +6508,7 @@ keyspec _X509_SUBJECT_KEY_IDENTIFIER {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Identity of the key for the certificate"
     doc: """
 The subject key identifier extension provides a means of identifying
@@ -6532,7 +6532,7 @@ keyspec _X509_AUTHORITY_KEY_IDENTIFIER {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Identity of the CA key used to mint certificate"
     doc: """
 The authority key identifier extension provides a means of
@@ -6551,7 +6551,7 @@ keyspec _X509_NOT_BEFORE {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate Creation Datetime"
     doc: """
 The certificate validity period is the time interval during which the
@@ -6570,7 +6570,7 @@ keyspec _X509_NOT_AFTER {
     kind:             RunTimeArtifact
     type:             string
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Certificate Expiration Datetime"
     doc: """
 The certificate validity period is the time interval during which the
@@ -6589,7 +6589,7 @@ keyspec _X509_EXTRA_EXTENSIONS {
     kind:             RunTimeArtifact
     type:             dict[string, string]
     standard:         true
-    since:            "0.5.9"
+    since:            "0.6.0"
     shortdoc:         "Extra Certificate Extensions"
     doc: """
 Extra certificate extensions not already reported in other chalk keys normalized as a string.

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2422,8 +2422,7 @@ after postexec is complete.
     default: 5
     range:   (0, 19)
     doc: """
-Nice level for the post exec forked process to reduce impact to the
-primary exec process.
+Nice level for the post exec to reduce overall system impact.
 See https://www.man7.org/linux/man-pages/man2/nice.2.html
 """
   }

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2193,6 +2193,7 @@ well.
 """
 
   allow postexec
+  allow heartbeat
 
   field command_name {
     type:     string
@@ -2328,9 +2329,17 @@ If it is NOT true, set exec.searchpath to provide any locations Chalk should che
 """
   }
 
-  field heartbeat {
-    type:    bool
-    default: false
+}
+
+singleton heartbeat {
+  user_def_ok:   false
+  doc: """
+Chalk periodic heartbeats configuration.
+"""
+
+  field run {
+    type:      bool
+    default:   false
     shortdoc: "Report heartbeats"
     doc: """
 When this is true, Chalk will, after initial reporting, connect
@@ -2339,7 +2348,7 @@ controlled by the `heartbeat_rate` field.
 """
   }
 
-  field heartbeat_rate {
+  field rate {
     type:    Duration
     default: <<20 seconds>>
     shortdoc: "Heartbeat rate"
@@ -2357,13 +2366,23 @@ final report, if the monitored process has exited.
 """
   }
 
-  field heartbeat_rlimit {
+  field rlimit {
     type: Size
     default: <<0mb>>
     doc:     """
 rlimit for the heartbeat forked process.
 When set to 0, no limit is enforced.
 This can ensure heartbeat process does not consume more memory than allocated.
+"""
+  }
+
+  field nice {
+    type:    int
+    default: 5
+    range:   (0, 19)
+    doc: """
+Nice level for the heartbeat forked process to reduce system impact.
+See https://www.man7.org/linux/man-pages/man2/nice.2.html
 """
   }
 }
@@ -2384,6 +2403,17 @@ Post exec is executed after normal chalk exec which allows chalk to:
     default: false
     doc: """
 Whether postexec report collection should run after exec.
+"""
+  }
+
+  field fork {
+    type:    bool
+    default: false
+    doc: """
+Whether to fork to another pid for collecting postexec data.
+Using the same pid as the main exec/heartbeats process saves memory utilization
+however will delay initial heartbeats somewhat as heartbeat loop will only start
+after postexec is complete.
 """
   }
 

--- a/src/configs/getopts.c4m
+++ b/src/configs/getopts.c4m
@@ -498,7 +498,7 @@ This is most useful for short-lived processes, as it ensures chalk will complete
     }
 
     flag_yn heartbeat {
-    field_to_set: "exec.heartbeat"
+    field_to_set: "exec.heartbeat.run"
     doc: """
 When set to true, causes periodic reports to be run, past the initial one.
 """

--- a/src/plugin_api.nim
+++ b/src/plugin_api.nim
@@ -203,7 +203,9 @@ proc findFirstValidChalkMark*(s:            Stream,
 
 proc loadChalkFromFStream*(codec:  Plugin,
                            stream: FileStream,
-                           loc:    string): ChalkObj =
+                           loc:    string,
+                           cache   = RootRef(nil),
+                           ): ChalkObj =
   ## A helper function for codecs that use file streams to load
   ## an existing chalk mark.  The stream must be positioned over
   ## the start of the Chalk magic before you call this function.
@@ -211,7 +213,8 @@ proc loadChalkFromFStream*(codec:  Plugin,
   result = newChalk(name         = loc,
                     fsRef        = loc,
                     codec        = codec,
-                    resourceType = {ResourceFile})
+                    resourceType = {ResourceFile},
+                    cache        = cache)
 
   trace(result.name & ": chalk mark magic @ " & $(stream.getPosition()))
 

--- a/src/plugins/codecElf.nim
+++ b/src/plugins/codecElf.nim
@@ -131,7 +131,6 @@ proc elfHandleWrite*(codec: Plugin,
         elf.insertOrSetChalkSection(SH_NAME_CHALKMARK, data.get())
       else:
         elf.unchalk()
-    echo("READ ALL ", chalk.name)
     if success and chalk.fsRef.replaceFileContents(elf.fileData.readAll()):
       return
   except:

--- a/src/plugins/elf.nim
+++ b/src/plugins/elf.nim
@@ -9,6 +9,7 @@ import std/[
 ]
 import ".."/[
   types,
+  utils/files,
 ]
 
 # We've got a lot of ELF-specific defines we're not using but we
@@ -221,7 +222,7 @@ type
     name:                    string
 
   ElfFile*                   = ref object of RootRef
-    fileData*:               string
+    fileData*:               FileStringStream
     header*:                 ElfHeader
     programHeaders*:         seq[ElfProgramHeader]
     sectionHeaders*:         seq[ElfSectionHeader]
@@ -237,10 +238,10 @@ proc pad8(offset: uint64): uint64 =
   # pad8() returns to us how many bytes to pad for 64bit alignment
   return uint64((8 - (offset and 7)) and NOT8)
 
-proc getInt[T](data: var string, whence: int = 0): T =
-  return cast[ref [T]](addr data[whence])[]
+proc getInt[T](data: FileStringStream, whence: int = 0): T =
+  result = readInt[T](data, whence)
 
-proc setInt[T](data: var string, whence: uint64, value: T) =
+proc setInt[T](data: var (string | FileStringStream), whence: uint64, value: T) =
   for byteIndex in 0 ..< sizeof(T):
     var newValue = (uint(value) shr uint(byteIndex * 8)) and uint(0xFF)
     data[int(whence) + byteIndex] = char(newValue)
@@ -360,20 +361,23 @@ proc setElfIntValue[T](self:       ElfFile,
   elfValue.value = newValue
   setInt[T](self.fileData, elfValue.whence, newValue)
 
-proc getValue[T](data: var string, whence: uint64): ElfIntValue[T] =
+proc getValue[T](data: FileStringStream, whence: uint64): ElfIntValue[T] =
   return ElfIntValue[T](whence: whence, value: getInt[T](data, int(whence)))
 
 proc locateChalkSection(self: ElfFile) =
-  var sectionHeaders = self.sectionHeaders
-  for index in low(sectionHeaders) .. high(sectionHeaders):
-    var header = sectionHeaders[index]
+  for header in self.sectionHeaders:
     if header.headerType.value != uint32(SHT_PROGBITS):
       continue
-    if header.name == SH_NAME_CHALKMARK:
+    case header.name
+    of SH_NAME_CHALKMARK:
       self.chalkSectionHeader = header
-    if header.name == SH_NAME_CHALKFREE:
+      break
+    of SH_NAME_CHALKFREE:
       self.chalkSectionHeader = header
       self.hasBeenUnchalked   = true
+      break
+    else:
+      discard
 
 proc parseHeader*(self: ElfFile): bool =
   let
@@ -603,16 +607,9 @@ proc parse*(self: ElfFile): bool =
      self.parseSectionTable()
   if result:
     self.locateChalkSection()
+  else:
+    error("elf: " & $self.errors)
   return result
-
-proc parseAndShow*(fileData: string) =
-  var file = ElfFile(
-    fileData: fileData,
-  )
-  if not file.parse():
-    echo ERR_ELF_PARSE_GENERAL
-    return
-  file.ranges.show()
 
 proc setChalkSection*(self: ElfFile, name, data: string): bool =
   # NOTE!
@@ -695,10 +692,11 @@ proc setChalkSection*(self: ElfFile, name, data: string): bool =
                              NULLBYTE)
   sectionTableOffset += alignmentNeeded
   self.setElfIntValue(self.header.sectionTable, sectionTableOffset)
-  self.fileData = self.fileData[0 ..< chalkSectionOffset] &
-                  data                                    &
-                  stringTableData                         &
-                  sectionTableData
+  self.fileData[chalkSectionOffset] = (
+    data &
+    stringTableData &
+    sectionTableData
+  )
   return self.parse()
 
 proc insertChalkSection*(self: ElfFile, name: string, data: string): bool =
@@ -839,29 +837,30 @@ proc insertChalkSection*(self: ElfFile, name: string, data: string): bool =
   else:
     sectionTableData &= sectionHeader
 
-  var fileData  = self.fileData
-  fileData      = fileData[0 ..< truncateOffset]
-  fileData     &= chalkSectionData
-  fileData     &= stringTableData
-  fileData     &= sectionTableData
-  self.fileData = fileData
+  self.fileData[truncateOffset] = (
+    chalkSectionData &
+    stringTableData &
+    sectionTableData
+  )
   return self.parse()
 
-proc unchalk*(self: ElfFile): bool =
-  var unmark = newString(SHA256_BYTE_LENGTH)
+proc insertOrSetChalkSection*(self: ElfFile, name: string, data: string): bool =
   if self.chalkSectionHeader == nil:
-    if not self.insertChalkSection(SH_NAME_CHALKFREE, unmark):
-      return false
+    return self.insertChalkSection(name, data)
   else:
-    if not self.setChalkSection(SH_NAME_CHALKFREE, unmark):
-      return false
+    return self.setChalkSection(name, data)
+
+proc unchalk*(self: ElfFile): bool =
+  if not self.insertOrSetChalkSection(SH_NAME_CHALKFREE, newString(SHA256_BYTE_LENGTH)):
+    return false
   var chalkOffset = self.chalkSectionHeader.offset.value
   var unchalked   = self.fileData[0 ..< chalkOffset] &
                     self.fileData[chalkOffset + SHA256_BYTE_LENGTH .. ^1]
   var hash        = unchalked.sha256()
-  self.fileData   = self.fileData[0 ..< chalkOffset] &
-                    hash                             &
-                    self.fileData[chalkOffset + SHA256_BYTE_LENGTH .. ^1]
+  self.fileData[chalkOffset] = (
+    hash &
+    self.fileData[chalkOffset + SHA256_BYTE_LENGTH .. ^1]
+  )
   return true
 
 proc getChalkSectionData*(self: ElfFile): string =
@@ -872,10 +871,12 @@ proc getChalkSectionData*(self: ElfFile): string =
   let size   = chalkHeader.size.value
   return self.fileData[offset ..< offset + size]
 
-proc newElfFileFromData*(fileData: string): ElfFile =
+proc newElfFileFromData*(fileData: FileStringStream): ElfFile =
   return ElfFile(
     fileData: fileData,
   )
 
-proc newElfFileFromFilename*(filename: string): ElfFile =
-  return newElfFileFromData(open(filename, fmRead).readAll())
+proc copy*(self: ElfFile): ElfFile =
+  return ElfFile(
+    fileData: self.fileData.copy(),
+  )

--- a/src/plugins/system.nim
+++ b/src/plugins/system.nim
@@ -271,9 +271,8 @@ proc sysGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
     result.setIfNeeded("HOST_NODENAME_WHEN_CHALKED", uinfo.nodename)
     result.setIfNeeded("HOST_MACHINE_WHEN_CHALKED", uinfo.machine)
 
-  if isSubscribedKey("INJECTOR_CHALK_ID"):
-    let selfIdOpt = selfId
-    if selfIdOpt.isSome(): result["INJECTOR_CHALK_ID"] = pack(selfIdOpt.get())
+  if isSubscribedKey("INJECTOR_CHALK_ID") and selfChalk != nil:
+    result.setIfNeeded("INJECTOR_CHALK_ID", selfChalk.callGetChalkId())
 
 proc attestationGetChalkTimeArtifactInfo*(self: Plugin, obj: ChalkObj):
                                           ChalkDict {.cdecl.} =

--- a/src/reporting.nim
+++ b/src/reporting.nim
@@ -151,7 +151,7 @@ proc doCustomReporting() =
 
     safePublish(topic, buildHostReport(templateToUse))
 
-proc doReporting*(topic="report") {.exportc, cdecl.} =
+proc doReporting*(topic="report", clearState = false) {.exportc, cdecl.} =
   if inSubscan():
     let ctx = getCurrentCollectionCtx()
     ctx.report = doEmbeddedReport()
@@ -170,3 +170,5 @@ proc doReporting*(topic="report") {.exportc, cdecl.} =
     if not skipCustom:
       doCustomReporting()
     writeReportCache()
+  if clearState:
+    clearReportingState()

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -51,6 +51,17 @@ template withOnlyCodecs*(codecs: seq[Plugin], c: untyped) =
 template getOnlyCodecs*(): seq[Plugin] =
   onlyCodecs
 
+template withInternalScan*(c: untyped) =
+  let old = inInternalScan
+  inInternalScan = true
+  try:
+    c
+  finally:
+    inInternalScan = old
+
+template getInternalScan*(): bool =
+  inInternalScan
+
 proc inSubscan*(): bool =
   return len(ctxStack) > 1
 

--- a/src/selfextract.nim
+++ b/src/selfextract.nim
@@ -80,10 +80,10 @@ proc getSelfExtraction*(): Option[ChalkObj] =
   # If we call twice and we're on a platform where we don't
   # have a codec for this type of executable, avoid dupe errors.
   once:
-    var
-      myPath = getMyAppPath()
-      cmd    = getCommandName()
+    var cmd    = getCommandName()
 
+    # /proc/self/exe is a symlink hence have to use absolute path of the exe
+    var myPath = getMyAppPath()
     try:
       myPath = myPath.resolvePath()
     except:
@@ -140,8 +140,6 @@ proc getSelfExtraction*(): Option[ChalkObj] =
     if selfChalk.extract == nil:
       selfChalk.marked = false
       selfChalk.extract = ChalkDict()
-
-      selfId = some(selfChalk.callGetChalkId())
 
     setCommandName(cmd)
 

--- a/src/selfextract.nim
+++ b/src/selfextract.nim
@@ -127,21 +127,21 @@ proc getSelfExtraction*(): Option[ChalkObj] =
                "Ensure chalk has both read and execute permissions. " &
                "To add permissions run: 'chmod +rx " & myPath & "'\n")
 
-    let ai = ArtifactIterationInfo(filePaths: @[myPath])
-    for i in ai.scanArtifactLocationsWith(getNativeCodecs()):
-      selfChalk = i
-      break
+    withInternalScan():
+      let ai = ArtifactIterationInfo(filePaths: @[myPath])
+      for i in ai.scanArtifactLocationsWith(getNativeCodecs()):
+        selfChalk = i
+        break
 
-    if selfChalk == nil:
-      canSelfInject = false
       setCommandName(cmd)
-      return none(ChalkObj)
 
-    if selfChalk.extract == nil:
-      selfChalk.marked = false
-      selfChalk.extract = ChalkDict()
+      if selfChalk == nil:
+        canSelfInject = false
+        return none(ChalkObj)
 
-    setCommandName(cmd)
+      if selfChalk.extract == nil:
+        selfChalk.marked = false
+        selfChalk.extract = ChalkDict()
 
   if selfChalk != nil:
     result = some(selfChalk)

--- a/src/types.nim
+++ b/src/types.nim
@@ -549,6 +549,7 @@ var
   canSelfInject*          = true
   doingTestRun*           = false
   onlyCodecs*             = newSeq[Plugin]()
+  inInternalScan*         = false
   passedHelpFlag*         = false
   installedPlugins*       = Table[string, Plugin]()
   externalActions*        = newSeq[seq[string]]()

--- a/src/types.nim
+++ b/src/types.nim
@@ -546,7 +546,6 @@ var
   subscribedKeys*         = Table[string, bool]()
   systemErrors*           = seq[string](@[])
   selfChalk*              = ChalkObj(nil)
-  selfId*                 = none(string)
   canSelfInject*          = true
   doingTestRun*           = false
   onlyCodecs*             = newSeq[Plugin]()

--- a/src/utils/exe.nim
+++ b/src/utils/exe.nim
@@ -41,19 +41,20 @@ proc findExePath*(cmdName:    string,
   if ignoreChalkExes:
     var newExes: seq[string]
 
-    withOnlyCodecs(getNativeCodecs()):
-      for location in foundExes:
-        let
-          subscan   = runChalkSubScan(location, "extract")
-          allChalks = subscan.getAllChalks()
-          isChalk   = (
-            len(allChalks) != 0 and
-            allChalks[0].extract != nil and
-           "$CHALK_IMPLEMENTATION_NAME" in allChalks[0].extract
-          )
-        if not isChalk:
-          newExes.add(location)
-          break
+    withInternalScan():
+      withOnlyCodecs(getNativeCodecs()):
+        for location in foundExes:
+          let
+            subscan   = runChalkSubScan(location, "extract")
+            allChalks = subscan.getAllChalks()
+            isChalk   = (
+              len(allChalks) != 0 and
+              allChalks[0].extract != nil and
+             "$CHALK_IMPLEMENTATION_NAME" in allChalks[0].extract
+            )
+          if not isChalk:
+            newExes.add(location)
+            break
 
     foundExes = newExes
 

--- a/src/utils/file_string_stream.nim
+++ b/src/utils/file_string_stream.nim
@@ -1,0 +1,134 @@
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+import std/[
+  os,
+  streams,
+  posix
+]
+import "."/[
+  fd_cache,
+  tables,
+]
+
+export fd_cache
+
+type
+  # alias to allow using different ints in the same function signature generic
+  # as otherwise nim doesnt match signature
+  IntA = SomeInteger
+  IntB = SomeInteger
+
+  EndOverride = tuple
+    i:    int
+    data: string
+
+  FileStringStream* = ref object
+    path:        string
+    size:        int
+    loaded:      bool
+    data:        string
+    overrides:   TableRef[int, char]
+    endOverride: EndOverride
+
+template withFileStream(self: FileStringStream, code: untyped) =
+  withFileStream(self.path, mode = fmRead, strict = true):
+    code
+
+proc load*(self: FileStringStream) =
+  if not self.loaded:
+    self.withFileStream:
+      self.data   = stream.readAll()
+      self.loaded = true
+
+proc len*(self: FileStringStream): int =
+  if self.loaded:
+    return len(self.data)
+  elif self.endOverride.i < 0:
+    result = self.size
+  else:
+    result = self.endOverride.i + len(self.endOverride.data)
+
+proc `[]`*(self: FileStringStream, s: HSlice[IntA, IntB]): string =
+  if self.loaded:
+    result = self.data[s]
+  else:
+    self.withFileStream:
+      stream.setPosition(int(s.a))
+      let n = int(s.b) - int(s.a) + 1
+      result = stream.readStr(n)
+      for i, o in self.overrides.pairs():
+        if i >= int(s.a) and i <= int(s.b):
+          result[i - int(s.a)] = o
+      if self.endOverride.i >= int(s.a) and self.endOverride.i <= int(s.b):
+        let
+          a = self.endOverride.i - int(s.a)
+          l = n - a
+        result = result[0 ..< a] & self.endOverride.data[0 ..< l]
+      elif self.endOverride.i >= 0 and self.endOverride.i < int(s.a):
+        let
+          a = int(s.a) - self.endOverride.i
+          b = int(s.b) - self.endOverride.i
+        result = self.endOverride.data[a .. b]
+
+proc `[]`*(self: FileStringStream, s: HSlice[SomeInteger, BackwardsIndex]): string =
+  result = self[int(s.a) .. len(self) - int(s.b)]
+
+proc `[]=`*(self: FileStringStream, i: SomeInteger, c: char) =
+  if self.loaded:
+    self.data[i] = c
+  else:
+    self.overrides[i] = c
+
+proc `[]=`*(self: FileStringStream, i: SomeInteger, d: string) =
+  if self.loaded:
+    self.data = self.data[0 ..< i] & d
+  else:
+    self.endOverride = (int(i), d)
+    var toCleanUp = newSeq[int]()
+    for j, _ in self.overrides.pairs():
+      if j >= int(i):
+        toCleanUp.add(j)
+    for j in toCleanUp:
+      self.overrides.del(j)
+
+proc readInt*[T](self: FileStringStream, where: int): T =
+  let value =
+    if self.loaded:
+      self.data[where ..< where + sizeof(T)]
+    else:
+      self[where ..< where + sizeof(T)]
+  result = cast[ref T](addr value[0])[]
+
+proc readAll*(self: FileStringStream): string =
+  if self.loaded:
+    result = self.data
+  else:
+    result = self[0 ..< len(self)]
+
+proc writeAll*(self: FileStringStream, s: string) =
+  self.data   = s
+  self.loaded = true
+
+proc copy*(self: FileStringStream): FileStringStream =
+  result = FileStringStream(
+    loaded:      self.loaded,
+    data:        self.data,
+    path:        self.path,
+    size:        self.size,
+    overrides:   newTable[int, char](),
+    endOverride: (-1, ""),
+  )
+
+proc newFileStringStream*(path: string): FileStringStream =
+  let info = getFileInfo(path)
+  result = FileStringStream(
+    path:        path,
+    size:        info.size,
+    overrides:   newTable[int, char](),
+    endOverride: (-1, ""),
+  )

--- a/src/utils/file_string_stream.nim
+++ b/src/utils/file_string_stream.nim
@@ -28,9 +28,10 @@ type
     data: string
 
   FileStringStream* = ref object
-    path:        string
+    path*:       string
     size:        int
     loaded:      bool
+    mutated:     bool
     data:        string
     overrides:   TableRef[int, char]
     endOverride: EndOverride
@@ -57,34 +58,39 @@ proc `[]`*(self: FileStringStream, s: HSlice[IntA, IntB]): string =
   if self.loaded:
     result = self.data[s]
   else:
-    self.withFileStream:
-      stream.setPosition(int(s.a))
-      let n = int(s.b) - int(s.a) + 1
-      result = stream.readStr(n)
-      for i, o in self.overrides.pairs():
-        if i >= int(s.a) and i <= int(s.b):
-          result[i - int(s.a)] = o
-      if self.endOverride.i >= int(s.a) and self.endOverride.i <= int(s.b):
-        let
-          a = self.endOverride.i - int(s.a)
-          l = n - a
-        result = result[0 ..< a] & self.endOverride.data[0 ..< l]
-      elif self.endOverride.i >= 0 and self.endOverride.i < int(s.a):
-        let
-          a = int(s.a) - self.endOverride.i
-          b = int(s.b) - self.endOverride.i
-        result = self.endOverride.data[a .. b]
+    # requested slice is exclusively within the endOverride range
+    if self.endOverride.i >= 0 and self.endOverride.i <= int(s.a):
+      let
+        a = int(s.a) - self.endOverride.i
+        b = int(s.b) - self.endOverride.i
+      result = self.endOverride.data[a .. b]
+    # otherwise we need to read section of the file
+    else:
+      self.withFileStream:
+        stream.setPosition(int(s.a))
+        let n = int(s.b) - int(s.a) + 1
+        result = stream.readStr(n)
+        for i, o in self.overrides.pairs():
+          if i >= int(s.a) and i <= int(s.b):
+            result[i - int(s.a)] = o
+        if self.endOverride.i >= int(s.a) and self.endOverride.i <= int(s.b):
+          let
+            a = self.endOverride.i - int(s.a)
+            l = n - a
+          result = result[0 ..< a] & self.endOverride.data[0 ..< l]
 
 proc `[]`*(self: FileStringStream, s: HSlice[SomeInteger, BackwardsIndex]): string =
   result = self[int(s.a) .. len(self) - int(s.b)]
 
 proc `[]=`*(self: FileStringStream, i: SomeInteger, c: char) =
+  self.mutated = true
   if self.loaded:
     self.data[i] = c
   else:
     self.overrides[i] = c
 
 proc `[]=`*(self: FileStringStream, i: SomeInteger, d: string) =
+  self.mutated = true
   if self.loaded:
     self.data = self.data[0 ..< i] & d
   else:
@@ -104,25 +110,37 @@ proc readInt*[T](self: FileStringStream, where: int): T =
       self[where ..< where + sizeof(T)]
   result = cast[ref T](addr value[0])[]
 
+iterator chunks*(self: FileStringStream, s: HSlice[IntA, IntB], size: int): string =
+  for i in countup(int(s.a), int(s.b), size):
+    let step = i .. min(i + size - 1, int(s.b))
+    yield self[step]
+
+iterator chunks*(self: FileStringStream, s: HSlice[SomeInteger, BackwardsIndex], size: int): string =
+  let l = len(self)
+  for i in self.chunks(int(s.a) .. l - int(s.b), size):
+    yield i
+
 proc readAll*(self: FileStringStream): string =
   if self.loaded:
     result = self.data
   else:
     result = self[0 ..< len(self)]
 
-proc writeAll*(self: FileStringStream, s: string) =
-  self.data   = s
-  self.loaded = true
-
-proc copy*(self: FileStringStream): FileStringStream =
+proc reset*(self: FileStringStream): FileStringStream =
   result = FileStringStream(
-    loaded:      self.loaded,
-    data:        self.data,
     path:        self.path,
     size:        self.size,
     overrides:   newTable[int, char](),
     endOverride: (-1, ""),
   )
+  # there were mutations on loaded data so
+  # cannot simply copy-paste but need to reread the data
+  if self.mutated and self.loaded:
+    result.load()
+  # otherwise copy existing data as-is
+  else:
+    result.loaded = self.loaded
+    result.data   = self.data
 
 proc newFileStringStream*(path: string): FileStringStream =
   let info = getFileInfo(path)

--- a/src/utils/file_string_stream.nim
+++ b/src/utils/file_string_stream.nim
@@ -18,8 +18,12 @@ import "."/[
 export fd_cache
 
 type
-  # alias to allow using different ints in the same function signature generic
-  # as otherwise nim doesnt match signature
+  # Type aliases to work around Nim's generic type matching limitations.
+  # When using HSlice[IntA, IntB] in proc signatures, Nim requires both
+  # bounds to be the exact same integer type (e.g., both int or both int64).
+  # These aliases allow mixing different integer types in slices (e.g., myStream[0..len(data)])
+  # where 0 is int and len() returns int64, avoiding explicit type conversions.
+  # Without these aliases, users would need to write myStream[0.int..len(data)]
   IntA = SomeInteger
   IntB = SomeInteger
 

--- a/src/utils/files.nim
+++ b/src/utils/files.nim
@@ -21,10 +21,12 @@ import ".."/[
 ]
 import "."/[
   fd_cache,
+  file_string_stream,
   times, # TODO remove
 ]
 
 export fd_cache
+export file_string_stream
 export managedtmp
 export os
 export tempfiles
@@ -63,6 +65,7 @@ proc replaceFileContents*(fsRef: string, contents: string): bool =
         if statResult == 0:
           discard chmod(cstring(fsRef), info.st_mode)
       except:
+        error("file: " & getCurrentExceptionMsg())
         removeFile(path)
         if not fileExists(fsRef):
           # We might have managed to move it but not copy the new guy in.

--- a/src/utils/strings.nim
+++ b/src/utils/strings.nim
@@ -66,6 +66,14 @@ proc strip*(items: seq[string],
   for i in items:
     result.add(i.strip(leading = leading, trailing = trailing, chars = chars))
 
+proc splitLinesAnd*(items: string, keepEol = false, keepEmpty = true): seq[string] =
+  let lines = items.splitLines(keepEol = keepEol)
+  if keepEmpty:
+    return lines
+  for i in lines:
+    if i != "":
+      result.add(i)
+
 proc elseWhenEmpty*(s: string, default: string): string =
   if s == "":
     return default

--- a/tests/functional/data/configs/composable/valid/multiple/sample_2.c4m
+++ b/tests/functional/data/configs/composable/valid/multiple/sample_2.c4m
@@ -1,3 +1,3 @@
 # exec heartbeat
-exec.heartbeat: true
-exec.heartbeat_rate: <<1 seconds>>
+exec.heartbeat.run: true
+exec.heartbeat.rate: <<1 seconds>>

--- a/tests/functional/data/configs/docker_heartbeat.c4m
+++ b/tests/functional/data/configs/docker_heartbeat.c4m
@@ -3,8 +3,8 @@ subscribe("report", "json_console_out")
 custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false
 
-exec.heartbeat: true
-exec.heartbeat_rate: <<1 seconds>>
+exec.heartbeat.run: true
+exec.heartbeat.rate: <<1 seconds>>
 
 docker.wrap_entrypoint: true
 docker.wrap_cmd: true

--- a/tests/functional/data/configs/heartbeat.c4m
+++ b/tests/functional/data/configs/heartbeat.c4m
@@ -2,8 +2,8 @@ unsubscribe("report", "json_console_out")
 custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false
 
-exec.heartbeat: true
-exec.heartbeat_rate: <<1 seconds>>
+exec.heartbeat.run: true
+exec.heartbeat.rate: <<1 seconds>>
 
 report_template heartbeat_report_template {
     key._CHALKS.use = true # Needed to include the per-artifact reports.

--- a/tests/unit/test_file_string_stream.nim
+++ b/tests/unit/test_file_string_stream.nim
@@ -1,12 +1,16 @@
 import std/[
+  # enumerate,
   os,
+  sequtils,
   streams,
   strutils,
 ]
 import ../../src/utils/file_string_stream {.all.}
 
 template assertEq(a, b: untyped) =
-  doAssert a == b, "\"" & $a & "\" != \"" & $b & "\""
+  let aa = a
+  let bb = b
+  doAssert aa == bb, "\"" & $aa & "\" != \"" & $bb & "\""
 
 proc test(load: bool) =
   var s = newFileStringStream("one")
@@ -46,9 +50,14 @@ proc test(load: bool) =
   assertEq(len(s), 25)
   s[23] = "derful"
   assertEq(len(s), 29)
+  assertEq(s[0..<5], "he11o")
+  assertEq(s[20..<25], "wonde")
   assertEq(s[20..<26], "wonder")
+  assertEq(s[20..<27], "wonderf")
+  assertEq(s[20..<28], "wonderfu")
   assertEq(s[20..<29], "wonderful")
   assertEq(s[20..^1], "wonderful")
+  assertEq(s[20..^2], "wonderfu")
   assertEq(s[23..<29], "derful")
   assertEq(s[23..<28], "derfu")
   assertEq(s[24..<29], "erful")
@@ -67,8 +76,16 @@ proc test(load: bool) =
     "wonderful".toHex(),
   )
 
-  s.writeAll("hello")
-  assertEq(s.readAll(), "hello")
+  let expected = @[
+    "he11o".toHex(),
+    "0A" & "1000" & "2000",
+    "0000" & "4000" & "00",
+    "00" & "0000" & "0000",
+    "wonde".toHex(),
+    "rful".toHex(),
+  ]
+  for (c, e) in zip(s.chunks(0 .. ^1, 5).toSeq(), expected):
+    assertEq(c.toHex(), e)
 
 proc main =
   let s = newFileStream("one", fmWrite)

--- a/tests/unit/test_file_string_stream.nim
+++ b/tests/unit/test_file_string_stream.nim
@@ -1,0 +1,91 @@
+import std/[
+  os,
+  streams,
+  strutils,
+]
+import ../../src/utils/file_string_stream {.all.}
+
+template assertEq(a, b: untyped) =
+  doAssert a == b, "\"" & $a & "\" != \"" & $b & "\""
+
+proc test(load: bool) =
+  var s = newFileStringStream("one")
+  if load:
+    s.load()
+
+  assertEq(len(s), 25)
+  assertEq(
+    s.readAll().toHex(),
+    "hello".toHex() &
+    "08" &
+    "1000" &
+    "2000" & "0000" &
+    "4000" & "0000" & "0000" & "0000" &
+    "world".toHex(),
+  )
+  assertEq(s[0..<5], "hello")
+  assertEq(s[20..<25], "world")
+  assertEq(s[20..^1], "world")
+  assertEq(s[20..^2], "worl")
+  assertEq(readInt[uint8](s, 5), 8'u8)
+  assertEq(readInt[uint16](s, 6), 16'u16)
+  assertEq(readInt[uint32](s, 8), 32u32)
+  assertEq(readInt[uint64](s, 12), 64u64)
+
+  s[24] = 'D'
+  assertEq(s[20..^1], "worlD")
+
+  s[2] = '1'
+  s[3] = '1'
+  assertEq(s[0..<5], "he11o")
+
+  s[5] = '\n'
+  assertEq(readInt[uint8](s, 5), uint8('\n'))
+
+  s[22] = 'n'
+  assertEq(len(s), 25)
+  s[23] = "derful"
+  assertEq(len(s), 29)
+  assertEq(s[20..<26], "wonder")
+  assertEq(s[20..<29], "wonderful")
+  assertEq(s[20..^1], "wonderful")
+  assertEq(s[23..<29], "derful")
+  assertEq(s[23..<28], "derfu")
+  assertEq(s[24..<29], "erful")
+  assertEq(s[26..<29], "ful")
+  assertEq(s[25..<28], "rfu")
+
+  assertEq(s[0..<5], "he11o")
+
+  assertEq(
+    s.readAll().toHex(),
+    "he11o".toHex() &
+    "0A" &
+    "1000" &
+    "2000" & "0000" &
+    "4000" & "0000" & "0000" & "0000" &
+    "wonderful".toHex(),
+  )
+
+  s.writeAll("hello")
+  assertEq(s.readAll(), "hello")
+
+proc main =
+  let s = newFileStream("one", fmWrite)
+  s.write("hello")
+  s.write(8'u8)
+  s.write(16'u16)
+  s.write(32'u32)
+  s.write(64'u64)
+  s.write("world")
+  s.close()
+
+  echo(newFileStream("one").readAll().toHex())
+
+  try:
+    test(load = false)
+    test(load = true)
+  finally:
+    removeFile("one")
+
+main()


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

heartbeats/postexec is taking too much memory (>300Mb).

## Description

allow to read elfs only sections we actually need vs reading/parsing the whole file. This brights up regular elf parsing memory utilization to around 60M so for postexec/heartbeats its around 100M locally now

## Testing

```
V reset;
  echo > ~/.local/chalk/chalk.log;
  docker rm mem;
  docker run -it \
      --name mem \
      -v $PWD:$PWD \
      -w $PWD \
      -v (echo '
  exec.postexec.run = true
  exec.heartbeat = true
  ' | psub):/etc/chalk.c4m \
      -v $HOME/.local/chalk:/root/.local/chalk \
      -v ./chalk.json:/chalk.json \
      -v (echo '
  /etc/ssl/certs/ca-certificates.crt
  ' | psub):/tmp/prep_postexec.txt \
      --entrypoint=$PWD/chalk \
      alpine \
      --trace exec --chalk-as-parent -- \
      /bin/sh -c '
  tail /etc/ssl/certs/ca-certificates.crt
  sleep 20
  '
```

and then in another tab:

```
✗ while true; sleep 0.5;  docker container stats --no-stream --format '{{ .MemUsage }}' mem; end
```
