### PR TITLE
fix: only set artifact accessed in postexec

### DIFF
--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -324,8 +324,8 @@ proc doPostExec(state: Option[PostExecState], detach: bool) =
         "out of known " & $len(ws.toWatchPaths) & " artifacts")
   withOnlyCodecs(getPluginsByName(codecs)):
     for chalk in runChalkSubScan(ws.toWatchPaths, "extract").allChalks:
-      chalk.accessed = chalk.fsRef in accessedPaths
-      if chalk.accessed:
+      chalk.accessed = some(chalk.fsRef in accessedPaths)
+      if chalk.accessed.get():
         trace(chalk.fsRef & ": chalkmark accessed")
       else:
         trace(chalk.fsRef & ": chalkmark not accessed")

--- a/src/types.nim
+++ b/src/types.nim
@@ -84,7 +84,7 @@ type
                                              ## something else, use the cache field
                                              ## below, instead.
     fsRef*:                 string           ## Reference for this artifact on a fs
-    accessed*:              bool             ## Whether artifact was accessed during chalk operation (used only in exec)
+    accessed*:              Option[bool]     ## Whether artifact was accessed during chalk operation (used only in exec)
     envVarName*:            string           ## env var name from where artifact is found
     platform*:              DockerPlatform   ## platform
     baseChalk*:             ChalkObj


### PR DESCRIPTION
small nit PR

otherwise `_OP_ARTIFACT_ACCESSED` is being always sent as `false` for all other reports
