### PR TITLE
 feat(dust): add Lambda layer deployment automation

### DIFF
--- a/dust-lambda-extension/.editorconfig
+++ b/dust-lambda-extension/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+# shfmt config
+# not all bash scripts in the repo are .sh
+# so this is in * extension block
+shell_variant      = bash  # like -ln=posix
+binary_next_line   = true  # like -bn
+switch_case_indent = true  # like -ci
+space_redirects    = true  # like -sr
+function_next_line = false # like -fn
+keep_padding       = false # like -kp
+never_split        = false # like -ns
+
+[*.sh,dust]
+indent_style = space
+indent_size = 4

--- a/dust-lambda-extension/Makefile
+++ b/dust-lambda-extension/Makefile
@@ -111,6 +111,62 @@ deploy-layer-dry-run: package-layer ## Perform a dry-run of layer deployment (no
 test: ## test dust script against fake lambda runtime
 	./extensions/dust
 
+delete-layer: ## Delete Lambda layer versions from AWS regions
+	@# Check if AWS_REGIONS is set
+	@if [ -z "$(AWS_REGIONS)" ]; then \
+		echo ""; \
+		echo "Error: AWS_REGIONS is required"; \
+		echo ""; \
+		echo "Usage:"; \
+		echo "  make delete-layer AWS_REGIONS=\"us-east-1\""; \
+		echo "  make delete-layer AWS_REGIONS=\"us-east-1,us-west-2\""; \
+		echo ""; \
+		echo "Options:"; \
+		echo "  AWS_ACCOUNT_ID=123456789012    # AWS Account ID (auto-detected if not set)"; \
+		echo "  LAYER_VERSION=5                # Delete specific version"; \
+		echo "  DELETE_ALL=true                # Delete all versions"; \
+		echo "  DRY_RUN=true                   # Preview deletions without executing"; \
+		echo ""; \
+		echo "Example:"; \
+		echo "  make delete-layer AWS_REGIONS=\"us-east-1\" DELETE_ALL=true"; \
+		echo "  make delete-layer AWS_ACCOUNT_ID=123456789012 AWS_REGIONS=\"us-east-1\" LAYER_VERSION=5"; \
+		echo ""; \
+		exit 1; \
+	fi
+	@# Check if AWS_ACCOUNT_ID is set
+	@if [ -z "$(AWS_ACCOUNT_ID)" ]; then \
+		echo ""; \
+		echo "Error: Unable to determine AWS Account ID"; \
+		echo ""; \
+		echo "Please ensure you are authenticated with AWS CLI or provide AWS_ACCOUNT_ID:"; \
+		echo "  make delete-layer AWS_ACCOUNT_ID=123456789012 AWS_REGIONS=\"us-east-1\" DELETE_ALL=true"; \
+		echo ""; \
+		exit 1; \
+	fi
+	@# Determine version flag
+	@if [ -n "$(LAYER_VERSION)" ]; then \
+		VERSION_FLAG="-V $(LAYER_VERSION)"; \
+	elif [ "$(DELETE_ALL)" = "true" ]; then \
+		VERSION_FLAG="-A"; \
+	else \
+		echo "Error: Must specify either LAYER_VERSION or DELETE_ALL=true"; \
+		exit 1; \
+	fi
+	@# Run delete script
+	@sh $(CURDIR)/scripts/delete-layer.sh \
+		-a "$(AWS_ACCOUNT_ID)" \
+		-n "$(LAYER_NAME)" \
+		-R "$(AWS_REGIONS)" \
+		$$VERSION_FLAG \
+		$(if $(filter true,$(DRY_RUN)),-d) \
+		$(if $(filter true,$(SKIP_CONFIRMATION)),-y) \
+		$(if $(filter true,$(VERBOSE)),-v)
+.PHONY: delete-layer
+
+delete-layer-dry-run: ## Preview layer deletions without executing (dry-run)
+	@$(MAKE) delete-layer DRY_RUN=true DELETE_ALL=true
+.PHONY: delete-layer-dry-run
+
 #> UTILITIES
 
 clean: ## delete Lambda layer zip archives

--- a/dust-lambda-extension/Makefile
+++ b/dust-lambda-extension/Makefile
@@ -14,7 +14,7 @@ IS_DIRTY := $(shell git diff-index --quiet HEAD -- 2>/dev/null || echo "dirty")
 # Determine Dust extension version
 DUST_TAG := $(shell git describe --exact-match --match "dust-*" --tags HEAD 2>/dev/null)
 ifneq ($(DUST_TAG),)
-  # Extract version from tag (dust-v1.0.0 -> 1.0.0)
+  # Extract version from tag (dust-1.0.0 -> 1.0.0)
   DUST_VERSION := $(patsubst dust-%,%,$(DUST_TAG))
 else
   # Use dev version with short hash
@@ -65,7 +65,7 @@ package-layer: $(ARCHIVE_NAME) ## create a zip archive for AWS Lambda Layer depl
 $(ARCHIVE_NAME): $(SOURCES)
 	@echo "Creating Lambda Layer package: $@"
 	@mkdir -p ./_build
-	@zip -r $@ extensions/
+	@zip -qr $@ extensions/
 	@echo "Lambda Layer package created: $@"
 
 deploy-layer: package-layer ## Deploy Lambda layer to all AWS regions with public access
@@ -131,35 +131,35 @@ test: ## test dust script against fake lambda runtime
 	./extensions/dust
 
 delete-layer: ## Delete Lambda layer versions from AWS regions
-	@# Check if AWS_REGIONS is set
+	# Check if AWS_REGIONS is set
 	@if [ -z "$(AWS_REGIONS)" ]; then \
-		echo ""; \
-		echo "Error: AWS_REGIONS is required"; \
-		echo ""; \
-		echo "Usage:"; \
-		echo "  make delete-layer AWS_REGIONS=\"us-east-1\""; \
-		echo "  make delete-layer AWS_REGIONS=\"us-east-1,us-west-2\""; \
-		echo ""; \
-		echo "Options:"; \
-		echo "  AWS_ACCOUNT_ID=123456789012    # AWS Account ID (auto-detected if not set)"; \
-		echo "  LAYER_VERSION=5                # Delete specific version"; \
-		echo "  DELETE_ALL=true                # Delete all versions"; \
-		echo "  DRY_RUN=true                   # Preview deletions without executing"; \
-		echo ""; \
-		echo "Example:"; \
-		echo "  make delete-layer AWS_REGIONS=\"us-east-1\" DELETE_ALL=true"; \
-		echo "  make delete-layer AWS_ACCOUNT_ID=123456789012 AWS_REGIONS=\"us-east-1\" LAYER_VERSION=5"; \
-		echo ""; \
+		@echo ""; \
+		@echo "Error: AWS_REGIONS is required"; \
+		@echo ""; \
+		@echo "Usage:"; \
+		@echo "  make delete-layer AWS_REGIONS=\"us-east-1\""; \
+		@echo "  make delete-layer AWS_REGIONS=\"us-east-1,us-west-2\""; \
+		@echo ""; \
+		@echo "Options:"; \
+		@echo "  AWS_ACCOUNT_ID=123456789012    # AWS Account ID (auto-detected if not set)"; \
+		@echo "  LAYER_VERSION=5                # Delete specific version"; \
+		@echo "  DELETE_ALL=true                # Delete all versions"; \
+		@echo "  DRY_RUN=true                   # Preview deletions without executing"; \
+		@echo ""; \
+		@echo "Example:"; \
+		@echo "  make delete-layer AWS_REGIONS=\"us-east-1\" DELETE_ALL=true"; \
+		@echo "  make delete-layer AWS_ACCOUNT_ID=123456789012 AWS_REGIONS=\"us-east-1\" LAYER_VERSION=5"; \
+		@echo ""; \
 		exit 1; \
 	fi
