### PR TITLE
fix: handle confspec errors during chalk load

### DIFF
--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -40,6 +40,11 @@ proc getExeVersion(args: seq[Box], unused: ConfigState): Option[Box] =
   return some(pack(getChalkExeVersion()))
 
 proc logBase(ll: string, args: seq[Box], s: ConfigState): Option[Box] =
+  # silence all logs during test run
+  # also prevent adjusting log level during config validationg
+  if doingTestRun:
+    return none(Box)
+
   let
     msg      = unpack[string](args[0])
     color    = s.attrLookup("color")

--- a/src/plugins/conffile.nim
+++ b/src/plugins/conffile.nim
@@ -26,7 +26,7 @@ proc scanForWork(kt: auto, opt: Option[ChalkObj], args: seq[Box]): ChalkDict =
     try:
       # during configuration testing, some keys are registered
       # which are not fully initialized so just skip here
-      # if the kind id missing.
+      # if the "kind" id missing.
       # otherwise this should never happen as the config is validated
       # while loading
       if attrGet[int](v & ".kind") != int(kt):

--- a/src/plugins/conffile.nim
+++ b/src/plugins/conffile.nim
@@ -19,14 +19,26 @@ proc scanForWork(kt: auto, opt: Option[ChalkObj], args: seq[Box]): ChalkDict =
   result = ChalkDict()
   for k in getChalkSubsections("keyspec"):
     let v = "keyspec." & k
-    if opt.isNone() and k in hostInfo:                continue
-    if opt.isSome() and k in opt.get().collectedData: continue
-    if attrGet[int](v & ".kind") != int(kt): continue
-    if not isSubscribedKey(k):
+    if opt.isNone() and k in hostInfo:
+      continue
+    if opt.isSome() and k in opt.get().collectedData:
       continue
     try:
-      let valueOpt = attrGetOpt[Box](v & ".value")
-      let callbackOpt = attrGetOpt[CallbackObj](v & ".callback")
+      # during configuration testing, some keys are registered
+      # which are not fully initialized so just skip here
+      # if the kind id missing.
+      # otherwise this should never happen as the config is validated
+      # while loading
+      if attrGet[int](v & ".kind") != int(kt):
+        continue
+      if not isSubscribedKey(k):
+        continue
+    except:
+      continue
+    try:
+      let
+        valueOpt    = attrGetOpt[Box](v & ".value")
+        callbackOpt = attrGetOpt[CallbackObj](v & ".callback")
       if valueOpt.isSome():
         result.setIfNeeded(k, valueOpt.get())
       elif callbackOpt.isSome():

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -29,9 +29,12 @@ var ctxStack = @[CollectionCtx()]
 # This is for when we're doing a `conf load`.  We force silence, turning off
 # all logging of merit.
 proc startTestRun*() =
-  doingTestRun = true
+  doingTestRun  = true
+  savedLogLevel = getLogLevel()
 proc endTestRun*()   =
   doingTestRun = false
+  # the stack above might be adjusting global log level so restore it
+  setLogLevel(savedLogLevel)
 
 template withOnlyCodecs*(codecs: seq[Plugin], c: untyped) =
   if len(codecs) > 0:

--- a/src/selfextract.nim
+++ b/src/selfextract.nim
@@ -264,22 +264,23 @@ proc testConfigFile(newCon4m: string,
                addConfLoad(coConfName,        toStream(coConfig))
 
   try:
+    startTestRun()
     # Test Run will cause (un)subscribe() to ignore subscriptions, and
     # will suppress log messages, etc.
     stack.run()
     stack.configState.loadCachedComponents(cache)
     stack.configState.loadComponentParams(params)
-    startTestRun()
     stack.addConfLoad(uri, toStream(newCon4m))
     stack.run()
     if stack.errored:
       quit(1)
-    info(uri & ": Configuration successfully validated.")
+    endTestRun()
   except:
+    endTestRun()
     dumpExOnDebug()
     cantLoad(getCurrentExceptionMsg() & "\n")
-  finally:
-    endTestRun()
+
+  info(uri & ": Configuration successfully validated.")
 
 proc toBox(param: ParameterInfo, component: ComponentInfo): Box =
   # Though you can pack / unpack con4m types, we don't have a JSON

--- a/src/types.nim
+++ b/src/types.nim
@@ -550,6 +550,7 @@ var
   systemErrors*           = seq[string](@[])
   selfChalk*              = ChalkObj(nil)
   canSelfInject*          = true
+  savedLogLevel*          = llError
   doingTestRun*           = false
   onlyCodecs*             = newSeq[Plugin]()
   inInternalScan*         = false


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] ~~Updated `CHANGELOG.md` if necessary~~

## Issue

during chalk load which is registering additional keys would see:

```
error: When collecting chalk-time host info, plugin implementation conffile threw an exception it didn't handle: get() of an attribute that isn't set.
error: When collecting chalk-time artifact data, plugin implementation conffile threw an exception it didn't handle (artifact = /home/root/Code/co/setup-chalk-action/chalk): get() of an attribute that isn't set.
error: When collecting run-time host info, plugin implementation conffile threw an exception it didn't handle: get() of an attribute that isn't set.
```

## Description

while testing the configuration some keys are partially registered which shows non-errors as error logs while calculating the report while doing the command report

## Testing


for the log updates:

```
➜ ./chalk load configs/debug.c4m
```
