### PR TITLE
feat: BUILD_UNIQUE_ID for github runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,11 @@
   - `chalk_magic` - Chalks magic strict to allow to detect chalk logs
   - `timestamp` - ISO8601 time of the log message
   - `msg` - Log message
-    ([#561](https://github.com/crashappsec/chalk/pull/561))
+
+  ([#561](https://github.com/crashappsec/chalk/pull/561))
+
+- `BUILD_UNIQUE_ID` to uniquely identify jobs in GitHub.
+  ([#562](https://github.com/crashappsec/chalk/pull/562))
 
 ### Fixes
 

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -561,7 +561,6 @@ keyspec CONTAINING_ARTIFACT_WHEN_CHALKED {
     codec:            true
     since:            "0.1.0"
     doc:              """
-
 For items chalked when they were in a embedded into a ZIP file, this is the
 `CHALK_ID` of the containing artifact.
 """
@@ -1287,9 +1286,25 @@ keyspec BUILD_ID {
     since:            "0.1.0"
     shortdoc: "CI/CD job info when adding chalk mark"
     doc:              """
-
-If, at the time of chalking, the system can field will contain the
+If, at the time of chalking, the system field will contain the
 associated job ID.
+"""
+}
+
+keyspec BUILD_UNIQUE_ID {
+    kind:             ChalkTimeHost
+    type:             string
+    standard:         true
+    since:            "0.6.0"
+    shortdoc:         "For some CI systems, chalk generated unique build id"
+    doc:              """
+Chalk-generated unique build ID.
+
+In some CI systems `BUILD_ID` is sometimes reused. For example in GitHub Actions,
+`BUILD_ID` is populated from workflow ID which is the same for all jobs within
+the same workflow as well as it is reused for all job retries.
+In that case chalk will generate its own unique build ID to allow to associate
+multiple chalk operations within the same build.
 """
 }
 

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -133,7 +133,7 @@ artifacts will be attached to that info.
 
 plugin ci_github {
     enabled:         true
-    pre_run_keys:    ["BUILD_ID", "BUILD_COMMIT_ID",
+    pre_run_keys:    ["BUILD_ID", "BUILD_UNIQUE_ID", "BUILD_COMMIT_ID",
                       "BUILD_URI", "BUILD_API_URI",
                       "BUILD_TRIGGER", "BUILD_CONTACT",
                       "BUILD_ORIGIN_ID", "BUILD_ORIGIN_OWNER_ID",

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -97,6 +97,7 @@ report and subtract from it.
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
+  key.BUILD_UNIQUE_ID.use                     = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -723,6 +724,7 @@ doc: """
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
+  key.BUILD_UNIQUE_ID.use                     = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -1232,6 +1234,7 @@ container.
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
+  key.BUILD_UNIQUE_ID.use                     = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -1726,6 +1729,7 @@ and keep the run-time key.
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
+  key.BUILD_UNIQUE_ID.use                     = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -208,6 +208,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.VCS_DIR_WHEN_CHALKED.use                = true
   ~key.VCS_MISSING_FILES.use                   = true
   ~key.BUILD_ID.use                            = true
+  ~key.BUILD_UNIQUE_ID.use                     = true
   ~key.BUILD_COMMIT_ID.use                     = true
   ~key.BUILD_URI.use                           = true
   ~key.BUILD_API_URI.use                       = true


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

as we send `chalk env` at the end of the workflow, its not easy to associate it with earlier builds in the same workflow

## Description

adds `BUILD_UNIQUE_ID` which is chalk generated to allow to associate multiple chalk operations within the same CI job (currently only github)

## Testing

```
➜ maketest test_plugins.py::test_github
```