-	@# Check if AWS_ACCOUNT_ID is set
+	# Check if AWS_ACCOUNT_ID is set
 	@if [ -z "$(AWS_ACCOUNT_ID)" ]; then \
-		echo ""; \
-		echo "Error: Unable to determine AWS Account ID"; \
-		echo ""; \
-		echo "Please ensure you are authenticated with AWS CLI or provide AWS_ACCOUNT_ID:"; \
-		echo "  make delete-layer AWS_ACCOUNT_ID=123456789012 AWS_REGIONS=\"us-east-1\" DELETE_ALL=true"; \
-		echo ""; \
+		@echo ""; \
+		@echo "Error: Unable to determine AWS Account ID"; \
+		@echo ""; \
+		@echo "Please ensure you are authenticated with AWS CLI or provide AWS_ACCOUNT_ID:"; \
+		@echo "  make delete-layer AWS_ACCOUNT_ID=123456789012 AWS_REGIONS=\"us-east-1\" DELETE_ALL=true"; \
+		@echo ""; \
 		exit 1; \
 	fi
 	@# Determine version flag
@@ -168,7 +168,7 @@ delete-layer: ## Delete Lambda layer versions from AWS regions
 	elif [ "$(DELETE_ALL)" = "true" ]; then \
 		VERSION_FLAG="-A"; \
 	else \
-		echo "Error: Must specify either LAYER_VERSION or DELETE_ALL=true"; \
+		@echo "Error: Must specify either LAYER_VERSION or DELETE_ALL=true"; \
 		exit 1; \
 	fi
 	@# Run delete script

--- a/dust-lambda-extension/Makefile
+++ b/dust-lambda-extension/Makefile
@@ -10,6 +10,25 @@ MAKEFLAGS += --warn-undefined-variables
 SHORT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 TAG := $(shell git describe --exact-match HEAD 2>/dev/null)
 IS_DIRTY := $(shell git diff-index --quiet HEAD -- 2>/dev/null || echo "dirty")
