### PR TITLE
fix: lazy copy_report_template_keys()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,12 @@
 
   ([#570](https://github.com/crashappsec/chalk/issues/570))
 
+- `copy_report_template_keys()` now lazily copies keys when the report
+  template is used, not when the function is called.
+  This avoids errors when new keys are added to the source template
+  after the copy function is called.
+  ([#576](https://github.com/crashappsec/chalk/pull/576))
+
 ## 0.5.9
 
 **August 14, 2025**

--- a/src/types.nim
+++ b/src/types.nim
@@ -543,24 +543,25 @@ const
   artX509Cert*            = "x509 Cert"
 
 var
-  hostInfo*               = ChalkDict()
-  objectsData*            = ObjectsDict()
-  failedKeys*             = ChalkDict()
-  subscribedKeys*         = Table[string, bool]()
-  systemErrors*           = seq[string](@[])
-  selfChalk*              = ChalkObj(nil)
-  canSelfInject*          = true
-  savedLogLevel*          = llError
-  doingTestRun*           = false
-  onlyCodecs*             = newSeq[Plugin]()
-  inInternalScan*         = false
-  passedHelpFlag*         = false
-  installedPlugins*       = Table[string, Plugin]()
-  externalActions*        = newSeq[seq[string]]()
-  commandName*            = ""
-  sshKeyscanExeLocation*  = ""
-  dockerInvocation*:      DockerInvocation # ca be nil
-  chalkExeSize*           = 0
+  hostInfo*                 = ChalkDict()
+  objectsData*              = ObjectsDict()
+  failedKeys*               = ChalkDict()
+  subscribedKeys*           = Table[string, bool]()
+  systemErrors*             = seq[string](@[])
+  selfChalk*                = ChalkObj(nil)
+  canSelfInject*            = true
+  savedLogLevel*            = llError
+  doingTestRun*             = false
+  onlyCodecs*               = newSeq[Plugin]()
+  inInternalScan*           = false
+  passedHelpFlag*           = false
+  installedPlugins*         = Table[string, Plugin]()
+  externalActions*          = newSeq[seq[string]]()
+  commandName*              = ""
+  sshKeyscanExeLocation*    = ""
+  dockerInvocation*:        DockerInvocation # ca be nil
+  chalkExeSize*             = 0
+  toCopyReportTemplateKeys* = TableRef[string, seq[string]]()
 
 template dumpExOnDebug*() =
   when not defined(release):

--- a/tests/functional/data/configs/copy_report_template_keys.c4m
+++ b/tests/functional/data/configs/copy_report_template_keys.c4m
@@ -1,0 +1,10 @@
+copy_report_template_keys("source", "insertion_default")
+copy_report_template_keys("insertion_default", "source") # check infinite recursion
+keyspec X_TEST {
+  kind:  ChalkTimeHost
+  type:  string
+  value: "TEST"
+}
+report_template source {
+  key.X_TEST.use = true
+}

--- a/tests/functional/test_command.py
+++ b/tests/functional/test_command.py
@@ -29,7 +29,11 @@ logger = get_logger()
 def test_insert_extract_repeated(copy_files: list[Path], chalk: Chalk):
     artifact = copy_files[0]
 
-    insert = chalk.insert(artifact=artifact, virtual=False)
+    insert = chalk.insert(
+        artifact=artifact,
+        virtual=False,
+        config=CONFIGS / "copy_report_template_keys.c4m",
+    )
     insert.marks_by_path.contains({str(artifact): {}})
 
     extract = chalk.extract(artifact=artifact)


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

for custom keys defined along with co chalk profile loaded, there are error logs which can alert in monitoring stack

## Description

if the copy is not lazy, then depending on the order of loaded modules, some keys might not be copied into the destination report template

for example:

```
copy_report_template_keys("source", "destination")
keyspec X_TEST {
  kind:  ChalkTimeHost
  type:  string
  value: ""
}
report_template.source.key.X_TEST.use = true
```

in above example `one.c4m` copies `source` into `destination` report template. At a later time if another key is added to `source` report template, it wont be copied to the `destination` report template as at the time of the time that key is not fully defined.

By making the copy lazy, all keys are copied when report template is referenced in chalk hence all keys can be successfully copied


## Testing

```
➜ maketest test_command.py::test_insert_extract_repeated --logs
```
