### PR TITLE
fix: dont inotify system folders like /proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,8 @@
   ([#539](https://github.com/crashappsec/chalk/pull/539))
 - `_OP_ARTIFACT_MOUNTED` key which indicates whether the artifact
   file is externally mounted (e.g. docker volume).
-  ([#559](https://github.com/crashappsec/chalk/pull/559))
+  ([#559](https://github.com/crashappsec/chalk/pull/559),
+  [#563](https://github.com/crashappsec/chalk/pull/563))
 - `_OP_ARTIFACT_PATH_WITHIN_VCTL` key which indicates path of the file
   in the git repo.
   ([#515](https://github.com/crashappsec/chalk/pull/515))

--- a/src/utils/files.nim
+++ b/src/utils/files.nim
@@ -22,6 +22,7 @@ import ".."/[
 import "."/[
   fd_cache,
   file_string_stream,
+  strings,
   times, # TODO remove
 ]
 
@@ -168,7 +169,7 @@ when defined(linux):
         if len(parts) <= 2:
           continue
         let path = parts[1]
-        if path.fileExists():
+        if not path.startsWithAnyOf(systemIgnoreStartsWithPaths) and path.fileExists():
           yield path
 
 else:

--- a/src/utils/strings.nim
+++ b/src/utils/strings.nim
@@ -78,3 +78,9 @@ proc elseWhenEmpty*(s: string, default: string): string =
   if s == "":
     return default
   return s
+
+proc startsWithAnyOf*(s: string, suffixes: openArray[string]): bool =
+  for i in suffixes:
+    if s.startsWith(i):
+      return true
+  return false

--- a/tests/functional/data/configs/docker_postexec.c4m
+++ b/tests/functional/data/configs/docker_postexec.c4m
@@ -1,3 +1,4 @@
+log_level                                     = "trace"
 docker.wrap_entrypoint                        = true
 docker.scan_context.run                       = true
 docker.prep_postexec                          = true


### PR DESCRIPTION
k8s seems to be mounting some files in /proc so we just ignore them

the system folders are grabbed from nimutils

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

chalk has errors like:

```
error: inotify: could not watch /proc/sysrq-trigger
```

## Description

ignore system folders from using inotify

## Testing

test with k8s container