+
+# Determine Dust extension version
+DUST_TAG := $(shell git describe --exact-match --match "dust-*" --tags HEAD 2>/dev/null)
+ifneq ($(DUST_TAG),)
+  # Extract version from tag (dust-v1.0.0 -> 1.0.0)
+  DUST_VERSION := $(patsubst dust-%,%,$(DUST_TAG))
+else
+  # Use dev version with short hash
+  DUST_VERSION := dust-dev-$(SHORT_HASH)
+endif
+
+# Add dirty suffix if working tree is dirty
+ifeq ($(IS_DIRTY),dirty)
+  ifneq ($(findstring dust-dev,$(DUST_VERSION)),)
+    DUST_VERSION := $(DUST_VERSION)-dirty
+  else
+    DUST_VERSION := $(DUST_VERSION)-dirty
+  endif
+endif
 SOURCES := $(wildcard extensions/*)
 BUILD_PREFIX ?= "."
 BUILD_DIR ?= $(BUILD_PREFIX)/_build
@@ -168,6 +187,10 @@ delete-layer-dry-run: ## Preview layer deletions without executing (dry-run)
 .PHONY: delete-layer-dry-run
 
 #> UTILITIES
+
+version: ## show the Dust extension version
+	@echo $(DUST_VERSION)
+.PHONY: version
 
 clean: ## delete Lambda layer zip archives
 	rm -rf $(BUILD_DIR)

--- a/dust-lambda-extension/Makefile
+++ b/dust-lambda-extension/Makefile
@@ -186,6 +186,14 @@ delete-layer-dry-run: ## Preview layer deletions without executing (dry-run)
 	@$(MAKE) delete-layer DRY_RUN=true DELETE_ALL=true
 .PHONY: delete-layer-dry-run
 
+list-extension-arns: ## List all published Lambda extension ARNs in tab-delimited format
+	@sh $(CURDIR)/scripts/list-extension-arns.sh \
+		$(if $(AWS_ACCOUNT_ID),-a "$(AWS_ACCOUNT_ID)") \
+		$(if $(LAYER_NAME),-n "$(LAYER_NAME)") \
+		$(if $(AWS_REGIONS),-R "$(AWS_REGIONS)") \
+		$(if $(REGION_FILTER),-r "$(REGION_FILTER)")
+.PHONY: list-extension-arns
+
 #> UTILITIES
 
 version: ## show the Dust extension version

--- a/dust-lambda-extension/Makefile
+++ b/dust-lambda-extension/Makefile
@@ -18,6 +18,17 @@ TASK_PATH?=..
 export AWS_LAMBDA_RUNTIME_API
 export TASK_PATH
 
+# AWS deployment configuration
+AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --query Account --output text 2>/dev/null)
+LAYER_NAME ?= crashoverride-dust-extension
+REGION_FILTER ?= all
+BATCH_SIZE ?= 5
+LAYER_VERSION ?=
+DELETE_ALL ?=
+SKIP_CONFIRMATION ?=
+VERBOSE ?=
+DRY_RUN ?=
+
 # Determine archive name based on git status
 ifeq ($(TAG),)
   ifeq ($(IS_DIRTY),dirty)
@@ -34,12 +45,68 @@ package-layer: $(ARCHIVE_NAME) ## create a zip archive for AWS Lambda Layer depl
 
 $(ARCHIVE_NAME): $(SOURCES)
 	@echo "Creating Lambda Layer package: $@"
-	mkdir -p ./_build
-	zip -r $@ extensions/
+	@mkdir -p ./_build
+	@zip -r $@ extensions/
 	@echo "Lambda Layer package created: $@"
 
-deploy-layer: ## TODO
-	@echo "Deploying..."
+deploy-layer: package-layer ## Deploy Lambda layer to all AWS regions with public access
+	@# Check if repository is dirty
+	@if [ "$(IS_DIRTY)" = "dirty" ]; then \
+		@echo "Error: Git repository has uncommitted changes."; \
+		@echo "Please commit or stash your changes before deploying."; \
+		exit 1; \
+	fi
+	@# Check if AWS_ACCOUNT_ID is set
+	@if [ -z "$(AWS_ACCOUNT_ID)" ]; then \
+		echo "Error: AWS_ACCOUNT_ID is not set."; \
+		echo "Please set it as an environment variable or pass it as a make argument:"; \
+		echo "  make deploy-layer AWS_ACCOUNT_ID=123456789012"; \
+		exit 1; \
+	fi
+	@# Deploy the layer
+	@echo "Deploying layer to AWS regions..."
+	@echo "  AWS Account ID: $(AWS_ACCOUNT_ID)"
+	@echo "  Layer Name: $(LAYER_NAME)"
+	@echo "  Region Filter: $(REGION_FILTER)"
+	@echo "  Archive: $(ARCHIVE_NAME)"
+	@echo ""
+	@sh $(CURDIR)/scripts/deploy-layer.sh \
+		-a "$(AWS_ACCOUNT_ID)" \
+		-n "$(LAYER_NAME)" \
+		-r "$(REGION_FILTER)" \
+		-b "$(BATCH_SIZE)" \
+		"$(ARCHIVE_NAME)"
+.PHONY: deploy-layer
+
+deploy-layer-dry-run: package-layer ## Perform a dry-run of layer deployment (no actual changes)
+	@# Check if repository is dirty
+	@if [ "$(IS_DIRTY)" = "dirty" ]; then \
+		echo "Warning: Git repository has uncommitted changes."; \
+		echo "In a real deployment, this would fail."; \
+		echo ""; \
+	fi
+	@# Check if AWS_ACCOUNT_ID is set
+	@if [ -z "$(AWS_ACCOUNT_ID)" ]; then \
+		echo "Error: AWS_ACCOUNT_ID is not set."; \
+		echo "Please set it as an environment variable or pass it as a make argument:"; \
+		echo "  make deploy-layer-dry-run AWS_ACCOUNT_ID=123456789012"; \
+		exit 1; \
+	fi
+	@# Perform dry-run deployment
+	@echo "DRY-RUN: Simulating layer deployment to AWS regions..."
+	@echo "  AWS Account ID: $(AWS_ACCOUNT_ID)"
+	@echo "  Layer Name: $(LAYER_NAME)"
+	@echo "  Region Filter: $(REGION_FILTER)"
+	@echo "  Archive: $(ARCHIVE_NAME)"
+	@echo ""
+	@sh $(CURDIR)/scripts/deploy-layer.sh \
+		-a "$(AWS_ACCOUNT_ID)" \
+		-n "$(LAYER_NAME)" \
+		-r "$(REGION_FILTER)" \
+		-b "$(BATCH_SIZE)" \
+		-d \
+		"$(ARCHIVE_NAME)"
+.PHONY: deploy-layer-dry-run
 
 test: ## test dust script against fake lambda runtime
 	./extensions/dust

--- a/dust-lambda-extension/scripts/aws-regions.sh
+++ b/dust-lambda-extension/scripts/aws-regions.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env sh
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of the Chalk project
+## (see https://crashoverride.com/docs/chalk)
+##
+## aws-regions.sh - Get list of AWS regions for Lambda deployment
+
+set -eu
+
+# Source common utilities
+SCRIPT_DIR=$(dirname "$0")
+. "${SCRIPT_DIR}/lib/common.sh"
+
+# Default list of AWS regions (as of January 2025)
+# This is used as fallback if AWS CLI query fails
+readonly DEFAULT_REGIONS="us-east-1 us-east-2 us-west-1 us-west-2
+ca-central-1 ca-west-1
+eu-west-1 eu-west-2 eu-west-3 eu-central-1 eu-north-1 eu-south-1 eu-south-2 eu-central-2
+ap-south-1 ap-south-2 ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-southeast-1 ap-southeast-2 ap-southeast-3 ap-southeast-4 ap-east-1
+me-south-1 me-central-1
+sa-east-1
+af-south-1
+il-central-1"
+
+# Get regions that support Lambda
+get_lambda_regions() {
+  # Try to get regions dynamically from AWS
+  if command_exists aws && aws sts get-caller-identity >/dev/null 2>&1; then
+    # Get all regions
+    all_regions=$(aws ec2 describe-regions --all-regions --query 'Regions[?OptInStatus==`opted-in` || OptInStatus==`opt-in-not-required`].RegionName' --output text 2>/dev/null)
+
+    if [ -n "$all_regions" ]; then
+      # Filter for regions that support Lambda
+      lambda_regions=""
+      for region in $all_regions; do
+        # Check if Lambda service is available in this region
+        if aws lambda list-functions --region "$region" --max-items 1 >/dev/null 2>&1; then
+          if [ -z "$lambda_regions" ]; then
+            lambda_regions="$region"
+          else
+            lambda_regions="$lambda_regions $region"
+          fi
+        fi
+      done
+
+      if [ -n "$lambda_regions" ]; then
+        printf "%s" "$lambda_regions"
+        return 0
+      fi
+    fi
+  fi
+
+  # Fallback to default list
+  log_warning "Unable to query AWS for regions, using default list"
+  printf "%s" "$DEFAULT_REGIONS" | tr '\n' ' '
+}
+
+# Get regions for deployment (with optional filtering)
+get_deployment_regions() {
+  filter="${1:-all}"
+
+  regions=$(get_lambda_regions)
+
+  case "$filter" in
+    all)
+      printf "%s\n" "$regions"
+      ;;
+    us)
+      printf "%s\n" "$regions" | tr ' ' '\n' | grep '^us-' | tr '\n' ' '
+      ;;
+    eu)
+      printf "%s\n" "$regions" | tr ' ' '\n' | grep '^eu-' | tr '\n' ' '
+      ;;
+    ap)
+      printf "%s\n" "$regions" | tr ' ' '\n' | grep '^ap-' | tr '\n' ' '
+      ;;
+    primary)
+      # Primary regions only (one per geographic area)
+      printf "us-east-1 eu-west-1 ap-northeast-1 ap-south-1\n"
+      ;;
+    *)
+      log_error "Unknown filter: $filter"
+      return 1
+      ;;
+  esac
+}
+
+# Validate a region name
+validate_region() {
+  region="$1"
+
+  if [ -z "$region" ]; then
+    log_error "Region name is empty"
+    return 1
+  fi
+
+  # Check if region follows AWS naming pattern
+  if ! printf "%s" "$region" | grep -E '^[a-z]{2}-[a-z]+-[0-9]+$' >/dev/null 2>&1; then
+    log_error "Invalid region format: $region"
+    return 1
+  fi
+
+  return 0
+}
+
+# Count regions
+count_regions() {
+  regions="$1"
+  printf "%s" "$regions" | tr ' ' '\n' | grep -c -v '^$'
+}
+
+# Main execution
+main() {
+  filter="${1:-all}"
+
+  regions=$(get_deployment_regions "$filter")
+
+  if [ -z "$regions" ]; then
+    log_error "No regions found"
+    exit 1
+  fi
+
+  # Output regions
+  printf "%s\n" "$regions"
+
+  # Show count if verbose
+  if [ "$VERBOSE" = "true" ]; then
+    count=$(count_regions "$regions")
+    log_info "Found $count regions"
+  fi
+}
+
+# Run main if executed directly (not sourced)
+if [ "${0##*/}" = "aws-regions.sh" ]; then
+  main "$@"
+fi

