### PR TITLE
feat: switch to json logs when non-interactive and no color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   - `exec.heartbeat.rlimit`
   - `exec.heartbeat.nice`
 
-  ([#552](https://github.com/crashappsec/chalk/pull/552)
+  ([#552](https://github.com/crashappsec/chalk/pull/552))
 
 ### New Features
 
@@ -147,6 +147,14 @@
 - Chalk can set rlimit for heartbeats process.
   By default no limit is set.
   ([#544](https://github.com/crashappsec/chalk/pull/544))
+- Chalk will output its logs in `json` format for non-interactive sessions.
+  Each log will include:
+  - `chalk_version` - Chalks version number
+  - `chalk_commit` - Chalks commit ID
+  - `chalk_magic` - Chalks magic strict to allow to detect chalk logs
+  - `timestamp` - ISO8601 time of the log message
+  - `msg` - Log message
+    ([#561](https://github.com/crashappsec/chalk/pull/561))
 
 ### Fixes
 
@@ -187,7 +195,7 @@
 
 - Better error handling when receiving different in-toto attestation
   for docker images.
-  ([#552](https://github.com/crashappsec/chalk/pull/552)
+  ([#552](https://github.com/crashappsec/chalk/pull/552))
 
 ## 0.5.9
 

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -15,7 +15,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#abae0aaafc683d75cc04d00e720326e6c19790b1"
+requires "https://github.com/crashappsec/con4m#ac16c5861b410af56728452f68ca7212fc216739"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

in deployed environments, chalk logs are not easily searchable or ignorable as they are not structured logs

## Description

switch to json structured logging for non-interactive shell sessions

## Testing

```
➜ docker run --rm -v ./chalk:/chalk alpine /chalk version
```

will show json logs
