### PR TITLE
feat: add deflate64 support for ZIP archives

### DIFF
--- a/chalk.nimble
+++ b/chalk.nimble
@@ -16,7 +16,8 @@ bin           = @["chalk"]
 # Dependencies
 requires "nim >= 2.0.8"
 requires "https://github.com/crashappsec/con4m#abae0aaafc683d75cc04d00e720326e6c19790b1"
-requires "https://github.com/viega/zippy == 0.10.7" # MIT
+# TODO: move to viega's fork if/when merged
+requires "https://github.com/mbaltrusitis/zippy#687505f3114c7c237da9ec82d78efe4ac023a309" # MIT - stream API with deflate64 + extraction fix
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 
 # this allows us to get version externally


### PR DESCRIPTION
- Integrate stream-based zippy API with deflate64 capability
- Use hybrid approach: new API for reading (deflate64), v1 API for writing
- Update ZipCache to include ZipArchiveReader for deflate64 support
- Replace legacy ziparchives_v1 import with ziparchives
- Use extractAll(path, dest) for file extraction with deflate64 support
- Rebuild v1 cache from extracted files for writing operations
- Add proper resource cleanup with reader.close()

Resolves deflate64 'not supported' errors in chalk insert operations.

BREAKING CHANGE: Updates zippy dependency to custom fork with stream API

<!-- Please ensure you have done the following steps: -->

- [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ ] Filled out the template to a useful degree
- [ ] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

## Testing

<!-- What are the steps needed to test this PR? -->