--- a/dust-lambda-extension/scripts/delete-layer.sh
+++ b/dust-lambda-extension/scripts/delete-layer.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env sh
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of the Chalk project
+## (see https://crashoverride.com/docs/chalk)
+##
+## delete-layer.sh - Delete Lambda layer versions from AWS regions
+
+set -e
+
+# Script configuration
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME=$(basename "$0")
+
+# Source utilities
+. "${SCRIPT_DIR}/lib/common.sh"
+. "${SCRIPT_DIR}/aws-regions.sh"
+
+# Default values
+LAYER_NAME="${LAYER_NAME:-crashoverride-dust-extension}"
+DRY_RUN="${DRY_RUN:-false}"
+DELETE_ALL="${DELETE_ALL:-false}"
+BATCH_SIZE="${BATCH_SIZE:-5}"
+VERBOSE="${VERBOSE:-false}"
+
+# Tracking
+SUCCESSFUL_DELETIONS=""
+FAILED_DELETIONS=""
+TEMP_FILES=""
+
+# Usage
+usage() {
+  cat <<EOF
+Usage: $SCRIPT_NAME [OPTIONS]
+
+Delete Lambda layer versions from AWS regions.
+
+Options:
+  -a, --account-id ID      AWS Account ID (required, or set AWS_ACCOUNT_ID)
+  -n, --layer-name NAME    Layer name (default: $LAYER_NAME)
+  -r, --region REGION      AWS region (required unless using --regions)
+  -R, --regions LIST       Comma-separated list of regions
+  -V, --version VERSION    Specific version to delete (delete all if not specified)
+  -A, --all                Delete all versions (requires confirmation)
+  -d, --dry-run            Show what would be deleted without deleting
+  -y, --yes                Skip confirmation prompts
+  -v, --verbose            Enable verbose output
+  -h, --help               Show this help message
+
+Environment Variables:
+  AWS_ACCOUNT_ID          AWS Account ID (can be set instead of -a)
+  LAYER_NAME              Layer name (can be set instead of -n)
+
+Examples:
+  # List all versions in a region (dry-run)
+  $SCRIPT_NAME -a 123456789012 -r us-east-1 -d
+
+  # Delete specific version
+  $SCRIPT_NAME -a 123456789012 -r us-east-1 -V 5
+
+  # Delete all versions in a region (with confirmation)
+  $SCRIPT_NAME -a 123456789012 -r us-east-1 -A
+
+  # Delete all versions in multiple regions
+  $SCRIPT_NAME -a 123456789012 -R us-east-1,us-west-2 -A
+
+  # Skip confirmation with environment variable
+  export AWS_ACCOUNT_ID=123456789012
+  $SCRIPT_NAME -r us-east-1 -A -y
+
+EOF
+  exit "${1:-0}"
+}
+
+# Parse command line arguments
+parse_args() {
+  SKIP_CONFIRMATION="false"
+  SPECIFIC_VERSION=""
+  REGION=""
+  REGIONS=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -a|--account-id)
+        AWS_ACCOUNT_ID="$2"
+        shift 2
+        ;;
+      -n|--layer-name)
+        LAYER_NAME="$2"
+        shift 2
+        ;;
+      -r|--region)
+        REGION="$2"
+        shift 2
+        ;;
+      -R|--regions)
+        REGIONS="$2"
+        shift 2
+        ;;
+      -V|--version)
+        SPECIFIC_VERSION="$2"
+        shift 2
+        ;;
+      -A|--all)
+        DELETE_ALL="true"
+        shift
+        ;;
+      -d|--dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+      -y|--yes)
+        SKIP_CONFIRMATION="true"
+        shift
+        ;;
+      -v|--verbose)
+        VERBOSE="true"
+        export VERBOSE
+        shift
+        ;;
+      -h|--help)
+        usage 0
+        ;;
+      -*)
+        log_error "Unknown option: $1"
+        usage 1
+        ;;
+      *)
+        log_error "Unexpected argument: $1"
+        usage 1
+        ;;
+    esac
+  done
+
+  # Validate required arguments
+  if [ -z "$REGION" ] && [ -z "$REGIONS" ]; then
+    log_error "Either --region or --regions is required"
+    usage 1
+  fi
+
+  if [ -n "$REGION" ] && [ -n "$REGIONS" ]; then
+    log_error "Cannot specify both --region and --regions"
+    usage 1
+  fi
+
+  if [ -z "$SPECIFIC_VERSION" ] && [ "$DELETE_ALL" != "true" ]; then
+    log_error "Must specify either --version or --all"
+    usage 1
+  fi
+
+  if [ -n "$SPECIFIC_VERSION" ] && [ "$DELETE_ALL" = "true" ]; then
+    log_error "Cannot specify both --version and --all"
+    usage 1
+  fi
+
+  # Convert single region to regions list
+  if [ -n "$REGION" ]; then
+    REGIONS="$REGION"
+  fi
+
+  # Convert comma-separated to space-separated
+  REGIONS=$(printf "%s" "$REGIONS" | tr ',' ' ')
+
+  # Get AWS account ID if not provided
+  if [ -z "${AWS_ACCOUNT_ID:-}" ]; then
+    log_info "AWS_ACCOUNT_ID not provided, attempting to get from AWS CLI..."
+    AWS_ACCOUNT_ID=$(get_aws_account_id)
+    if [ -z "$AWS_ACCOUNT_ID" ]; then
+      log_error "Unable to determine AWS Account ID"
+      log_error "Please provide it via -a option or AWS_ACCOUNT_ID environment variable"
+      exit 1
+    fi
+    log_info "Using AWS Account ID: $AWS_ACCOUNT_ID"
+  fi
+}
+
+# Get layer versions in a region
+get_layer_versions() {
+  region="$1"
+  layer_name="$2"
+
+  if [ "${VERBOSE:-false}" = "true" ]; then
+    log_info "Fetching versions for $layer_name in $region..."
+  fi
+
+  versions=$(aws lambda list-layer-versions \
+    --layer-name "$layer_name" \
+    --region "$region" \
+    --query "LayerVersions[*].Version" \
+    --output text 2>/dev/null) || {
+    # Check if layer doesn't exist
+    error_msg=$(aws lambda list-layer-versions \
+      --layer-name "$layer_name" \
+      --region "$region" 2>&1 | grep -o "ResourceNotFoundException" || true)
+
+    if [ -n "$error_msg" ]; then
+      log_warning "Layer '$layer_name' not found in region $region"
+      return 1
+    else
+      log_error "Failed to list versions for '$layer_name' in $region"
+      return 1
+    fi
+  }
+
+  if [ -z "$versions" ]; then
+    log_warning "No versions found for layer '$layer_name' in region $region"
+    return 1
+  fi
+
+  printf "%s" "$versions"
+}
+
+# Delete a specific layer version
+delete_layer_version() {
+  region="$1"
+  layer_name="$2"
+  version="$3"
+  output_file="$4"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    printf "DRY-RUN: Would delete %s:%s (version %s)\n" "$region" "$layer_name" "$version" >> "$output_file"
+    return 0
+  fi
+
+  if aws lambda delete-layer-version \
+    --layer-name "$layer_name" \
+    --version-number "$version" \
+    --region "$region" >/dev/null 2>&1; then
+    printf "SUCCESS: Deleted %s:%s (version %s)\n" "$region" "$layer_name" "$version" >> "$output_file"
+    return 0
+  else
+    printf "ERROR: Failed to delete %s:%s (version %s)\n" "$region" "$layer_name" "$version" >> "$output_file"
+    return 1
+  fi
+}
+
+# Delete layer versions in a region
+delete_in_region() {
+  region="$1"
+
+  log_info "Processing region: $region"
+
+  # Get versions to delete
+  if [ -n "$SPECIFIC_VERSION" ]; then
+    versions="$SPECIFIC_VERSION"
+  else
+    versions=$(get_layer_versions "$region" "$LAYER_NAME") || return 1
+  fi
+
+  if [ -z "$versions" ]; then
+    return 0
+  fi
+
+  # Count versions
+  version_count=$(printf "%s" "$versions" | wc -w)
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log_info "Found $version_count version(s) that would be deleted in $region:"
+    for version in $versions; do
+      log_info "  - Version $version"
+    done
+  else
+    log_info "Found $version_count version(s) to delete in $region"
+  fi
+
+  # Delete each version
+  for version in $versions; do
+    output_file=$(create_temp_file "delete-${region}-${version}")
+    TEMP_FILES="$TEMP_FILES $output_file"
+
+    delete_layer_version "$region" "$LAYER_NAME" "$version" "$output_file"
+
+    # Process result
+    if [ -f "$output_file" ]; then
+      result=$(cat "$output_file")
+
+      if printf "%s" "$result" | grep -q "^SUCCESS"; then
+        SUCCESSFUL_DELETIONS="$SUCCESSFUL_DELETIONS ${region}:${version}"
+        log_success "$result"
+      elif printf "%s" "$result" | grep -q "^DRY-RUN"; then
+        log_info "$result"
+      else
+        FAILED_DELETIONS="$FAILED_DELETIONS ${region}:${version}"
+        log_error "$result"
+      fi
+
+      rm -f "$output_file"
+    fi
+  done
+}
+
+# Process all regions
+process_all_regions() {
+
+  if [ "$DELETE_ALL" = "true" ] && [ "$SKIP_CONFIRMATION" != "true" ] && [ "$DRY_RUN" != "true" ]; then
+    printf "\n"
+    log_warning "WARNING: This will delete ALL versions of layer '$LAYER_NAME' in the following region(s):"
+    for region in $REGIONS; do
+      log_warning "  - $region"
+    done
+    printf "\n"
+    printf "Are you sure you want to continue? (yes/no): "
+    read -r confirmation
+    if [ "$confirmation" != "yes" ]; then
+      log_info "Operation cancelled"
+      exit 0
+    fi
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log_warning "DRY-RUN MODE: No actual deletions will be made"
+  fi
+
+  # Process each region
+  for region in $REGIONS; do
+    delete_in_region "$region"
+  done
+}
+
+# Print summary
+print_summary() {
+  printf "\n"
+  log_info "========================================="
+  log_info "          DELETION SUMMARY"
+  log_info "========================================="
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log_warning "DRY-RUN MODE: No actual deletions were made"
+    return 0
+  fi
+
+  # Count successes and failures
+  success_count=$(printf "%s" "$SUCCESSFUL_DELETIONS" | wc -w)
+  failure_count=$(printf "%s" "$FAILED_DELETIONS" | wc -w)
+
+  if [ "$success_count" -gt 0 ]; then
+    log_success "Successfully deleted $success_count version(s)"
+    if [ "${VERBOSE:-false}" = "true" ]; then
+      log_info "Successful deletions:"
+      for item in $SUCCESSFUL_DELETIONS; do
+        log_info "  - $item"
+      done
+    fi
+  fi
+
+  if [ "$failure_count" -gt 0 ]; then
+    log_error "Failed to delete $failure_count version(s)"
+    log_error "Failed deletions:"
+    for item in $FAILED_DELETIONS; do
+      log_error "  - $item"
+    done
+  fi
+
+  if [ "$success_count" -eq 0 ] && [ "$failure_count" -eq 0 ]; then
+    log_info "No versions to delete"
+  fi
+}
+
+# Main execution
+main() {
+  # Set up cleanup trap
+  setup_cleanup_trap
+
+  # Parse arguments
+  parse_args "$@"
+
+  # Validate AWS CLI
+  if [ "$DRY_RUN" != "true" ]; then
+    log_info "Validating AWS CLI configuration..."
+    if ! validate_aws_cli; then
+      exit 1
+    fi
+  fi
+
+  # Display account info
+  log_info "Using AWS Account ID: $AWS_ACCOUNT_ID"
+  log_info "Layer name: $LAYER_NAME"
+
+  # Process all regions
+  process_all_regions
+
+  # Print summary
+  print_summary
+
+  # Exit with appropriate code
+  if [ -n "$FAILED_DELETIONS" ] && [ "$DRY_RUN" != "true" ]; then
+    exit 1
+  fi
+
+  exit 0
+}
+
+# Run main
+main "$@"

