### PR TITLE
fix: handle SIGTTOU and SIGTTIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,16 @@
 - Better error handling when receiving different in-toto attestation
   for docker images.
   ([#552](https://github.com/crashappsec/chalk/pull/552))
+- Handle `SIGTTOU`, `SIGTTIN` signals. In some cases, during chalk
+  exit machinery, when chalk restores full terminal state (as chalk itself
+  can emit terminal control characters such as for colorful logs),
+  it uses `tcsetattr` which then sends control sequence to the TTY
+  via `ioctl` which ends up blocking the operation if the `SIGTTOU`
+  signal is not handled. This normally does not happen as the `SIGTTOU`
+  is not sent to chalk however there are cases when it does such as
+  when chalk is wrapped with a `timeout` utility. Either way handling
+  the signals allows the reset sequence to not-block and exit chalk normally.
+  ([#567](https://github.com/crashappsec/chalk/pull/567))
 
 ## 0.5.9
 

--- a/src/utils/terminal.nim
+++ b/src/utils/terminal.nim
@@ -73,11 +73,17 @@ proc setupTerminal*() =
   addExitProc(restoreTerminal)
 
 proc setupSignalHandlers*() =
-  var handler: Sigaction
-
-  handler.sa_handler = regularTerminationSignal
-  handler.sa_flags   = 0
+  var
+    handler = Sigaction(
+      sa_handler: regularTerminationSignal,
+      sa_flags:   0,
+    )
+    ignore = Sigaction(
+      sa_handler: SIG_IGN,
+    )
 
   for signal in [SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGABRT, SIGBUS, SIGKILL,
                  SIGSEGV, SIGTERM]:
     discard sigaction(signal, handler, nil)
+  for signal in [SIGTTOU, SIGTTIN]:
+    discard sigaction(signal, ignore, nil)


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

running `./setup.sh` would hang on `chalk version` when running in an interactive shell

## Description

otherwise there are cases when chalk hangs on exit when chalk receices SIGTTOU while resetting terminal state

## Testing

in interactive shell

```
➜ sh ./setup.sh --token=$CHALK_TOKEN   --saas   --chalk-path=./chalk   --no-wrap  --timeout=30 --copy-from=../chalk/chalk --debug
```
