### PR TITLE
feat: add zip inject binary threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,9 +142,17 @@
   ([#515](https://github.com/crashappsec/chalk/pull/515))
 - Reporting all IMDSv2 errors in `FAILED_KEYS` or `_OP_FAILED_KEYS`.
   ([#519](https://github.com/crashappsec/chalk/pull/519))
-- Adds `zip.inject_binary` config and `--inject-binary-into-zip` CLI flag to
-  the `chalk insert` command as part of chalk's AWS Lambda support
-  ([#498](https://github.com/crashappsec/chalk/pull/498))
+- During `chalk insert` allow chalk to inject itself (binary) into
+  ZIP archive as part of schalk's AWS Lambda support.
+  Added configurations:
+  - `zip.inject_binary` (`--inject-binary-into-zip` CLI flag)
+  - `zip.inject_binary_allowed_extensions` (default only `.zip`)
+  - `zip.inject_zip_size_threshold` (default `50Mb`)
+
+  ([#498](https://github.com/crashappsec/chalk/pull/498),
+  [#547](https://github.com/crashappsec/chalk/pull/547),
+  [#573](https://github.com/crashappsec/chalk/pull/573))
+
 - Chalk can set rlimit for heartbeats process.
   By default no limit is set.
   ([#544](https://github.com/crashappsec/chalk/pull/544))
@@ -160,10 +168,6 @@
 
 - `BUILD_UNIQUE_ID` to uniquely identify jobs in GitHub.
   ([#562](https://github.com/crashappsec/chalk/pull/562))
-- Adds `zip.allowed_extensions` which will only inject the chalk binary if a
-  target archive's extension is in the list of `allowed_extensions`. Defaults to
-  `[zip]` and can be overriden with the `--zip-allowed-extensions` flag. (
-  [#547](https://github.com/crashappsec/chalk/pull/547))
 - In GitHub in the same workflow job, for the same context,
   cache external tool outputs. This avoid running same external
   tool multiple times between multiple chalk operations.

--- a/src/config.nim
+++ b/src/config.nim
@@ -7,6 +7,9 @@
 
 ## Wrappers for more abstracted accessing of configuration information
 
+import std/[
+  os,
+]
 import "."/[
   config_version,
   types,
@@ -109,6 +112,11 @@ proc runCallback*(s: string, args: seq[Box]): Option[Box] =
 proc getChalkExeVersion*(): string =
   const version = getChalkVersion()
   version
+
+proc getChalkExeSize*(): int =
+  if chalkExeSize == 0:
+    chalkExeSize = getFileInfo(getMyAppPath()).size
+  return chalkExeSize
 
 proc getChalkCommitId*(): string     = commitID
 proc getChalkPlatform*(): string     = osStr & " " & archStr

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2033,6 +2033,21 @@ archive being processed upon insertion.
 """
   }
 
+  field inject_zip_size_threshold {
+    type:    Size
+    default: <<50mb>>
+    doc:     """
+Threshold of zip size + uncompressed chalk size at which chalk will refuse
+to inject itself into a zip file.
+
+Threshold of 0 will always inject chalk binary into zip.
+
+This uses uncompressed chalk size as chalk cant know to what size will
+chalk compress to to do most accurate calculation however it might
+not be a bad thing to leave some buffer room in there just in case.
+"""
+  }
+
   field allowed_extensions {
     type:     list[string]
     default:  ["zip"]

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2048,7 +2048,7 @@ not be a bad thing to leave some buffer room in there just in case.
 """
   }
 
-  field allowed_extensions {
+  field inject_binary_allowed_extensions {
     type:     list[string]
     default:  ["zip"]
     shortdoc: "File extensions allowed for zip binary injection"

--- a/src/plugins/codecZip.nim
+++ b/src/plugins/codecZip.nim
@@ -250,7 +250,7 @@ proc zipHandleWrite*(self: Plugin, chalk: ChalkObj, encoded: Option[string])
     else:
       let
         filename = chalk.fsRef.splitFile().name & chalk.fsRef.splitFile().ext
-        allowedExtensions = attrGet[seq[string]]("zip.allowed_extensions")
+        allowedExtensions = attrGet[seq[string]]("zip.inject_binary_allowed_extensions")
 
       var shouldInject = false
       for ext in allowedExtensions:

--- a/src/plugins/codecZip.nim
+++ b/src/plugins/codecZip.nim
@@ -30,6 +30,7 @@ const chalkBinary = "chalk"
 
 type
   ZipCache = ref object of RootRef
+    size:          int
     onDisk:        ZipArchive
     embeddedChalk: Box
     tmpDir:        string
@@ -104,7 +105,7 @@ proc zipScan*(self: Plugin, loc: string): Option[ChalkObj] {.cdecl.} =
 
     let
       tmpDir   = getNewTempDir()
-      cache    = ZipCache()
+      cache    = ZipCache(size: getFileInfo(loc).size)
       origD    = tmpDir.joinPath("contents")
       hashD    = tmpDir.joinPath("hash")
       subscans = attrGet[bool]("chalk_contained_items")
@@ -237,25 +238,34 @@ proc doZipWrite(chalk: ChalkObj, encoded: Option[string], virtual: bool) =
 proc zipHandleWrite*(self: Plugin, chalk: ChalkObj, encoded: Option[string])
                    {.cdecl.} =
   let injectBinary = attrGet[bool]("zip.inject_binary")
-  if injectBinary:
+
+  if injectBinary :
     let
-      filename = chalk.fsRef.splitFile().name & chalk.fsRef.splitFile().ext
-      allowedExtensions = attrGet[seq[string]]("zip.allowed_extensions")
-
-    var shouldInject = false
-    for ext in allowedExtensions:
-      if filename.toLowerAscii().endsWith("." & ext.toLowerAscii()):
-        shouldInject = true
-        break
-
-    if shouldInject:
-      try:
-        info(chalk.name & ": Inserting binary into zip archive")
-        insertChalkBinaryIntoZip(chalk)
-      except:
-        error(chalk.name & ": failed to insert chalk binary due to: " & getCurrentExceptionMsg())
+      cache        = ZipCache(chalk.cache)
+      threshold    = attrGet[int]("zip.inject_zip_size_threshold")
+      combinedSize = cache.size + getChalkExeSize()
+    if threshold > 0 and combinedSize > threshold:
+      warn(chalk.name & ": skipping inserting binary into zip as combined size " &
+           $combinedSize & " (bytes) >= " & $threshold & " (bytes)")
     else:
-      trace(chalk.name & ": skipping binary injection - no matching extension found")
+      let
+        filename = chalk.fsRef.splitFile().name & chalk.fsRef.splitFile().ext
+        allowedExtensions = attrGet[seq[string]]("zip.allowed_extensions")
+
+      var shouldInject = false
+      for ext in allowedExtensions:
+        if filename.toLowerAscii().endsWith("." & ext.toLowerAscii()):
+          shouldInject = true
+          break
+
+      if shouldInject:
+        try:
+          info(chalk.name & ": Inserting binary into zip archive")
+          insertChalkBinaryIntoZip(chalk)
+        except:
+          error(chalk.name & ": failed to insert chalk binary due to: " & getCurrentExceptionMsg())
+      else:
+        trace(chalk.name & ": skipping binary injection - no matching extension found")
 
   chalk.doZipWrite(encoded, virtual = false)
 

--- a/src/types.nim
+++ b/src/types.nim
@@ -560,6 +560,7 @@ var
   commandName*            = ""
   sshKeyscanExeLocation*  = ""
   dockerInvocation*:      DockerInvocation # ca be nil
+  chalkExeSize*           = 0
 
 template dumpExOnDebug*() =
   when not defined(release):

--- a/tests/functional/data/configs/serverless_zip.c4m
+++ b/tests/functional/data/configs/serverless_zip.c4m
@@ -1,4 +1,4 @@
 # inject the chalk binary into zip archives by default
 zip.inject_binary: true
 # only inject the chalk binary into these exetensions
-zip.allowed_extensions: ["zip", "serverless.zip"]
+zip.inject_binary_allowed_extensions: ["zip", "serverless.zip"]


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

there are scenarios when injecting chalk binary into zip will make it too large (e.g. lambda zip deployment) in which case chalk should bail out injecting chalk binary

## Description

add option to bypass binary injection when zip is >= threashold

## Testing

```
➜ dd if=/dev/urandom bs=1M count=50 > chalk.random
➜ zip chalk.zip chalk.random
➜ ./chalk insert chalk.zip --inject-binary-into-zip
```

dont think this small case needs explicit integration test so prolly ok for now as-is (zip codec is very slow too)