--- a/dust-lambda-extension/scripts/deploy-layer.sh
+++ b/dust-lambda-extension/scripts/deploy-layer.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env sh
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of the Chalk project
+## (see https://crashoverride.com/docs/chalk)
+##
+## deploy-layer.sh - Deploy Lambda layer to all AWS regions
+
+set -e
+
+# Script configuration
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME=$(basename "$0")
+
+# Source utilities
+. "${SCRIPT_DIR}/lib/common.sh"
+. "${SCRIPT_DIR}/aws-regions.sh"
+
+# Default values
+LAYER_NAME="${LAYER_NAME:-crashoverride-dust-extension}"
+BATCH_SIZE="${BATCH_SIZE:-5}"
+DRY_RUN="${DRY_RUN:-false}"
+REGION_FILTER="${REGION_FILTER:-all}"
+COMPATIBLE_RUNTIMES="${COMPATIBLE_RUNTIMES:-provided.al2 provided.al2023}"
+COMPATIBLE_ARCHITECTURES="${COMPATIBLE_ARCHITECTURES:-x86_64}"
+
+# Deployment tracking
+SUCCESSFUL_REGIONS=""
+FAILED_REGIONS=""
+TEMP_FILES=""
+
+# Usage
+usage() {
+  cat <<EOF
+Usage: $SCRIPT_NAME [OPTIONS] <archive_path>
+
+Deploy Lambda layer to multiple AWS regions with public access.
+
+Arguments:
+  archive_path              Path to the layer ZIP archive
+
+Options:
+  -a, --account-id ID      AWS Account ID (required, or set AWS_ACCOUNT_ID)
+  -n, --layer-name NAME    Layer name (default: $LAYER_NAME)
+  -r, --regions FILTER     Region filter: all, us, eu, ap, primary (default: all)
+  -b, --batch-size SIZE    Number of parallel deployments (default: $BATCH_SIZE)
+  -d, --dry-run            Show what would be deployed without deploying
+  -v, --verbose            Enable verbose output
+  -h, --help               Show this help message
+
+Environment Variables:
+  AWS_ACCOUNT_ID          AWS Account ID (can be set instead of -a)
+  LAYER_NAME              Layer name (can be set instead of -n)
+  REGION_FILTER           Region filter (can be set instead of -r)
+
+Examples:
+  # Deploy to all regions
+  $SCRIPT_NAME -a 123456789012 dist/layer.zip
+
+  # Deploy to US regions only with dry-run
+  $SCRIPT_NAME -a 123456789012 -r us -d dist/layer.zip
+
+  # Deploy with environment variables
+  export AWS_ACCOUNT_ID=123456789012
+  $SCRIPT_NAME dist/layer.zip
+
+EOF
+  exit "${1:-0}"
+}
+
+# Parse command line arguments
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -a|--account-id)
+        AWS_ACCOUNT_ID="$2"
+        shift 2
+        ;;
+      -n|--layer-name)
+        LAYER_NAME="$2"
+        shift 2
+        ;;
+      -r|--regions)
+        REGION_FILTER="$2"
+        shift 2
+        ;;
+      -b|--batch-size)
+        BATCH_SIZE="$2"
+        shift 2
+        ;;
+      -d|--dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+      -v|--verbose)
+        VERBOSE="true"
+        export VERBOSE
+        shift
+        ;;
+      -h|--help)
+        usage 0
+        ;;
+      -*)
+        log_error "Unknown option: $1"
+        usage 1
+        ;;
+      *)
+        ARCHIVE_PATH="$1"
+        shift
+        ;;
+    esac
+  done
+
+  # Validate required arguments
+  if [ -z "$ARCHIVE_PATH" ]; then
+    log_error "Archive path is required"
+    usage 1
+  fi
+
+  if [ ! -f "$ARCHIVE_PATH" ]; then
+    log_error "Archive file does not exist: $ARCHIVE_PATH"
+    exit 1
+  fi
+
+  # Get AWS account ID if not provided
+  if [ -z "$AWS_ACCOUNT_ID" ]; then
+    log_info "AWS_ACCOUNT_ID not provided, attempting to get from AWS CLI..."
+    AWS_ACCOUNT_ID=$(get_aws_account_id)
+    if [ -z "$AWS_ACCOUNT_ID" ]; then
+      log_error "Unable to determine AWS Account ID"
+      log_error "Please provide it via -a option or AWS_ACCOUNT_ID environment variable"
+      exit 1
+    fi
+    log_info "Using AWS Account ID: $AWS_ACCOUNT_ID"
+  fi
+}
+
+# Get layer description based on git status
+get_layer_description() {
+  description="Dust Lambda Extension"
+
+  if command_exists git && git rev-parse --git-dir >/dev/null 2>&1; then
+    git_hash=$(git rev-parse --short HEAD 2>/dev/null || echo "")
+    git_tag=$(git describe --exact-match HEAD 2>/dev/null || echo "")
+
+    if [ -n "$git_tag" ]; then
+      description="$description - Version: $git_tag"
+    elif [ -n "$git_hash" ]; then
+      description="$description - Commit: $git_hash"
+    fi
+  fi
+
+  printf "%s" "$description"
+}
+
+# Deploy layer to a single region
+deploy_to_region() {
+  region="$1"
+  archive="$2"
+  layer_name="$3"
+  description="$4"
+  output_file="$5"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    printf "DRY-RUN: Would deploy to %s\n" "$region" >> "$output_file"
+    return 0
+  fi
+
+  # Create or update layer version
+  if aws lambda publish-layer-version \
+    --layer-name "$layer_name" \
+    --description "$description" \
+    --zip-file "fileb://$archive" \
+    --compatible-runtimes "${COMPATIBLE_RUNTIMES}" \
+    --compatible-architectures "${COMPATIBLE_ARCHITECTURES}" \
+    --region "$region" \
+    --output json > "${output_file}.json" 2>&1; then
+
+    # Extract version number
+    version=$(grep '"Version"' "${output_file}.json" | sed 's/.*"Version": *\([0-9]*\).*/\1/')
+
+    if [ -n "$version" ]; then
+      # Add permission for public access
+      if aws lambda add-layer-version-permission \
+        --layer-name "$layer_name" \
+        --version-number "$version" \
+        --principal "*" \
+        --statement-id "public-access" \
+        --action "lambda:GetLayerVersion" \
+        --region "$region" >/dev/null 2>&1; then
+
+        layer_arn=$(grep '"LayerVersionArn"' "${output_file}.json" | sed 's/.*"LayerVersionArn": *"\([^"]*\)".*/\1/')
+        printf "SUCCESS: %s - %s (v%s)\n" "$region" "$layer_arn" "$version" >> "$output_file"
+        return 0
+      else
+        printf "PARTIAL: %s - Layer created (v%s) but failed to add public permission\n" "$region" "$version" >> "$output_file"
+        return 1
+      fi
+    else
+      printf "ERROR: %s - Failed to extract version from response\n" "$region" >> "$output_file"
+      return 1
+    fi
+  else
+    error_msg=$(grep -o '"Message":"[^"]*"' "${output_file}.json" 2>/dev/null | sed 's/"Message":"\([^"]*\)"/\1/')
+    printf "ERROR: %s - %s\n" "$region" "${error_msg:-Failed to create layer}" >> "$output_file"
+    return 1
+  fi
+}
+
+# Deploy to all regions
+deploy_to_all_regions() {
+  regions="$1"
+  total_regions=$(printf "%s" "$regions" | wc -w)
+
+  log_info "Starting deployment to $total_regions regions..."
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log_warning "DRY-RUN MODE: No actual deployments will be made"
+  fi
+
+  # Get layer description
+  description=$(get_layer_description)
+
+  # Deploy in batches
+  batch_count=0
+  completed_count=0
+
+  for region in $regions; do
+    # Create output file for this region
+    output_file=$(create_temp_file "deploy-${region}")
+    TEMP_FILES="$TEMP_FILES $output_file ${output_file}.json"
+
+    # Start deployment in background
+    deploy_to_region "$region" "$ARCHIVE_PATH" "$LAYER_NAME" "$description" "$output_file" &
+
+    batch_count=$((batch_count + 1))
+
+    # Wait for batch to complete if we've reached batch size
+    if [ $batch_count -ge "$BATCH_SIZE" ]; then
+      wait
+
+      # Process results
+      for temp_file in $TEMP_FILES; do
+        if [ -f "$temp_file" ] && [ -s "$temp_file" ] && ! printf "%s" "$temp_file" | grep -q '\.json$'; then
+          result=$(cat "$temp_file")
+
+          # Extract region from result
+          result_region=$(printf "%s" "$result" | awk '{print $2}' | sed 's/://')
+
+          if printf "%s" "$result" | grep -q "^SUCCESS"; then
+            SUCCESSFUL_REGIONS="$SUCCESSFUL_REGIONS $result_region"
+            log_success "$result"
+          elif printf "%s" "$result" | grep -q "^DRY-RUN"; then
+            log_info "$result"
+          else
+            FAILED_REGIONS="$FAILED_REGIONS $result_region"
+            log_error "$result"
+          fi
+
+          completed_count=$((completed_count + 1))
+          show_progress "$completed_count" "$total_regions" "Deploying"
+        fi
+      done
+
+      # Clean up temp files for this batch
+      for temp_file in $TEMP_FILES; do
+        rm -f "$temp_file"
+      done
+      TEMP_FILES=""
+
+      batch_count=0
+    fi
+  done
+
+  # Wait for remaining jobs
+  if [ $batch_count -gt 0 ]; then
+    wait
+
+    # Process remaining results
+    for temp_file in $TEMP_FILES; do
+      if [ -f "$temp_file" ] && [ -s "$temp_file" ] && ! printf "%s" "$temp_file" | grep -q '\.json$'; then
+        result=$(cat "$temp_file")
+        result_region=$(printf "%s" "$result" | awk '{print $2}' | sed 's/://')
+
+        if printf "%s" "$result" | grep -q "^SUCCESS"; then
+          SUCCESSFUL_REGIONS="$SUCCESSFUL_REGIONS $result_region"
+          log_success "$result"
+        elif printf "%s" "$result" | grep -q "^DRY-RUN"; then
+          log_info "$result"
+        else
+          FAILED_REGIONS="$FAILED_REGIONS $result_region"
+          log_error "$result"
+        fi
+
+        completed_count=$((completed_count + 1))
+        show_progress "$completed_count" "$total_regions" "Deploying"
+      fi
+    done
+  fi
+}
+
+# Print deployment summary
+print_summary() {
+  printf "\n"
+  log_info "========================================="
+  log_info "          DEPLOYMENT SUMMARY"
+  log_info "========================================="
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log_warning "DRY-RUN MODE: No actual deployments were made"
+    return 0
+  fi
+
+  # Count successes and failures
+  success_count=$(printf "%s" "$SUCCESSFUL_REGIONS" | wc -w)
+  failure_count=$(printf "%s" "$FAILED_REGIONS" | wc -w)
+  total_count=$((success_count + failure_count))
+
+  if [ "$success_count" -gt 0 ]; then
+    log_success "Successfully deployed to $success_count/$total_count regions"
+    if [ "$VERBOSE" = "true" ]; then
+      log_info "Successful regions: $SUCCESSFUL_REGIONS"
+    fi
+  fi
+
+  if [ "$failure_count" -gt 0 ]; then
+    log_error "Failed to deploy to $failure_count/$total_count regions"
+    log_error "Failed regions: $FAILED_REGIONS"
+
+    # Provide retry command
+    log_info ""
+    log_info "To retry failed regions, run:"
+    failed_list=$(printf "%s" "$FAILED_REGIONS" | tr ' ' ',')
+    log_info "  AWS_REGIONS='$failed_list' $SCRIPT_NAME $ARCHIVE_PATH"
+  fi
+
+  # Print Layer ARN format for reference
+  if [ "$success_count" -gt 0 ]; then
+    log_info ""
+    log_info "Layer ARN format:"
+    log_info "  arn:aws:lambda:<region>:$AWS_ACCOUNT_ID:layer:$LAYER_NAME:<version>"
+  fi
+}
+
+# Main execution
+main() {
+  # Set up cleanup trap
+  setup_cleanup_trap
+
+  # Parse arguments
+  parse_args "$@"
+
+  # Validate prerequisites
+  if [ "$DRY_RUN" != "true" ]; then
+    log_info "Validating AWS CLI configuration..."
+    if ! validate_aws_cli; then
+      exit 1
+    fi
+  fi
+
+  # Get regions for deployment
+  if [ -n "$AWS_REGIONS" ]; then
+    # Use explicitly provided regions (comma-separated)
+    regions=$(printf "%s" "$AWS_REGIONS" | tr ',' ' ')
+    log_info "Using explicitly provided regions: $regions"
+  else
+    # Get regions based on filter
+    log_info "Getting AWS regions (filter: $REGION_FILTER)..."
+    regions=$(get_deployment_regions "$REGION_FILTER")
+  fi
+
+  if [ -z "$regions" ]; then
+    log_error "No regions found for deployment"
+    exit 1
+  fi
+
+  # Deploy to all regions
+  deploy_to_all_regions "$regions"
+
+  # Print summary
+  print_summary
+
+  # Exit with appropriate code
+  if [ -n "$FAILED_REGIONS" ] && [ "$DRY_RUN" != "true" ]; then
+    exit 1
+  fi
+
+  exit 0
+}
+
+# Run main
+main "$@"

