### PR TITLE
fix(chalk): process explicitly specified files without applying ignore patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,9 @@
 
   ([#570](https://github.com/crashappsec/chalk/issues/570))
 
+- `chalk` now processes files explicitly passed to it without applying `ignore_patterns`
+  ([#575](https://github.com/crashappsec/chalk/pull/575))
+
 ## 0.5.9
 
 **August 14, 2025**

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -3529,7 +3529,8 @@ validate in the transparency log.
     shortdoc: "Ignore Patterns"
     doc:       """
 This is a list of regular expressions for files to ignore when scanning
-for artifacts to chalk.
+for artifacts to chalk. These rules are disregarded if a path to an artifact
+is passed to chalk directly (e.g., .some-dir/artifact.zip).
 """
   }
 


### PR DESCRIPTION
:warning: _*merging is blocked on https://github.com/crashappsec/chalk/pull/565*_ :warning: 
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

When a user specifies a file path directly (not a directory), the file is now processed even if it would normally be excluded by ignore patterns. This ensures that explicitly requested files are always scanned, while directories still respect exclusion rules during recursive scanning.

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

## Testing

```
mkdir -p /tmp/foo/.some-dir/archive.zip
./chalk insert /tmp/foo/.some-dir # ignore rules followed, no chalk.json
./chalk insert /tmp/foo/.some-dir/archive.zip
zipinfo /tmp/foo/.some-dir/archive.zip # chalk.json exists!
```

<!-- What are the steps needed to test this PR? -->
