### PR TITLE
feat: docker.update_dockerignore

### DIFF
--- a/.github/update_dockerignore.sh
+++ b/.github/update_dockerignore.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+for file; do
+    if grep 'added by chalk' "$file"; then
+        # remove all lines after the match
+        sed '/added by chalk/,$d' -i "$file"
+        sed -z 's/\n*$/\n/' -i "$file"
+    fi
+done

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,13 @@ repos:
     hooks:
       - id: pre-commit-sync
 
-  # - repo: local
-  #   hooks:
+  - repo: local
+    hooks:
+      - id: dockerignore
+        name: dockerignore
+        language: system
+        entry: ./.github/update_dockerignore.sh
+        files: \.dockerignore$
   # - id: licenseheaders
   #   name: licenseheaders
   #   language: python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,11 @@
   By default no limit is set.
   ([#544](https://github.com/crashappsec/chalk/pull/544))
 
+- New configuration `docker.update_dockerignore` which allows chalk to
+  update `.dockerignore` to allow to copy files in `Dockerfile`.
+  This allows to wrap legacy builder builds which dont support `--build-context`.
+  ([#556](https://github.com/crashappsec/chalk/pull/556)
+
 ### Fixes
 
 - Docker pass-through commands (non build/push) commands were capturing all

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2002,6 +2002,19 @@ Whether to prepare postexec state which will be used during wrapped exec entrypo
 """
   }
 
+  field update_dockerignore {
+    type:    bool
+    default: true
+    doc: """
+When buildx is not available and therefore chalk cannot use additional contexts to
+copy files (e.g. chalkmark) in the `Dockerfile`. In that case chalk has no choice but
+to copy the file into the primary docker build context. There is however no guarantee
+that the file will actually be copied due to `.dockerignore`.
+In order to ensure the file is copied, this setting allows chalk to mutate the
+`.dockerignore` file by explicitly allowing to copy all `*.chalk` files.
+"""
+  }
+
 }
 
 singleton zip {

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -36,6 +36,11 @@ import "."/[
   wrap,
 ]
 
+const
+  HEADER     = "# {{{ added by chalk - https://crashoverride.com/docs/chalk"
+  PIN_HEADER = "# {{{ pinned to specific digest by chalk - https://crashoverride.com/docs/chalk"
+  FOOTER     = "# }}}"
+
 proc processGitContext(ctx: DockerInvocation) =
   try:
     if isGitContext(ctx.foundContext):
@@ -231,9 +236,9 @@ proc getUpdatedDockerFile(ctx: DockerInvocation): string =
     for _, base in ctx.addedPlatform:
       updated = updated.join("\n").strip().splitLines() & @[
         "",
-        "# {{{ added by chalk - https://crashoverride.com/docs/chalk",
+        HEADER,
         base.join("\n"),
-        "# }}}",
+        FOOTER,
         "",
       ]
   for s in ctx.dfSections:
@@ -243,10 +248,10 @@ proc getUpdatedDockerFile(ctx: DockerInvocation): string =
         original &= @["# " & l]
       updated = updated.join("\n").strip().splitLines() & @[
         "",
-        "# {{{ pinned to specific digest by chalk - https://crashoverride.com/docs/chalk",
+        PIN_HEADER,
         original.join("\n"),
         s.asFrom(),
-        "# }}}",
+        FOOTER,
         "",
         lines[s.fromInfo.endLine + 1 .. s.endLine].join("\n"),
       ]
@@ -255,9 +260,9 @@ proc getUpdatedDockerFile(ctx: DockerInvocation): string =
     if s == target and len(ctx.addedInstructions) > 0:
       updated = updated.join("\n").strip().splitLines() & @[
         "",
-        "# {{{ added by chalk - https://crashoverride.com/docs/chalk",
+        HEADER,
         ctx.addedInstructions.join("\n"),
-        "# }}}",
+        FOOTER,
         "",
       ]
   updated &= lines[last.endLine + 1 .. ^1]
@@ -285,6 +290,27 @@ proc setDockerFile(ctx: DockerInvocation) =
     trace("docker: new docker file:\n" & dockerFile)
     ctx.newCmdLine.add("-f")
     ctx.newCmdLine.add(path)
+
+proc dockerignoreAlreadyUpdated(path: string): bool =
+  withFileStream(path, mode = fmRead, strict = true):
+    for l in stream.lines():
+      if l == HEADER:
+        return true
+  return false
+
+proc updateDockerignoreFile(ctx: DockerInvocation) =
+  if not ctx.updateDockerignore:
+    return
+  let path = ctx.foundContext.resolvePath().joinPath(".dockerignore")
+  if path.dockerignoreAlreadyUpdated():
+    trace("docker: " & path & " is already updated to allow to copy chalk files")
+    return
+  withFileStream(path, mode = fmAppend, strict = true):
+    stream.writeLine("")
+    stream.writeLine(HEADER)
+    stream.writeLine("!*.chalk")
+    stream.writeLine(FOOTER)
+    stream.writeLine("")
 
 proc setIidFile(ctx: DockerInvocation) =
   if ctx.foundIidFile == "":
@@ -583,6 +609,10 @@ proc dockerBuild*(ctx: DockerInvocation): int =
   ctx.setDockerFile()
   ctx.setIidFile()
   ctx.setMetadataFile()
+  try:
+    ctx.updateDockerignoreFile()
+  except:
+    error("docker: could not update .dockerignore file: " & getCurrentExceptionMsg())
 
   result = setExitCode(ctx.runMungedDockerInvocation())
   if result != 0:

--- a/src/docker/wrap.nim
+++ b/src/docker/wrap.nim
@@ -62,6 +62,7 @@ proc makeFileAvailableToDocker(ctx:        DockerInvocation,
   let
     loc           = path.resolvePath()
     (dir, file)   = loc.splitPath()
+    (_, nfile) = newPath.splitPath()
     hasUser       = user != "" and user != "root" and user != "0"
 
   # if USER directive is present and --chmod is not requested
@@ -122,11 +123,6 @@ proc makeFileAvailableToDocker(ctx:        DockerInvocation,
       trace("docker: injection method: COPY")
 
     let contextDir = ctx.foundContext.resolvePath()
-    # using extension which is unlikely to be already ignored by .dockerignore
-    # by default temporary files use .tmp extension which might be ignored
-    # whereas chalk is a lot less likely
-    var dstLoc     = contextDir.joinPath(file & ".chalk")
-
     trace("docker: context directory is: " & contextDir)
     if not dirExists(contextDir):
       raise newException(
@@ -134,9 +130,14 @@ proc makeFileAvailableToDocker(ctx:        DockerInvocation,
         "Cannot find context directory (" & contextDir & ")"
       )
 
+    # using extension which is unlikely to be already ignored by .dockerignore
+    # by default temporary files use .tmp extension which might be ignored
+    # whereas chalk is a lot less likely
+    var dstLoc     = contextDir.joinPath(nfile & ".chalk")
+    while dirExists(dstLoc) or fileExists(dstLoc):
+      dstLoc &= ".chalk"
+
     try:
-      while dirExists(dstLoc) or fileExists(dstLoc):
-        dstLoc &= ".chalk"
       if move:
         moveFile(loc, dstLoc)
         trace("docker: moved " & loc & " to " & dstLoc)
@@ -172,6 +173,9 @@ proc makeFileAvailableToDocker(ctx:        DockerInvocation,
             toAdd.add("USER " & user)
         else:
           toAdd.add("COPY " & name & " " & newPath)
+
+      if contextDir.joinPath(".dockerignore").fileExists():
+        ctx.updateDockerignore = attrGet[bool]("docker.update_dockerignore")
 
     except:
       dumpExOnDebug()

--- a/src/types.nim
+++ b/src/types.nim
@@ -454,6 +454,7 @@ type
       inDockerFile*:          string
       addedPlatform*:         OrderedTableRef[string, seq[string]]
       addedInstructions*:     seq[string]
+      updateDockerignore*:    bool
 
       # parsed dockerfile
       dfSections*:            seq[DockerFileSection]

--- a/tests/functional/data/dockerfiles/valid/sample_1/.dockerignore
+++ b/tests/functional/data/dockerfiles/valid/sample_1/.dockerignore
@@ -1,0 +1,2 @@
+*
+!helloworld.sh


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

when `dockerignore` is restrictive (e.g. has `*`), legacy runner builds fail to be wrapped as copying chalkmark/chalk fails as the file is not copied into the context

## Description

this allows to wrap legacy builds with restrictive dockerignore files

## Testing

```
➜ maketest test_docker.py::test_build[cwd0-None-False-False-False-None] --logs
```