--- a/dust-lambda-extension/scripts/deploy-layer.sh
+++ b/dust-lambda-extension/scripts/deploy-layer.sh
@@ -360,7 +360,7 @@ main() {
   fi
 
   # Get regions for deployment
-  if [ -n "$AWS_REGIONS" ]; then
+  if [ -n "${AWS_REGIONS:-}" ]; then
     # Use explicitly provided regions (comma-separated)
     regions=$(printf "%s" "$AWS_REGIONS" | tr ',' ' ')
     log_info "Using explicitly provided regions: $regions"

--- a/dust-lambda-extension/scripts/lib/common.sh
+++ b/dust-lambda-extension/scripts/lib/common.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env sh
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of the Chalk project
+## (see https://crashoverride.com/docs/chalk)
+##
+## common.sh - Common utilities for deployment scripts
+
+set -eu
+
+# Color codes for output (POSIX-compliant)
+if [ -t 1 ]; then
+  RED=$(printf '\033[0;31m')
+  GREEN=$(printf '\033[0;32m')
+  YELLOW=$(printf '\033[0;33m')
+  BLUE=$(printf '\033[0;34m')
+  RESET=$(printf '\033[0m')
+else
+  RED=""
+  GREEN=""
+  YELLOW=""
+  BLUE=""
+  RESET=""
+fi
+
+# Logging functions
+log_info() {
+  printf "${BLUE}[INFO]${RESET} %s\n" "$1" >&2
+}
+
+log_success() {
+  printf "${GREEN}[SUCCESS]${RESET} %s\n" "$1" >&2
+}
+
+log_warning() {
+  printf "${YELLOW}[WARN] %s\n" "$1${RESET}" >&2
+}
+
+log_error() {
+  printf "${RED}[ERROR] %s\n" "$1${RESET}" >&2
+}
+
+# Check if a command exists
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Validate AWS CLI is installed and configured
+validate_aws_cli() {
+  if ! command_exists aws; then
+    log_error "AWS CLI is not installed. Please install it first."
+    return 1
+  fi
+
+  if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    log_error "AWS credentials are not configured or are invalid."
+    log_error "Please configure AWS credentials using 'aws configure' or environment variables."
+    return 1
+  fi
+
+  return 0
+}
+
+# Get AWS account ID
+get_aws_account_id() {
+  aws sts get-caller-identity --query Account --output text 2>/dev/null
+}
+
+# Validate required environment variables
+validate_env_var() {
+  var_name="$1"
+  var_value="$2"
+
+  if [ -z "$var_value" ]; then
+    log_error "$var_name is not set. Please provide it as an environment variable or make argument."
+    return 1
+  fi
+
+  return 0
+}
+
+# Check if git repository is clean
+check_git_clean() {
+  if ! command_exists git; then
+    log_warning "git is not installed, skipping dirty check"
+    return 0
+  fi
+
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    log_warning "Not in a git repository, skipping dirty check"
+    return 0
+  fi
+
+  if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+    return 1
+  fi
+
+  return 0
+}
+
+# Create a temporary file (POSIX-compliant)
+create_temp_file() {
+  tmpdir="${TMPDIR:-/tmp}"
+  template="${1:-dust-deploy}"
+
+  # Use mktemp if available, otherwise fallback
+  if command_exists mktemp; then
+    mktemp "${tmpdir}/${template}.XXXXXX"
+  else
+    # Fallback for systems without mktemp
+    # Use process ID and timestamp for uniqueness
+    timestamp=$(date +%s 2>/dev/null || date +%Y%m%d%H%M%S)
+    tmpfile="${tmpdir}/${template}.$$.${timestamp}"
+    touch "$tmpfile"
+    printf "%s" "$tmpfile"
+  fi
+}
+
+# Clean up temporary files
+cleanup_temp_files() {
+  if [ -n "$TEMP_FILES" ]; then
+    for file in $TEMP_FILES; do
+      if [ -f "$file" ]; then
+        rm -f "$file"
+      fi
+    done
+  fi
+}
+
+# Set up trap for cleanup on exit
+setup_cleanup_trap() {
+  trap cleanup_temp_files EXIT INT TERM
+}
+
+# Wait for background processes and collect results
+wait_for_jobs() {
+  failed_count=0
+
+  while [ "$(jobs -p | wc -l)" -gt 0 ]; do
+    for pid in $(jobs -p); do
+      if ! kill -0 "$pid" 2>/dev/null; then
+        wait "$pid"
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+          failed_count=$((failed_count + 1))
+        fi
+      fi
+    done
+    sleep 1
+  done
+
+  return $failed_count
+}
+
+# Progress indicator
+show_progress() {
+  current=$1
+  total=$2
+  description="${3:-Processing}"
+
+  percentage=$((current * 100 / total))
+  printf "\r${BLUE}[%3d%%]${RESET} %s: %d/%d" "$percentage" "$description" "$current" "$total" >&2
+
+  if [ "$current" -eq "$total" ]; then
+    printf "\n" >&2
+  fi
+}

--- a/dust-lambda-extension/scripts/list-extension-arns.sh
+++ b/dust-lambda-extension/scripts/list-extension-arns.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env sh
+##
+## Copyright (c) 2025, Crash Override, Inc.
+##
+## This file is part of the Chalk project
+## (see https://crashoverride.com/docs/chalk)
+##
+## list-extension-arns.sh - List all published Lambda extension ARNs
+
+set -e
+
+# Script configuration
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME=$(basename "$0")
+
+# Source utilities
+. "${SCRIPT_DIR}/lib/common.sh"
+. "${SCRIPT_DIR}/aws-regions.sh"
+
+# Default values
+LAYER_NAME="${LAYER_NAME:-crashoverride-dust-extension}"
+REGION_FILTER="${REGION_FILTER:-all}"
+
+# Usage
+usage() {
+  cat <<EOF
+Usage: $SCRIPT_NAME [OPTIONS]
+
+List all published Lambda extension ARNs in tab-delimited format.
+
+Options:
+  -a, --account-id ID      AWS Account ID (optional, auto-detected if not provided)
+  -n, --layer-name NAME    Layer name (default: $LAYER_NAME)
+  -R, --regions REGIONS    Comma-separated list of regions to query
+  -r, --region-filter FLT  Region filter: all, us, eu, ap, primary (default: all)
+  -h, --help               Show this help message
+
+Environment Variables:
+  AWS_ACCOUNT_ID           AWS Account ID (can be set instead of -a)
+  LAYER_NAME               Layer name (can be set instead of -n)
+  AWS_REGIONS              Comma-separated list of regions (can be set instead of -R)
+  REGION_FILTER            Region filter (can be set instead of -r)
+
+Output Format:
+  Tab-delimited with columns: REGION VERSION ARN
+
+Examples:
+  # List all ARNs in all regions
+  $SCRIPT_NAME
+
+  # List ARNs in specific regions
+  $SCRIPT_NAME -R "us-east-1,us-west-2"
+
+  # List ARNs in US regions only
+  $SCRIPT_NAME -r us
+
+  # Use with specific layer name
+  $SCRIPT_NAME -n my-custom-layer
+
+EOF
+  exit "${1:-0}"
+}
+
+# Parse command line arguments
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -a|--account-id)
+        AWS_ACCOUNT_ID="$2"
+        shift 2
+        ;;
+      -n|--layer-name)
+        LAYER_NAME="$2"
+        shift 2
+        ;;
+      -R|--regions)
+        AWS_REGIONS="$2"
+        shift 2
+        ;;
+      -r|--region-filter)
+        REGION_FILTER="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage 0
+        ;;
+      -*)
+        log_error "Unknown option: $1"
+        usage 1
+        ;;
+      *)
+        log_error "Unexpected argument: $1"
+        usage 1
+        ;;
+    esac
+  done
+}
+
+# List ARNs in all specified regions
+list_arns() {
+  regions="$1"
+
+  # Print header
+  printf "REGION\tVERSION\tARN\n"
+  printf "======\t=======\t===\n"
+
+  # Create temp file for output
+  output_file=$(create_temp_file "arns")
+
+  # Track statistics
+  total_arns=0
+  regions_with_layers=0
+
+  # Query each region and collect results
+  for region in $regions; do
+    # List layer versions in this region
+    versions=$(aws lambda list-layer-versions \
+      --layer-name "$LAYER_NAME" \
+      --region "$region" \
+      --query 'LayerVersions[*].[Version,LayerVersionArn]' \
+      --output text 2>/dev/null || true)
+
+    if [ -n "$versions" ]; then
+      regions_with_layers=$((regions_with_layers + 1))
+
+      # Process each version and write to file
+      echo "$versions" | while IFS='	' read -r version arn; do
+        printf "%s\t%s\t%s\n" "$region" "$version" "$arn" >> "$output_file"
+      done
+
+      # Count lines added (versions for this region)
+      version_count=$(echo "$versions" | wc -l)
+      total_arns=$((total_arns + version_count))
+    fi
+  done
+
+  # Sort and display results
+  if [ -f "$output_file" ] && [ -s "$output_file" ]; then
+    sort -t'	' -k1,1 -k2,2nr "$output_file"
+  fi
+
+  # Clean up
+  rm -f "$output_file"
+
+  # Count total regions queried
+  total_regions=$(echo "$regions" | wc -w)
+
+  # Print summary
+  printf "\n"
+  if [ "$total_arns" -eq 0 ]; then
+    log_warning "No Lambda extension ARNs found for layer: $LAYER_NAME"
+    log_info "Queried $total_regions regions"
+  else
+    log_info "Found ARNs in $regions_with_layers out of $total_regions regions"
+  fi
+}
+
+# Main execution
+main() {
+  # Parse arguments
+  parse_args "$@"
+
+  # Get AWS account ID if needed (for display purposes)
+  if [ -z "$AWS_ACCOUNT_ID" ]; then
+    AWS_ACCOUNT_ID=$(get_aws_account_id)
+    if [ -z "$AWS_ACCOUNT_ID" ]; then
+      log_warning "Unable to determine AWS Account ID"
+    fi
+  fi
+
+  # Display configuration
+  log_info "Listing Lambda extension ARNs"
+  if [ -n "$AWS_ACCOUNT_ID" ]; then
+    log_info "AWS Account ID: $AWS_ACCOUNT_ID"
+  fi
+  log_info "Layer Name: $LAYER_NAME"
+
+  # Get regions to query
+  if [ -n "${AWS_REGIONS:-}" ]; then
+    # Use explicitly provided regions (comma-separated)
+    regions=$(printf "%s" "$AWS_REGIONS" | tr ',' ' ')
+    log_info "Using explicitly provided regions"
+  else
+    # Get regions based on filter
+    log_info "Getting AWS regions (filter: $REGION_FILTER)..."
+    regions=$(get_deployment_regions "$REGION_FILTER")
+  fi
+
+  if [ -z "$regions" ]; then
+    log_error "No regions found to query"
+    exit 1
+  fi
+
+  # List ARNs
+  printf "\n"
+  list_arns "$regions"
+}
+
+# Run main
+main "$@"


### PR DESCRIPTION
PR blocked on https://github.com/crashappsec/chalk/pull/546

<!-- Please ensure you have done the following steps: -->

- [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ ] Filled out the template to a useful degree
- [ ] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->
https://app.shortcut.com/crashoverride-1/story/9180/create-plugin-project-and-boilerplate

## Description

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

- adds basic operations for Lambda Extension deployment and management
  - create extension across region(s)
  - delete extension across regions(s)
  - list all published extension ARNs
- goals that modify state (deploy, delete) have `-dry-run` variants
- utility goal for echoing extension's SemVer2.0
- goals and related scripts are all parameterized allowing for use by other AWS Accounts and filtering by AWS regions.
