### PR TITLE
fix: use base command for custom_report.*.use_when matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Chalk Release Notes
 
+## On the `main` branch
+
+### Fixes
+
+- Custom reports `use_when` now matches based on the base command name.
+  For example `use_when = ["extract"]` will send report for all `extract`
+  sub-commands like `extract.containers`.
+  ([#590](https://github.com/crashappsec/chalk/pull/590))
+
 ## 0.6.0
 
 **September 9, 2025**

--- a/src/attestation_api.nim
+++ b/src/attestation_api.nim
@@ -122,12 +122,12 @@ proc saveKeyToSelf(key: AttestationKey): bool =
   selfChalk.extract["$CHALK_ENCRYPTED_PRIVATE_KEY"] = pack(key.privateKey)
   selfChalk.extract["$CHALK_PUBLIC_KEY"]            = pack(key.publicKey)
 
-  let savedCommandName = getCommandName()
-  setCommandName("setup")
+  let savedCommandName = getFullCommandName()
+  setFullCommandName("setup")
   try:
     result = selfChalk.writeSelfConfig()
   finally:
-    setCommandName(savedCommandName)
+    setFullCommandName(savedCommandName)
 
 proc setupAttestation*() =
   info("Ensuring cosign is present to setup attestation.")

--- a/src/chalk.nim
+++ b/src/chalk.nim
@@ -43,13 +43,13 @@ when isMainModule:
     warn("No working codec is available for the native executable type")
 
   if passedHelpFlag:
-    runChalkHelp(getCommandName()) # no return; in cmd_help.nim
+    runChalkHelp(getFullCommandName()) # no return; in cmd_help.nim
 
   setupAutocomplete()      # autocomplete.nim
   setupDefaultLogConfigs() # src/sinks.nim
   loadAttestation()        # attestation.nim
 
-  case getCommandName()    # config.nim
+  case getFullCommandName()    # config.nim
   of "extract":            runCmdExtract(attrGet[seq[string]]("artifact_search_path"))
   of "extract.containers": runCmdExtractContainers()
   of "extract.images":     runCmdExtractImages()
@@ -71,7 +71,7 @@ when isMainModule:
   of "__.onbuild":         runCmdOnBuild() # in cmd_internal
   of "__.prep_postexec":   runCmdPrepPostExec() # in cmd_internal
   else:
-    runChalkHelp(getCommandName()) # noreturn, will not show config.
+    runChalkHelp(getFullCommandName()) # noreturn, will not show config.
 
   showConfigValues()
   quitChalk()

--- a/src/collect.nim
+++ b/src/collect.nim
@@ -399,7 +399,7 @@ iterator artifacts*(argv: seq[string], notTmp=true): ChalkObj =
 
             info(path & ": Chalk mark extracted")
 
-        if getCommandName() in ["insert", "docker"]:
+        if getBaseCommandName() in ["insert", "docker"]:
           obj.persistInternalValues()
 
         yield obj
@@ -409,7 +409,7 @@ iterator artifacts*(argv: seq[string], notTmp=true): ChalkObj =
           obj.collectRunTimeArtifactInfo()
 
   if not inSubscan():
-    if getCommandName() != "extract":
+    if getBaseCommandName() != "extract":
       for item in iterInfo.otherPaths:
         error(item & ": No such file or directory.")
     else:

--- a/src/commands/cmd_docker.nim
+++ b/src/commands/cmd_docker.nim
@@ -51,11 +51,11 @@ proc runCmdDocker*(args: seq[string]) =
     case ctx.extractDockerCommand()
     of DockerCmd.build:
       info("Running docker build.")
-      setCommandName("build")
+      setFullCommandName("build")
       exitCode = ctx.dockerBuild()
     of DockerCmd.push:
       info("Running docker push.")
-      setCommandName("push")
+      setFullCommandName("push")
       exitCode = ctx.dockerPush()
     else:
       ctx.dockerPassThrough()

--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -197,7 +197,7 @@ proc doHeartbeat(chalkOpt: Option[ChalkObj], pid: Pid, fn: (pid: Pid) -> bool) =
   trace("heartbeat: using nice " & $niceValue)
   discard nice(cint(niceValue))
 
-  setCommandName("heartbeat")
+  setFullCommandName("heartbeat")
   setRlimit(limit)
 
   while true:
@@ -297,7 +297,7 @@ proc doPostExec(state: Option[PostExecState], detach: bool) =
   discard nice(cint(niceValue))
 
   try:
-    setCommandName("postexec")
+    setFullCommandName("postexec")
     initCollection()
     if detach:
       detachFromParent()

--- a/src/commands/cmd_extract.nim
+++ b/src/commands/cmd_extract.nim
@@ -29,7 +29,7 @@ proc coreExtractFiles(path: seq[string]) =
   var numExtracts = 0
   for item in artifacts(path):
     numExtracts += 1
-  if not inSubscan() and numExtracts == 0 and getCommandName() == "extract":
+  if not inSubscan() and numExtracts == 0 and getBaseCommandName() == "extract":
     warn("No chalk marks extracted")
 
 proc coreExtractImages() =

--- a/src/commands/cmd_setup.nim
+++ b/src/commands/cmd_setup.nim
@@ -19,7 +19,7 @@ import ".."/[
 ]
 
 proc runCmdSetup*() =
-  setCommandName("setup")
+  setFullCommandName("setup")
   initCollection()
 
   let selfChalk = getSelfExtraction().getOrElse(nil)

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -31,7 +31,7 @@ import "."/[
 ]
 
 proc getChalkCommand(args: seq[Box], unused: ConfigState): Option[Box] =
-  return some(pack(getCommandName()))
+  return some(pack(getBaseCommandName()))
 
 proc getArgvLocal(args: seq[Box], unused: ConfigState): Option[Box] =
   return some(pack(getArgs()))

--- a/src/config.nim
+++ b/src/config.nim
@@ -151,8 +151,8 @@ proc getChalkExeSize*(): int =
 
 proc getChalkCommitId*(): string     = commitID
 proc getChalkPlatform*(): string     = osStr & " " & archStr
-proc getCommandName*(): string       = commandName
-proc setCommandName*(s: string, msg = "running") =
+proc getFullCommandName*(): string       = commandName
+proc setFullCommandName*(s: string, msg = "running") =
   ## Used when nesting operations.  For instance, when recursively
   ## chalking Zip files, we run a 'delete' over a copy of the Zip
   ## to calculate the unchalked hash.

--- a/src/plugins/codecZip.nim
+++ b/src/plugins/codecZip.nim
@@ -107,7 +107,9 @@ proc extractChalkMark(chalk: ChalkObj) =
       chalk.marked  = false
 
 proc subscan(chalk: ChalkObj) =
-  let cache = ZipCache(chalk.cache)
+  let
+    cache = ZipCache(chalk.cache)
+    cmd   = getBaseCommandName()
   if isSubscribedKey("EMBEDDED_CHALK"):
     let extractCtx = runChalkSubScan(@[cache.origD], "extract")
     if extractCtx.report.kind == MkSeq:
@@ -117,8 +119,8 @@ proc subscan(chalk: ChalkObj) =
                "itself chalked.")
           chalk.extract = ChalkDict()
         chalk.extract.setIfNeeded("EMBEDDED_CHALK", extractCtx.report)
-  if getCommandName() != "extract":
-    let collectionCtx = runChalkSubScan(@[cache.origD], getCommandName(), baseChalk = chalk)
+  if cmd != "extract":
+    let collectionCtx = runChalkSubScan(@[cache.origD], cmd, baseChalk = chalk)
     cache.embeddedChalk = some(collectionCtx.report)
 
 proc zipScan(self: Plugin, loc: string): Option[ChalkObj] {.cdecl.} =

--- a/src/plugins/externalTool.nim
+++ b/src/plugins/externalTool.nim
@@ -147,7 +147,7 @@ proc toolBase(path: string): ChalkDict =
 
   # tools should only run during insert operations
   # note this is a subset of chalkable operations
-  if getCommandName() notin @["build", "insert"]:
+  if getBaseCommandName() notin @["build", "insert"]:
     return result
 
   for k in getChalkSubsections("tool"):
@@ -209,7 +209,7 @@ proc toolGetChalkTimeArtifactInfo(self: Plugin, obj: ChalkObj):
   result = ChalkDict()
   if obj.fsRef != "":
     result.merge(toolBase(obj.fsRef))
-  elif getCommandName() == "build":
+  elif getBaseCommandName() == "build":
     for c in getContextDirectories():
       result.merge(toolBase(getToolPath(c)))
       # only care about first context

--- a/src/selfextract.nim
+++ b/src/selfextract.nim
@@ -80,7 +80,7 @@ proc getSelfExtraction*(): Option[ChalkObj] =
   # If we call twice and we're on a platform where we don't
   # have a codec for this type of executable, avoid dupe errors.
   once:
-    var cmd    = getCommandName()
+    var cmd    = getFullCommandName()
 
     # /proc/self/exe is a symlink hence have to use absolute path of the exe
     var myPath = getMyAppPath()
@@ -92,7 +92,7 @@ proc getSelfExtraction*(): Option[ChalkObj] =
       # path contains ~ but uid does not have home directory
       discard
 
-    setCommandName("extract")
+    setFullCommandName("extract")
 
     # This can stay here, but won't show if the log level is set in the
     # config file, since this function runs before the config files load.
@@ -133,7 +133,7 @@ proc getSelfExtraction*(): Option[ChalkObj] =
         selfChalk = i
         break
 
-      setCommandName(cmd)
+      setFullCommandName(cmd)
 
       if selfChalk == nil:
         canSelfInject = false

--- a/src/subscan.nim
+++ b/src/subscan.nim
@@ -26,11 +26,11 @@ proc runChalkSubScan*(location:     seq[string],
                       ): CollectionCtx =
   let
     oldRecursive = attrGet[bool]("recursive")
-    oldCmd       = getCommandName()
+    oldCmd       = getFullCommandName()
     oldArgs      = getArgs()
     logLevel     = getLogLevel()
 
-  setCommandName(cmd)
+  setFullCommandName(cmd)
   setArgs(location)
   trace("Running subscan. Command name is temporarily: " & cmd)
   trace("Subscan location: " & $(location))
@@ -63,7 +63,7 @@ proc runChalkSubScan*(location:     seq[string],
     if savedLogLevel.isSome():
       setLogLevel(savedLogLevel.get())
 
-    setCommandName(oldCmd, msg = "restoring from " & cmd & " to")
+    setFullCommandName(oldCmd, msg = "restoring from " & cmd & " to")
     setArgs(oldArgs)
     trace("subscan: found " & $len(result.allChalks) & " artifacts")
     trace("Subscan done. Restored command name to: " & oldCmd)


### PR DESCRIPTION

<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

`chalk extract containers` didnt send custom report as expected. It was not caught before as other commands do not have subcommands

## Description

to make it obvious what is being referenced renamed `getCommandName` to `getFullCommandName` and switched in a few places to use `getBaseCommandName`.

## Testing

```
chalk extract containers
```

and check that custom reports are sent
