### PR TITLE
feat: github job id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## On the `main` branch
 
+### New Features
+
+- Support GitHub's new
+  [`{{ job.check_run_id }}`](https://github.com/orgs/community/discussions/8945#discussioncomment-14374985):
+  - `BUILD_ID` now references job id instead of workflow ID
+  - `BUILD_URI` is now complete URI which includes both:
+    - workflow id
+    - job id (was not available before)
+
+    For example:
+
+    ```
+    https://github.com/crashappsec/chalk/actions/runs/1234/job/6789
+    ```
+
+  - As the `BUILD_URI` wont include build attempt anymore,
+    new `BUILD_ATTEMPT` key is introduced.
+
+  ([#591](https://github.com/crashappsec/chalk/pull/591))
+
 ### Fixes
 
 - Custom reports `use_when` now matches based on the base command name.

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -77,6 +77,7 @@ or vice versa.
   key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_UNIQUE_ID.use                     = true
+  key.BUILD_ATTEMPT.use                       = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -186,6 +187,8 @@ mark_template mark_large {
   key.VCS_DIR_WHEN_CHALKED.use                = true
   key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
+  key.BUILD_UNIQUE_ID.use                     = true
+  key.BUILD_ATTEMPT.use                       = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -292,6 +295,8 @@ use the mark template named `reproducable`.
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.BUILD_ID.use                            = true
+  key.BUILD_UNIQUE_ID.use                     = true
+  key.BUILD_ATTEMPT.use                       = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -373,6 +378,8 @@ the time and the nonce removed.
   key.PACKAGE_URI.use                         = true
   key.CODE_OWNERS.use                         = true
   key.BUILD_ID.use                            = true
+  key.BUILD_UNIQUE_ID.use                     = true
+  key.BUILD_ATTEMPT.use                       = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -1341,6 +1341,19 @@ key's documentation for more detail).
 """
 }
 
+keyspec BUILD_ATTEMPT {
+    kind:                ChalkTimeHost
+    type:                string
+    standard:            true
+    since:               "0.6.1"
+    shortdoc:            "CI job build attempt"
+    doc:                 """
+If present, build attempt of the specific CI job.
+Only provided by some CI integrations:
+* GitHub
+"""
+}
+
 keyspec BUILD_COMMIT_ID {
   kind:     ChalkTimeHost
   type:     string
@@ -1512,6 +1525,19 @@ for that endpoint.
 This field is generally expected to be supplied by the user, and can
 use the same substitutions allowed for the `CHALK_PTR` field (see that
 key's documentation for more detail).
+"""
+}
+
+keyspec _BUILD_ATTEMPT {
+    kind:                RunTimeHost
+    type:                string
+    standard:            true
+    since:               "0.6.1"
+    shortdoc:            "CI job build attempt"
+    doc:                 """
+If present, build attempt of the specific CI job.
+Only provided by some CI integrations:
+* GitHub
 """
 }
 

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -135,6 +135,7 @@ plugin ci_github {
     enabled:         true
     pre_run_keys:    ["BUILD_ID",
                       "BUILD_UNIQUE_ID",
+                      "BUILD_ATTEMPT",
                       "BUILD_COMMIT_ID",
                       "BUILD_URI",
                       "BUILD_API_URI",
@@ -147,6 +148,7 @@ plugin ci_github {
                       "BUILD_ORIGIN_URI"]
     post_run_keys:   ["_BUILD_ID",
                       "_BUILD_UNIQUE_ID",
+                      "_BUILD_ATTEMPT",
                       "_BUILD_COMMIT_ID",
                       "_BUILD_URI",
                       "_BUILD_API_URI",

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -98,6 +98,7 @@ report and subtract from it.
   key.VCS_MISSING_FILES.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_UNIQUE_ID.use                     = true
+  key.BUILD_ATTEMPT.use                       = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -110,6 +111,7 @@ report and subtract from it.
   key.BUILD_ORIGIN_URI.use                    = true
   key._BUILD_ID.use                           = true
   key._BUILD_UNIQUE_ID.use                    = true
+  key._BUILD_ATTEMPT.use                      = true
   key._BUILD_COMMIT_ID.use                    = true
   key._BUILD_URI.use                          = true
   key._BUILD_API_URI.use                      = true
@@ -737,6 +739,7 @@ doc: """
   key.VCS_MISSING_FILES.use                   = true
   key._BUILD_ID.use                           = true
   key._BUILD_UNIQUE_ID.use                    = true
+  key._BUILD_ATTEMPT.use                      = true
   key._BUILD_COMMIT_ID.use                    = true
   key._BUILD_URI.use                          = true
   key._BUILD_API_URI.use                      = true
@@ -749,6 +752,7 @@ doc: """
   key._BUILD_ORIGIN_URI.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_UNIQUE_ID.use                     = true
+  key.BUILD_ATTEMPT.use                       = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -1259,6 +1263,7 @@ container.
   key.VCS_MISSING_FILES.use                   = true
   key._BUILD_ID.use                           = true
   key._BUILD_UNIQUE_ID.use                    = true
+  key._BUILD_ATTEMPT.use                      = true
   key._BUILD_COMMIT_ID.use                    = true
   key._BUILD_URI.use                          = true
   key._BUILD_API_URI.use                      = true
@@ -1271,6 +1276,7 @@ container.
   key._BUILD_ORIGIN_URI.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_UNIQUE_ID.use                     = true
+  key.BUILD_ATTEMPT.use                       = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true
@@ -1766,6 +1772,7 @@ and keep the run-time key.
   key.VCS_MISSING_FILES.use                   = true
   key._BUILD_ID.use                           = true
   key._BUILD_UNIQUE_ID.use                    = true
+  key._BUILD_ATTEMPT.use                      = true
   key._BUILD_COMMIT_ID.use                    = true
   key._BUILD_URI.use                          = true
   key._BUILD_API_URI.use                      = true
@@ -1778,6 +1785,7 @@ and keep the run-time key.
   key._BUILD_ORIGIN_URI.use                   = true
   key.BUILD_ID.use                            = true
   key.BUILD_UNIQUE_ID.use                     = true
+  key.BUILD_ATTEMPT.use                       = true
   key.BUILD_COMMIT_ID.use                     = true
   key.BUILD_URI.use                           = true
   key.BUILD_API_URI.use                       = true

--- a/src/plugins/ciGithub.nim
+++ b/src/plugins/ciGithub.nim
@@ -52,7 +52,8 @@ proc getGithubMetadata(self: Plugin, prefix=""): ChalkDict =
     GITHUB_REPOSITORY          = getEnv("GITHUB_REPOSITORY")
     GITHUB_REPOSITORY_ID       = getEnv("GITHUB_REPOSITORY_ID")
     GITHUB_REPOSITORY_OWNER_ID = getEnv("GITHUB_REPOSITORY_OWNER_ID")
-    GITHUB_RUN_ID              = getEnv("GITHUB_RUN_ID")
+    GITHUB_RUN_ID              = getEnv("GITHUB_RUN_ID") # workflow ID
+    GITHUB_CHECK_RUN_ID        = getEnv("GITHUB_CHECK_RUN_ID") # job ID - set by setup-chalk-action
     GITHUB_RUN_ATTEMPT         = getEnv("GITHUB_RUN_ATTEMPT")
     GITHUB_API_URL             = getEnv("GITHUB_API_URL")
     GITHUB_ACTOR               = getEnv("GITHUB_ACTOR")
@@ -63,11 +64,12 @@ proc getGithubMetadata(self: Plugin, prefix=""): ChalkDict =
   # probably not running in github CI
   if CI == "" and GITHUB_SHA == "": return
 
-  result.setIfNeeded(prefix & "BUILD_ID",              GITHUB_RUN_ID)
+  result.setIfNeeded(prefix & "BUILD_ID",              coalesce(GITHUB_CHECK_RUN_ID, GITHUB_RUN_ID))
   result.setIfNeeded(prefix & "BUILD_COMMIT_ID",       GITHUB_SHA)
   result.setIfNeeded(prefix & "BUILD_ORIGIN_ID",       GITHUB_REPOSITORY_ID)
   result.setIfNeeded(prefix & "BUILD_ORIGIN_OWNER_ID", GITHUB_REPOSITORY_OWNER_ID)
   result.setIfNeeded(prefix & "BUILD_API_URI",         GITHUB_API_URL)
+  result.setIfNeeded(prefix & "BUILD_ATTEMPT",         GITHUB_RUN_ATTEMPT)
 
   if RUNNER_TEMP != "":
     # RUNNER_TEMP is automatically cleaned up by GitHub at the end of the job execution
@@ -78,14 +80,19 @@ proc getGithubMetadata(self: Plugin, prefix=""): ChalkDict =
       getOrWriteExclusiveFile(uniquePath, secureRand[uint64]().toHex().toLower()),
     )
 
-  if (GITHUB_SERVER_URL != "" and GITHUB_REPOSITORY != "" and
-      GITHUB_RUN_ID != ""):
+  if GITHUB_SERVER_URL != "" and GITHUB_REPOSITORY != "" and GITHUB_RUN_ID != "":
     let base = (
       GITHUB_SERVER_URL.strip(leading = false, chars = {'/'}) & "/" &
       GITHUB_REPOSITORY.strip(chars = {'/'})
     )
+    # https://github.com/crashappsec/setup-chalk-action-test/actions/runs/17955140101/job/51064362862
     var uri = base & "/actions/runs/" & GITHUB_RUN_ID
-    if GITHUB_RUN_ATTEMPT != "":
+    # check id is set by the setup-chalk-action
+    # but its not an official env var just yet as its only available via github job context
+    # https://github.com/orgs/community/discussions/8945#discussioncomment-14374985
+    if GITHUB_CHECK_RUN_ID != "":
+      uri = uri.strip(chars = {'/'}) & "/job/" & GITHUB_CHECK_RUN_ID
+    elif GITHUB_RUN_ATTEMPT != "":
       uri = uri.strip(chars = {'/'}) & "/attempts/" & GITHUB_RUN_ATTEMPT
     result.setIfNeeded(prefix & "BUILD_ORIGIN_URI", base)
     result.setIfNeeded(prefix & "BUILD_URI",        uri)

--- a/src/utils/strings.nim
+++ b/src/utils/strings.nim
@@ -84,3 +84,9 @@ proc startsWithAnyOf*(s: string, suffixes: openArray[string]): bool =
     if s.startsWith(i):
       return true
   return false
+
+proc coalesce*(data: varargs[string]): string =
+  for s in data:
+    if s != "":
+      return s
+  return ""

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -114,6 +114,7 @@ def test_github(
         "GITHUB_SERVER_URL": "https://github.com",
         "GITHUB_REPOSITORY": "octocat/Hello-World",
         "GITHUB_RUN_ID": "1658821493",
+        "GITHUB_CHECK_RUN_ID": "51064362862",
         "GITHUB_RUN_ATTEMPT": "5",
         "GITHUB_API_URL": server_imds,
         "GITHUB_ACTOR": "octocat",
@@ -128,18 +129,19 @@ def test_github(
     insert = chalk.insert(bin_path, env=env)
     assert insert.report.contains(
         {
-            "BUILD_ID": "1658821493",
+            "BUILD_ID": "51064362862",
             "BUILD_UNIQUE_ID": str,
             "BUILD_COMMIT_ID": "ffac537e6cbbf934b08745a378932722df287a53",
             "BUILD_TRIGGER": "tag",
             "BUILD_CONTACT": ["octocat"],
-            "BUILD_URI": "https://github.com/octocat/Hello-World/actions/runs/1658821493/attempts/5",
+            "BUILD_URI": "https://github.com/octocat/Hello-World/actions/runs/1658821493/job/51064362862",
             "BUILD_API_URI": server_imds,
             "BUILD_ORIGIN_ID": "123",
             "BUILD_ORIGIN_KEY": "abc",
             "BUILD_ORIGIN_OWNER_ID": "456",
             "BUILD_ORIGIN_OWNER_KEY": "xyz",
             "BUILD_ORIGIN_URI": "https://github.com/octocat/Hello-World",
+            "BUILD_ATTEMPT": "5",
         }
     )
     insert2 = chalk.insert(bin_path, env=env)
@@ -148,18 +150,19 @@ def test_github(
     env = chalk.run(command="env", env=env)
     assert env.report.contains(
         {
-            "_BUILD_ID": "1658821493",
+            "_BUILD_ID": "51064362862",
             "_BUILD_UNIQUE_ID": str,
             "_BUILD_COMMIT_ID": "ffac537e6cbbf934b08745a378932722df287a53",
             "_BUILD_TRIGGER": "tag",
             "_BUILD_CONTACT": ["octocat"],
-            "_BUILD_URI": "https://github.com/octocat/Hello-World/actions/runs/1658821493/attempts/5",
+            "_BUILD_URI": "https://github.com/octocat/Hello-World/actions/runs/1658821493/job/51064362862",
             "_BUILD_API_URI": server_imds,
             "_BUILD_ORIGIN_ID": "123",
             "_BUILD_ORIGIN_KEY": "abc",
             "_BUILD_ORIGIN_OWNER_ID": "456",
             "_BUILD_ORIGIN_OWNER_KEY": "xyz",
             "_BUILD_ORIGIN_URI": "https://github.com/octocat/Hello-World",
+            "_BUILD_ATTEMPT": "5",
         }
     )
 


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

fixes https://github.com/crashappsec/chalk/issues/318

## Description

now that job.check_run_id is available, use it to construct full github build uri

previously only including the workflow id in the build uri had some edge cases:

* matrix builds. It was not possible to determine from which job did the chalk report originate from as multiple jobs were grouped under a single workflow
* multiple named jobs in a single workflow. Similarly all jobs share the same workflow id hence the build URI wasnt precise enough

This was a GitHub limitation which is now partially resolved as it exposes the job id as a github context variable although not yet as an env var therefore for now chalk will rely on setup-chalk-action actually setting the env var for chalk to read. Otherwise it will fallback to previous behavior.

## Testing

```
➜ maketest test_plugins.py::test_github
```
