### PR TITLE
feat: native model-file codecs (safetensors, gguf, zip-extension, sidecar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@
   when either `codesign` or `rcodesign` is available.
   Otherwise binary will not be runnable on macs anymore.
   ([657](https://github.com/crashappsec/chalk/pull/657))
+- New codecs:
+  - `gguf` - This codec marks `.gguf` (GGUF v2/v3) ML model files in place. The
+    chalk mark is inserted as a string KV pair `chalk.mark` in the
+    metadata section. GGUF tensor data offsets are relative to the data
+    section start, so the codec recomputes the alignment padding when
+    the KV section size changes — leaving offsets valid.
+  - `safetensors` - This codec marks `.safetensors` ML model files in place. The chalk
+    mark is inserted as a string value under `__metadata__.chalk` in the
+    file's JSON header — which is the location the SafeTensors format
+    reserves for arbitrary user metadata. Tensor `data_offsets` are
+    relative to the data section start, so the header may grow without
+    breaking offsets.
+  - `sidecar` - Last-resort codec for ML model files that can't be marked in-band.
+    The codec writes a `<path>.chalk` sidecar file alongside the
+    artifact containing the chalk-mark JSON; the artifact's bytes are
+    not modified. On extract the sidecar is read back as the mark.
+
+  ([#658](https://github.com/crashappsec/chalk/pull/658))
+
+- New caller attestation plugin. The plugin ingests a JSON envelope from the
+  spawning process — either inline via `CHALK_CALLER_ATTESTATION` or from a
+  file path in `CHALK_CALLER_ATTESTATION_FILE`. It allows a trusted system daemon
+  like `crayon` to inject useful metadata into the artifact which otherwise
+  chalk cannot derive.
+  ([#658](https://github.com/crashappsec/chalk/pull/658))
 
 ## 1.0.2
 

--- a/docs/design-caller-attestation.md
+++ b/docs/design-caller-attestation.md
@@ -1,0 +1,375 @@
+# Caller-attestation protocol
+
+Chalk's `insert` and `docker` paths now accept a structured attestation
+blob from the parent process — typically a system-spawned endpoint
+agent (Crayon being the motivating consumer) that knows things about
+an artifact chalk itself cannot derive: provenance ("this model came
+from huggingface"), build context, host context, and identifying
+information about the attestor itself.
+
+The attestation is informational, not authoritative. Chalk records
+what it is told and surfaces a discrepancy when its own observations
+disagree with the caller. The trust assumption is that the caller is
+a system process spawning chalk as the user; on Linux/macOS that is
+sufficient isolation for the use case.
+
+This document specifies the wire format, validation rules, status
+semantics, and where the data lands. Everything here is a contract:
+changing it after the fact requires a version bump.
+
+## Channel
+
+Two channels, in priority order:
+
+1. **`CHALK_CALLER_ATTESTATION`** — JSON envelope passed inline as an
+   environment variable.
+2. **`CHALK_CALLER_ATTESTATION_FILE`** — absolute path to a file
+   containing the same JSON envelope. Read only when
+   `CHALK_CALLER_ATTESTATION` is unset.
+
+The env-var channel is convenient but bounded by `ARG_MAX` (~256 KB
+on macOS, larger on Linux). Large attestations (signed VC chains,
+SBOM excerpts) should use the file channel; the caller may unlink the
+file after spawning chalk so secrets don't persist on disk.
+
+stdin is deliberately not a channel. `chalk docker` already consumes
+stdin in some flows; reusing it for attestation would conflict.
+
+If both env vars are unset, the attestation feature is inert. No
+message is logged. This is the common case for direct-CLI use.
+
+## Envelope
+
+```json
+{
+  "version": 1,
+
+  "CALLER_ATTESTED_INFO":         { "...": "about the attestor" },
+  "CALLER_ATTESTED_HOST_INFO":    { "...": "about the host" },
+  "CALLER_ATTESTED_BUILD_INFO":   { "...": "about the build" },
+
+  "CALLER_ATTESTED_ARTIFACT_INFO": {
+    "/abs/realpath/to/artifact": {
+      "sha256": "<lowercase hex>",
+      "info":   { "...": "free-form, opaque to chalk" }
+    }
+  }
+}
+```
+
+- **`version`** is required and must be `1` for this revision. An
+  unknown major version causes the envelope to be rejected with an
+  `error`-level log; chalk continues without attestation. Minor
+  versions can be added compatibly by extending top-level keys.
+- The four `CALLER_ATTESTED_*` keys are individually optional — any
+  combination is valid, including all four omitted (in which case
+  the envelope was pointless but is not an error).
+- Any other top-level key whose name matches `X-*` is allowed and
+  passed through untouched (forward-compat slot for caller
+  experimentation). Other unknown top-level keys are warned about
+  and dropped.
+- Each of the three host/build/info buckets is an object. Its inner
+  shape is opaque to chalk. Chalk does not validate, transform, or
+  redact it.
+- `CALLER_ATTESTED_ARTIFACT_INFO`'s value is an object whose keys are
+  paths and whose values are objects with the strict shape
+  `{ "sha256": string, "info": any }`. Any other shape rejects the
+  whole envelope.
+
+## Path-matching contract
+
+The caller MUST provide each artifact path as the **fully resolved
+absolute path with no symbolic links remaining** — i.e., the path that
+`realpath(3)` would produce. Chalk does not normalize on the caller's
+behalf. This is an explicit, documented contract: callers are system
+processes that already know their own filesystem layout, and pushing
+normalization to the caller eliminates an entire class of "the caller
+sent `./model.onnx` and chalk processed `/work/model.onnx`" bugs.
+
+Chalk on the receiving side computes the same realpath for each
+artifact it processes and matches against attestation entries by
+exact string equality. Anything not matched goes to the untracked
+bucket (see below).
+
+## Per-artifact value: status wrapper
+
+The value emitted into a chalked artifact's mark and reports under
+`CALLER_ATTESTED_ARTIFACT_INFO` is **always** the wrapped form below.
+The raw caller payload is never emitted directly.
+
+```json
+// status: match — common case
+{ "status": "match", "info": { ... } }
+
+// status: mismatch — caller-attested hash differs from chalk's
+// unchalked hash for the artifact.  Race condition or tampering.
+{
+  "status":          "mismatch",
+  "attested_sha256": "<from caller>",
+  "observed_sha256": "<chalk's unchalked hash>",
+  "info":            { ... }
+}
+
+// status: unverified — chalk could not compute an unchalked hash
+// for this artifact (codec didn't produce one, or the file moved
+// between scan and hash).  Treat as an integrity gap, not a match.
+{
+  "status":          "unverified",
+  "attested_sha256": "<from caller>",
+  "info":            { ... }
+}
+```
+
+Hashes surface in the mark only on `mismatch` / `unverified`. On
+`match` chalk has independently confirmed the attested hash; there is
+no value in echoing it back. This keeps marks compact in the common
+case and makes any appearance of an `attested_sha256`/`observed_sha256`
+pair a reliable signal that something needs investigation.
+
+`mismatch` and `unverified` each emit a `warn`-level log line naming
+the artifact and the status. The chalk operation does not abort —
+the attestation is recorded, the status flags the concern, and
+downstream tooling decides policy.
+
+## Untracked artifacts
+
+A `CALLER_ATTESTED_ARTIFACT_INFO` entry whose path does not match any
+artifact chalk ends up tracking is aggregated into a host-level key:
+
+```json
+"CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO": {
+  "/abs/path": { "sha256": "<hex>", "info": { ... } }
+}
+```
+
+No status wrapper — chalk never observed the file, so there is
+nothing to compare. Each untracked entry emits a `warn` log line.
+
+Common reasons a path lands here:
+- The caller hashed a file and chalk didn't end up scanning it
+  (filtered by ignore list, removed mid-flight, etc.).
+- The caller's path didn't survive realpath on the chalk side
+  (caller violated the contract above).
+- For `chalk docker`, a path that isn't inside any build context.
+
+## Docker semantics
+
+For `chalk docker build` (and other docker subcommands that produce
+an artifact), the caller's contract is:
+
+> Every path under `CALLER_ATTESTED_ARTIFACT_INFO` MUST be inside one
+> of the build's context directories.
+
+Chalk-docker enumerates the context dirs from the invocation —
+positional context, plus any `--build-context name=path` entries —
+and `realpath`s each. For each attested path, chalk checks that it
+starts with one of those realpaths. If yes, chalk reads the file
+from the host filesystem, computes its SHA-256, and emits the status
+wrapper into the **image's** mark. If no, it goes to the untracked
+bucket with a `warn`.
+
+Chalk does **not** attempt to map host paths to in-image paths.
+The caller's mental model is host-side; chalk records what was said
+about which host file, and the consumer of the mark decides how to
+reconcile that with the resulting image layout.
+
+The host/build/info buckets pass through unchanged — they're
+attached to the image's mark just as they would be to any other
+artifact's host-level keys.
+
+## Top-level proxying
+
+The non-artifact buckets are proxied to top-level chalk keys, name
+preserved:
+
+| Caller envelope key                | Chalk key (host-level)             |
+| ---------------------------------- | ---------------------------------- |
+| `CALLER_ATTESTED_INFO`             | `CALLER_ATTESTED_INFO`             |
+| `CALLER_ATTESTED_HOST_INFO`        | `CALLER_ATTESTED_HOST_INFO`        |
+| `CALLER_ATTESTED_BUILD_INFO`       | `CALLER_ATTESTED_BUILD_INFO`       |
+
+Each is a free-form object; chalk does not destructure, validate, or
+transform.
+
+## Keyspecs and templates
+
+Five new chalk keys, all of con4m type `` `x `` (free-form, mirroring
+the existing pattern used for nested data):
+
+- `CALLER_ATTESTED_INFO` — `ChalkTimeHost`
+- `CALLER_ATTESTED_HOST_INFO` — `ChalkTimeHost`
+- `CALLER_ATTESTED_BUILD_INFO` — `ChalkTimeHost`
+- `CALLER_ATTESTED_ARTIFACT_INFO` — `ChalkTimeArtifact`
+- `CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO` — `ChalkTimeHost`
+
+Mark templates take the four chalk-time keys (the `RunTimeHost`
+`CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO` is collected after marks
+are written and so cannot land in a mark by construction):
+- `mark_default` (covers all chalking ops, including docker — chalk
+  uses one mark template across the board)
+- `mark_all` and `mark_large`
+
+Report templates take all five keys:
+- `report_default`
+- `insertion_default`
+- `report_all` and `report_large`
+
+Explicitly **not** added to `mark_reproducable`. Attested payloads
+are not deterministic by design (timestamps, build IDs, attestor
+identity all vary), and the reproducible template's purpose is
+bit-for-bit reproducibility.
+
+## Validation and failure handling
+
+Validation is performed once, eagerly, when the attestation plugin
+is initialized:
+
+1. JSON parse — failure → `error` log, attestation discarded, chalk
+   continues without it. Exit code unaffected.
+2. Top-level must be an object.
+3. `version` must be present and equal to `1`.
+4. Each recognized `CALLER_ATTESTED_*` key, if present, must be an
+   object.
+5. `CALLER_ATTESTED_ARTIFACT_INFO`'s entries must each have a
+   `sha256` (lowercase hex, length 64) and may have an `info` of any
+   JSON type. No other fields are allowed in the per-entry shape.
+6. Unknown top-level keys not matching `X-*` → `warn`, then dropped.
+
+A validation failure at any non-soft step (1–5) discards the entire
+attestation. Half-applying a malformed envelope would be worse than
+applying none. The chalk operation continues; no attestation keys
+appear in the mark or report.
+
+## Plugin shape
+
+A single new plugin, `caller_attestation`:
+- Reads + parses + validates the envelope on first invocation.
+- Caches the parsed result for the lifetime of the chalk process.
+- `ctHostCallback` emits the three top-level buckets and (after
+  artifact iteration is complete) the untracked-artifact aggregate.
+- `ctArtCallback` per artifact: looks up by realpath, computes the
+  status wrapper against the artifact's unchalked hash, emits.
+
+The plugin does no I/O of its own beyond the initial envelope read.
+No network calls, no signature verification (the attestation is
+informational, not cryptographic). If signed attestations become
+interesting later, they slot in as `CALLER_ATTESTED_INFO.signature`
+on the caller side and a downstream verifier — not chalk's job.
+
+## Examples
+
+### Single-artifact insert
+
+Caller writes `/work/models/llama.gguf`, hashes it, then spawns:
+
+```sh
+CHALK_CALLER_ATTESTATION='{
+  "version": 1,
+  "CALLER_ATTESTED_INFO": {
+    "attestor": "crayon-file-tracker",
+    "attestor_version": "0.4.1"
+  },
+  "CALLER_ATTESTED_ARTIFACT_INFO": {
+    "/work/models/llama.gguf": {
+      "sha256": "ab12...ef",
+      "info": {
+        "source": "huggingface",
+        "repo":   "meta-llama/Llama-2-7b-gguf",
+        "revision": "v1.0"
+      }
+    }
+  }
+}' chalk insert /work/models/llama.gguf
+```
+
+Chalk hashes the file, gets a match, and the resulting GGUF mark
+contains:
+
+```json
+"CALLER_ATTESTED_INFO": { "attestor": "crayon-file-tracker", ... },
+"CALLER_ATTESTED_ARTIFACT_INFO": {
+  "status": "match",
+  "info": { "source": "huggingface", ... }
+}
+```
+
+### Race-condition mismatch
+
+Same call, but the file is rewritten between the caller hashing it
+and chalk processing it. Chalk's unchalked hash differs from
+`attested_sha256`. The mark records:
+
+```json
+"CALLER_ATTESTED_ARTIFACT_INFO": {
+  "status": "mismatch",
+  "attested_sha256": "ab12...ef",
+  "observed_sha256": "9f44...01",
+  "info": { "source": "huggingface", ... }
+}
+```
+
+and chalk logs at `warn`:
+
+> `/work/models/llama.gguf`: caller-attested hash mismatch (attested
+> ab12…ef, observed 9f44…01); attestation recorded with status
+> "mismatch".
+
+### Untracked attestation
+
+Caller attests two files but only one is actually scanned (e.g., the
+other is in an ignored path). The scanned one's mark gets the
+normal `CALLER_ATTESTED_ARTIFACT_INFO` entry; the operation's
+host-level keys also include:
+
+```json
+"CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO": {
+  "/work/cache/intermediate.bin": {
+    "sha256": "...",
+    "info":   { ... }
+  }
+}
+```
+
+with a `warn` per untracked path.
+
+### Docker build, multi-context
+
+```sh
+CHALK_CALLER_ATTESTATION_FILE=/run/crayon/attest.json \
+  chalk docker build \
+    --build-context vendor=/opt/vendor-deps \
+    -t myimg /work/repo
+```
+
+Chalk realpaths `/work/repo` and `/opt/vendor-deps`, then for each
+attested path checks membership in either. In-context paths get
+host-side hashed and emitted into the image's mark; out-of-context
+paths land in the untracked bucket.
+
+## Non-goals
+
+- **Schema enforcement on the inner `info` payloads.** Free-form is
+  the contract. If a downstream consumer wants schema discipline,
+  that's an agreement between the caller and that consumer.
+- **Signature verification.** The trust model is process-spawning,
+  not cryptographic. Signed attestations are out of scope; if added
+  later, they live inside `CALLER_ATTESTED_INFO`.
+- **Mapping host paths to in-image paths for docker.** Caller-side
+  concern.
+- **Mutating attestations across re-chalk operations.** The current
+  attestation overwrites whatever was there last; preserving history
+  is the job of `OLD_CHALK_METADATA_*`.
+
+## Open questions to resolve before implementation
+
+None blocking. Items deferred to the implementation PR or follow-ups:
+
+- The exact name and registration spot for the new plugin (likely
+  `src/plugins/callerAttestation.nim`, registered in
+  `base_plugins.c4m`).
+- Whether the file-channel read should use `O_NOFOLLOW` to reject
+  symlinks (defensive — the caller is trusted but symlink swaps are
+  cheap to defend against).
+- Whether to add a unit test that exercises envelope validation with
+  malformed JSON / wrong version / wrong shape, separate from any
+  end-to-end functional test.

--- a/docs/design-caller-attestation.md
+++ b/docs/design-caller-attestation.md
@@ -44,14 +44,14 @@ message is logged. This is the common case for direct-CLI use.
 {
   "version": 1,
 
-  "CALLER_ATTESTED_INFO":         { "...": "about the attestor" },
-  "CALLER_ATTESTED_HOST_INFO":    { "...": "about the host" },
-  "CALLER_ATTESTED_BUILD_INFO":   { "...": "about the build" },
+  "CALLER_ATTESTED_INFO": { "...": "about the attestor" },
+  "CALLER_ATTESTED_HOST_INFO": { "...": "about the host" },
+  "CALLER_ATTESTED_BUILD_INFO": { "...": "about the build" },
 
   "CALLER_ATTESTED_ARTIFACT_INFO": {
     "/abs/realpath/to/artifact": {
       "sha256": "<lowercase hex>",
-      "info":   { "...": "free-form, opaque to chalk" }
+      "info": { "...": "free-form, opaque to chalk" }
     }
   }
 }
@@ -146,6 +146,7 @@ No status wrapper — chalk never observed the file, so there is
 nothing to compare. Each untracked entry emits a `warn` log line.
 
 Common reasons a path lands here:
+
 - The caller hashed a file and chalk didn't end up scanning it
   (filtered by ignore list, removed mid-flight, etc.).
 - The caller's path didn't survive realpath on the chalk side
@@ -182,11 +183,11 @@ artifact's host-level keys.
 The non-artifact buckets are proxied to top-level chalk keys, name
 preserved:
 
-| Caller envelope key                | Chalk key (host-level)             |
-| ---------------------------------- | ---------------------------------- |
-| `CALLER_ATTESTED_INFO`             | `CALLER_ATTESTED_INFO`             |
-| `CALLER_ATTESTED_HOST_INFO`        | `CALLER_ATTESTED_HOST_INFO`        |
-| `CALLER_ATTESTED_BUILD_INFO`       | `CALLER_ATTESTED_BUILD_INFO`       |
+| Caller envelope key          | Chalk key (host-level)       |
+| ---------------------------- | ---------------------------- |
+| `CALLER_ATTESTED_INFO`       | `CALLER_ATTESTED_INFO`       |
+| `CALLER_ATTESTED_HOST_INFO`  | `CALLER_ATTESTED_HOST_INFO`  |
+| `CALLER_ATTESTED_BUILD_INFO` | `CALLER_ATTESTED_BUILD_INFO` |
 
 Each is a free-form object; chalk does not destructure, validate, or
 transform.
@@ -205,11 +206,13 @@ the existing pattern used for nested data):
 Mark templates take the four chalk-time keys (the `RunTimeHost`
 `CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO` is collected after marks
 are written and so cannot land in a mark by construction):
+
 - `mark_default` (covers all chalking ops, including docker — chalk
   uses one mark template across the board)
 - `mark_all` and `mark_large`
 
 Report templates take all five keys:
+
 - `report_default`
 - `insertion_default`
 - `report_all` and `report_large`
@@ -243,6 +246,7 @@ appear in the mark or report.
 ## Plugin shape
 
 A single new plugin, `caller_attestation`:
+
 - Reads + parses + validates the envelope on first invocation.
 - Caches the parsed result for the lifetime of the chalk process.
 - `ctHostCallback` emits the three top-level buckets and (after

--- a/docs/design-model-codecs.md
+++ b/docs/design-model-codecs.md
@@ -147,24 +147,83 @@ plugin (or a minor extension to `codecZip`'s `ctArtCallback`) emits
 torch ≥ 1.6 (or with `_use_new_zipfile_serialization=False`) are pure
 pickle, not ZIP. They land on the sidecar codec.
 
-### Sidecar fallback
+### Sidecar codec — narrow carve-out
 
-Last-resort codec for files that don't match any in-band format.
-Writes `<path>.chalk` next to the artifact containing the mark JSON,
-one line, terminated. Lower priority (lower number) than every
-format-specific codec, but still extension-gated to a configured
-`sidecar_extensions` list — the codec is not a global fallthrough,
-it's a deliberate "we recognize this as an ML model but cannot mark
-in-band" path.
+Chalk has no precedent for an external `.chalk` file next to an
+artifact. Every existing codec marks in-place: ELF section,
+Mach-O `LC_NOTE`, ZIP entry, source-comment, script wrapper,
+last-resort EOF append. The sidecar mechanism introduced here is a
+**deliberate exception** for one specific class of artifact, not a
+generalized escape hatch when an in-band codec can't claim a file.
 
-Default `sidecar_extensions`: `["onnx", "bin"]`. PyTorch legacy
-`.pt`/`.pth` pickle files are picked up if `codecZip`'s scan refuses
-them (magic mismatch).
+**Why it's needed.** ML model artifacts in formats we can't yet
+mark in-band (`.onnx` until protobuf support, `.bin` opaque blobs,
+legacy non-ZIP pickle `.pt`/`.pth`) are **non-executable data
+files** consumed by loaders that mmap them, validate format
+invariants, or run integrity checks (`onnxruntime.InferenceSession`,
+legacy `torch.load` pickle parser, `llama.cpp` GGUF reader-style
+checks). The chalk patterns that work for executable artifacts
+don't translate:
 
-Mark JSON is identical to in-band marks — same keys, same `HASH`
-semantics (sidecar's `HASH` is the natural file SHA-256, since
-nothing is mutated). Read path: `chalk extract <model.bin>` looks for
-`<path>.chalk` and parses it.
+- **Script-wrapper rewrite (à la `codecMacOs`).** Replaces the
+  binary with a shell script that re-execs after validation. ML
+  model files aren't executable; loaders fail immediately on the
+  shebang.
+- **EOF append (à la `elf_last_resort`).** Works because ELF
+  tolerates trailing junk. ONNX (protobuf), pickle, and raw `.bin`
+  do not — appending bytes either fails parse or silently corrupts
+  the loaded tensor.
+- **ZIP rewrap.** Wrapping a non-ZIP artifact inside a ZIP archive
+  with a `chalk.json` would be self-consistent inside chalk, but
+  changes the file's bytes and format. Loaders break. The cost to
+  pipelines outweighs the marking value.
+- **`--virtual` (the user-facing dry-run flag).** Exists already
+  but is a *user choice* to skip artifact mutation entirely; not a
+  codec-level handler for "this format can't be marked in-band."
+
+**Why not just refuse the artifact.** Returning `none(ChalkObj)`
+from `scan` is the standard "this codec doesn't handle X." If no
+other codec claims either, chalk silently ignores the file. That
+loses identity (CHALK_ID, HASH, extraction-by-path) for ML files
+the user clearly wants chalked. Sidecar gives chalk the same
+visibility for these files as for any other — the artifact is
+known, hashed, identifiable — at the cost of a sibling file.
+
+**Why this carve-out doesn't generalize.** The argument here turns
+on a property *specific* to ML model artifacts: they are
+non-executable, format-strict data that consumers do not tolerate
+modification of. Executable artifacts have always had an in-band
+option in chalk (the existing codecs prove this). Configuration
+files, source files, archives all have in-band options. Adding a
+sidecar to those for which an in-band option already exists would
+weaken chalk's "the mark lives with the artifact" invariant for
+no real gain. The codec is therefore strictly extension-gated to
+the small list below; expanding it is a per-format design
+decision, not a free-for-all.
+
+**Layout.**
+
+- Codec at `src/plugins/codecModelSidecar.nim`. Priority 1500
+  (below every format-specific codec; safetensors, gguf, zip
+  always get first chance).
+- Extension allowlist `sidecar_extensions` (default:
+  `onnx`, `bin`, `pt`, `pth`). PyTorch / Keras checkpoints whose
+  `.pt`/`.pth` files are ZIP-shaped will be claimed by `codecZip`
+  first; only the legacy pickle `.pt`/`.pth` files reach the
+  sidecar codec.
+- Sidecar file is `<path>.chalk`, one line of mark JSON, terminated.
+- `HASH` is the natural file SHA-256 — no canonicalization needed
+  since the artifact's bytes are never modified.
+- Extension list and allowlist semantics are documented in the
+  plugin's c4m doc string and `chalk.c42spec` field doc.
+
+**Operational notes.** A two-file invariant means moving the
+artifact without its `.chalk` produces an orphaned mark on the
+source side and an unmarked artifact on the destination. Chalk
+behaves correctly in both cases (extract-by-path on the destination
+returns no mark; the source `.chalk` becomes garbage). A future
+follow-up could publish sidecar-mark events to the egress sink so
+operators can detect drift; out of scope here.
 
 ## Repo layout
 

--- a/docs/design-model-codecs.md
+++ b/docs/design-model-codecs.md
@@ -30,19 +30,19 @@ only, or add a new keyspec.
 The motivating crayon-side prototype today has these keys in its
 mark; column three is the audit decision.
 
-| Concept | Crayon prototype today | Decision |
-|---|---|---|
-| Magic / version / identity | `MAGIC`, `CHALK_VERSION`, `CHALK_ID`, `METADATA_ID`, `METADATA_HASH`, `HASH`, `CHALK_RAND` | Reuse — chalk's standard mark already includes these. |
-| Timestamp | `TIMESTAMP_WHEN_CHALKED` | Reuse. |
-| Host | `HOST_NODENAME_WHEN_CHALKED`, `PLATFORM_WHEN_CHALKED` | Reuse. |
-| Path | `PATH_WHEN_CHALKED` | Reuse. |
-| Re-chalking lineage | `OLD_CHALK_METADATA_HASH`, `OLD_CHALK_METADATA_ID` | Reuse. |
-| File format | `CRAYON_FILE_FORMAT` | **Drop.** Use specific `ARTIFACT_TYPE` values (see below). |
-| Model identifier (`meta-llama/Llama-2-7b`, `llama2:7b`) | `CRAYON_MODEL_ID` | **Reuse `ORIGIN_URI`** — synthesize URI per source family: `https://huggingface.co/{org}/{name}`, `ollama://{name}:{tag}`. Treats hosted-model-card semantics the way `ORIGIN_URI` already treats VCS repository origin. |
-| Source family hint (`huggingface` / `ollama` / `local`) | `CRAYON_SOURCE` | **Drop.** Derivable from `ORIGIN_URI` scheme/host at report time. |
-| Triggering process | `CRAYON_DOWNLOADER_UID`, `CRAYON_DOWNLOADER_EXE` | **Drop from on-disk mark.** Belongs in the chalk operation report, not the artifact. The `INJECTOR_*` family already covers chalk's own identity; the upstream caller is correlation context that crayon emits in its own NDJSON. |
-| Session correlation | `CRAYON_SESSION_ID` | **Drop from on-disk mark.** Crayon-internal runtime correlation; redundant with crayon's NDJSON. |
-| Conversion lineage (CHALK_ID of source after ST → GGUF) | `DERIVED_FROM` | **NEW keyspec: `DERIVED_FROM_CHALK_ID`.** Type string. Kind `ChalkTimeArtifact`. General-purpose lineage — not ML-specific; any in-place file conversion can carry it. Drafted alongside this PR set. |
+| Concept                                                 | Crayon prototype today                                                                     | Decision                                                                                                                                                                                                                          |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Magic / version / identity                              | `MAGIC`, `CHALK_VERSION`, `CHALK_ID`, `METADATA_ID`, `METADATA_HASH`, `HASH`, `CHALK_RAND` | Reuse — chalk's standard mark already includes these.                                                                                                                                                                             |
+| Timestamp                                               | `TIMESTAMP_WHEN_CHALKED`                                                                   | Reuse.                                                                                                                                                                                                                            |
+| Host                                                    | `HOST_NODENAME_WHEN_CHALKED`, `PLATFORM_WHEN_CHALKED`                                      | Reuse.                                                                                                                                                                                                                            |
+| Path                                                    | `PATH_WHEN_CHALKED`                                                                        | Reuse.                                                                                                                                                                                                                            |
+| Re-chalking lineage                                     | `OLD_CHALK_METADATA_HASH`, `OLD_CHALK_METADATA_ID`                                         | Reuse.                                                                                                                                                                                                                            |
+| File format                                             | `CRAYON_FILE_FORMAT`                                                                       | **Drop.** Use specific `ARTIFACT_TYPE` values (see below).                                                                                                                                                                        |
+| Model identifier (`meta-llama/Llama-2-7b`, `llama2:7b`) | `CRAYON_MODEL_ID`                                                                          | **Reuse `ORIGIN_URI`** — synthesize URI per source family: `https://huggingface.co/{org}/{name}`, `ollama://{name}:{tag}`. Treats hosted-model-card semantics the way `ORIGIN_URI` already treats VCS repository origin.          |
+| Source family hint (`huggingface` / `ollama` / `local`) | `CRAYON_SOURCE`                                                                            | **Drop.** Derivable from `ORIGIN_URI` scheme/host at report time.                                                                                                                                                                 |
+| Triggering process                                      | `CRAYON_DOWNLOADER_UID`, `CRAYON_DOWNLOADER_EXE`                                           | **Drop from on-disk mark.** Belongs in the chalk operation report, not the artifact. The `INJECTOR_*` family already covers chalk's own identity; the upstream caller is correlation context that crayon emits in its own NDJSON. |
+| Session correlation                                     | `CRAYON_SESSION_ID`                                                                        | **Drop from on-disk mark.** Crayon-internal runtime correlation; redundant with crayon's NDJSON.                                                                                                                                  |
+| Conversion lineage (CHALK_ID of source after ST → GGUF) | `DERIVED_FROM`                                                                             | **NEW keyspec: `DERIVED_FROM_CHALK_ID`.** Type string. Kind `ChalkTimeArtifact`. General-purpose lineage — not ML-specific; any in-place file conversion can carry it. Drafted alongside this PR set.                             |
 
 **Net delta to the chalk key vocabulary: one new keyspec.** Every
 other crayon-prototype key collapses into reuse or moves to
@@ -54,13 +54,13 @@ runtime-only.
 (`"ELF"`, `"Mach-O executable"`, `"JAR"`, `"WAR"`, …). The model
 codecs follow the same pattern:
 
-| Codec | Value |
-|---|---|
-| safetensors | `"SafeTensors model"` |
-| gguf | `"GGUF model"` |
+| Codec                      | Value                  |
+| -------------------------- | ---------------------- |
+| safetensors                | `"SafeTensors model"`  |
+| gguf                       | `"GGUF model"`         |
 | codecZip on `.pt` / `.pth` | `"PyTorch checkpoint"` |
-| codecZip on `.keras` | `"Keras model"` |
-| sidecar | `"ML model"` (generic) |
+| codecZip on `.keras`       | `"Keras model"`        |
+| sidecar                    | `"ML model"` (generic) |
 
 These are added as `artType*` constants in `src/types.nim` and
 appended to the `ARTIFACT_TYPE` keyspec doc string. No new keyspec
@@ -170,19 +170,19 @@ nothing is mutated). Read path: `chalk extract <model.bin>` looks for
 
 Mirroring the Mach-O codec precedent (`docs/design-macho-codec.md`).
 
-| Path | What |
-|---|---|
-| `src/codecs/safetensors/{include,src}/` | C library (parse, mark insert/remove/extract, unchalked hash). C23, libcrypto for SHA-256. |
-| `src/codecs/gguf/{include,src}/` | Same shape, GGUF-specific. |
-| `src/utils/safetensors.nim`, `src/utils/gguf.nim` | FFI bindings, compile the C via `{.compile.}`. |
-| `src/plugins/codecSafetensors.nim`, `codecGguf.nim`, `codecModelSidecar.nim` | Codec plugins. |
-| `src/plugins/codecZip.nim` | Touched only for the `.pt`/`.pth`/`.keras` extension hook + `ARTIFACT_TYPE` differentiation. |
-| `src/plugin_load.nim` | Registers `codecSafetensors`, `codecGguf`, `codecModelSidecar`. |
-| `src/configs/base_plugins.c4m` | New `plugin safetensors`, `plugin gguf`, `plugin model_sidecar` blocks. Priority: safetensors `1`, gguf `1`, model_sidecar `1500` (below source/zip but above nothing). |
-| `src/configs/base_keyspecs.c4m` | New `keyspec DERIVED_FROM_CHALK_ID`. `ARTIFACT_TYPE` doc string extended. |
-| `src/types.nim` | New `artTypeSafetensors`, `artTypeGguf`, `artTypePytorchCheckpoint`, `artTypeKerasModel`, `artTypeMLModel`. |
-| `tests/unit/test_safetensors.nim`, `test_gguf.nim`, `test_model_sidecar.nim` | Nim unit tests on committed fixture artifacts. |
-| `tests/unit/test_codec_zip_models.nim` | Confirms `.pt` / `.pth` / `.keras` go through `codecZip` correctly. |
+| Path                                                                         | What                                                                                                                                                                    |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/codecs/safetensors/{include,src}/`                                      | C library (parse, mark insert/remove/extract, unchalked hash). C23, libcrypto for SHA-256.                                                                              |
+| `src/codecs/gguf/{include,src}/`                                             | Same shape, GGUF-specific.                                                                                                                                              |
+| `src/utils/safetensors.nim`, `src/utils/gguf.nim`                            | FFI bindings, compile the C via `{.compile.}`.                                                                                                                          |
+| `src/plugins/codecSafetensors.nim`, `codecGguf.nim`, `codecModelSidecar.nim` | Codec plugins.                                                                                                                                                          |
+| `src/plugins/codecZip.nim`                                                   | Touched only for the `.pt`/`.pth`/`.keras` extension hook + `ARTIFACT_TYPE` differentiation.                                                                            |
+| `src/plugin_load.nim`                                                        | Registers `codecSafetensors`, `codecGguf`, `codecModelSidecar`.                                                                                                         |
+| `src/configs/base_plugins.c4m`                                               | New `plugin safetensors`, `plugin gguf`, `plugin model_sidecar` blocks. Priority: safetensors `1`, gguf `1`, model_sidecar `1500` (below source/zip but above nothing). |
+| `src/configs/base_keyspecs.c4m`                                              | New `keyspec DERIVED_FROM_CHALK_ID`. `ARTIFACT_TYPE` doc string extended.                                                                                               |
+| `src/types.nim`                                                              | New `artTypeSafetensors`, `artTypeGguf`, `artTypePytorchCheckpoint`, `artTypeKerasModel`, `artTypeMLModel`.                                                             |
+| `tests/unit/test_safetensors.nim`, `test_gguf.nim`, `test_model_sidecar.nim` | Nim unit tests on committed fixture artifacts.                                                                                                                          |
+| `tests/unit/test_codec_zip_models.nim`                                       | Confirms `.pt` / `.pth` / `.keras` go through `codecZip` correctly.                                                                                                     |
 
 ## Cross-platform
 
@@ -206,8 +206,8 @@ convention and the per-codec `{.compile.}` pattern from
   format independently of `ARTIFACT_TYPE`, this is a future
   one-line addition.
 - **Trigger-context runtime keys.** If demand emerges to capture
-  which crayon-side process triggered a chalk run *inside the chalk
-  report* (vs crayon's own NDJSON), that becomes a small set of
+  which crayon-side process triggered a chalk run _inside the chalk
+  report_ (vs crayon's own NDJSON), that becomes a small set of
   `_OP_TRIGGER_*` runtime-only keys. Today crayon's NDJSON is the
   authoritative correlation, so no additions.
 - **Re-marking efficiency.** Per-format codecs all rewrite the file

--- a/docs/design-model-codecs.md
+++ b/docs/design-model-codecs.md
@@ -178,7 +178,7 @@ don't translate:
   changes the file's bytes and format. Loaders break. The cost to
   pipelines outweighs the marking value.
 - **`--virtual` (the user-facing dry-run flag).** Exists already
-  but is a *user choice* to skip artifact mutation entirely; not a
+  but is a _user choice_ to skip artifact mutation entirely; not a
   codec-level handler for "this format can't be marked in-band."
 
 **Why not just refuse the artifact.** Returning `none(ChalkObj)`
@@ -190,7 +190,7 @@ visibility for these files as for any other — the artifact is
 known, hashed, identifiable — at the cost of a sibling file.
 
 **Why this carve-out doesn't generalize.** The argument here turns
-on a property *specific* to ML model artifacts: they are
+on a property _specific_ to ML model artifacts: they are
 non-executable, format-strict data that consumers do not tolerate
 modification of. Executable artifacts have always had an in-band
 option in chalk (the existing codecs prove this). Configuration

--- a/docs/design-model-codecs.md
+++ b/docs/design-model-codecs.md
@@ -1,0 +1,216 @@
+# Native model-file codecs
+
+Chalk's model-file codecs mark ML model artifacts the same way the
+Mach-O codec marks executables — modify in place, leave the file a
+valid model that its native loaders accept. The `chalk` binary is the
+sole producer of marks; downstream tools (Crayon's file-tracker is the
+motivating one) trigger chalk via subprocess on the file write.
+
+This document covers four sibling codecs:
+
+- **safetensors** — single-file format, JSON header. New C codec.
+- **gguf** — single-file format, custom KV header (v2/v3). New C codec.
+- **PyTorch / Keras** (`.pt`/`.pth`/`.keras`) — ZIP-based. Extend the
+  existing `codecZip`; no new codec.
+- **sidecar** — last-resort `<path>.chalk` fallback for everything
+  else (legacy pickle `.pt`, `.bin`, ONNX until protobuf support
+  lands). New codec, file I/O only.
+
+ONNX is out of scope for this PR set — the protobuf parser is a
+separate undertaking.
+
+## Key audit
+
+The single most important section of this document. Adding chalk
+keyspecs is a versioned-schema commitment across every chalk mark in
+every customer environment; the bar is high. Each candidate key
+needs an explicit decision: reuse an existing key, move to runtime
+only, or add a new keyspec.
+
+The motivating crayon-side prototype today has these keys in its
+mark; column three is the audit decision.
+
+| Concept | Crayon prototype today | Decision |
+|---|---|---|
+| Magic / version / identity | `MAGIC`, `CHALK_VERSION`, `CHALK_ID`, `METADATA_ID`, `METADATA_HASH`, `HASH`, `CHALK_RAND` | Reuse — chalk's standard mark already includes these. |
+| Timestamp | `TIMESTAMP_WHEN_CHALKED` | Reuse. |
+| Host | `HOST_NODENAME_WHEN_CHALKED`, `PLATFORM_WHEN_CHALKED` | Reuse. |
+| Path | `PATH_WHEN_CHALKED` | Reuse. |
+| Re-chalking lineage | `OLD_CHALK_METADATA_HASH`, `OLD_CHALK_METADATA_ID` | Reuse. |
+| File format | `CRAYON_FILE_FORMAT` | **Drop.** Use specific `ARTIFACT_TYPE` values (see below). |
+| Model identifier (`meta-llama/Llama-2-7b`, `llama2:7b`) | `CRAYON_MODEL_ID` | **Reuse `ORIGIN_URI`** — synthesize URI per source family: `https://huggingface.co/{org}/{name}`, `ollama://{name}:{tag}`. Treats hosted-model-card semantics the way `ORIGIN_URI` already treats VCS repository origin. |
+| Source family hint (`huggingface` / `ollama` / `local`) | `CRAYON_SOURCE` | **Drop.** Derivable from `ORIGIN_URI` scheme/host at report time. |
+| Triggering process | `CRAYON_DOWNLOADER_UID`, `CRAYON_DOWNLOADER_EXE` | **Drop from on-disk mark.** Belongs in the chalk operation report, not the artifact. The `INJECTOR_*` family already covers chalk's own identity; the upstream caller is correlation context that crayon emits in its own NDJSON. |
+| Session correlation | `CRAYON_SESSION_ID` | **Drop from on-disk mark.** Crayon-internal runtime correlation; redundant with crayon's NDJSON. |
+| Conversion lineage (CHALK_ID of source after ST → GGUF) | `DERIVED_FROM` | **NEW keyspec: `DERIVED_FROM_CHALK_ID`.** Type string. Kind `ChalkTimeArtifact`. General-purpose lineage — not ML-specific; any in-place file conversion can carry it. Drafted alongside this PR set. |
+
+**Net delta to the chalk key vocabulary: one new keyspec.** Every
+other crayon-prototype key collapses into reuse or moves to
+runtime-only.
+
+### `ARTIFACT_TYPE` values
+
+`ARTIFACT_TYPE` already names file-format-specific values
+(`"ELF"`, `"Mach-O executable"`, `"JAR"`, `"WAR"`, …). The model
+codecs follow the same pattern:
+
+| Codec | Value |
+|---|---|
+| safetensors | `"SafeTensors model"` |
+| gguf | `"GGUF model"` |
+| codecZip on `.pt` / `.pth` | `"PyTorch checkpoint"` |
+| codecZip on `.keras` | `"Keras model"` |
+| sidecar | `"ML model"` (generic) |
+
+These are added as `artType*` constants in `src/types.nim` and
+appended to the `ARTIFACT_TYPE` keyspec doc string. No new keyspec
+needed.
+
+If reports later want to filter on format independently of
+ARTIFACT_TYPE (e.g. "all PyTorch artifacts regardless of container"),
+that's a future `MODEL_FORMAT` keyspec. Not in this PR set.
+
+## Per-codec design
+
+### safetensors
+
+**Container shape.** `[u64 LE header_size][JSON header][tensor data]`.
+Tensor `data_offsets` are relative to the data section, so the header
+can grow without breaking offsets.
+
+**Mark insertion.** Inject `__metadata__.chalk = "<mark JSON>"` into
+the header. If `__metadata__` is missing, create it; if `chalk` is
+already present, replace it. Atomic temp-file rename.
+
+**Mark extraction.** Read `__metadata__.chalk`, JSON-unescape, parse.
+
+**Unchalked hash.** SHA-256 of the file with the entire
+`,"chalk":"…"` (or `"chalk":"…",` when first key) byte range
+structurally located and removed from the JSON header — header_size
+field is recomputed for the canonical form. Stable under remarking
+with payloads of any length, regardless of whether `__metadata__` was
+created by us. If `__metadata__.chalk` is absent the unchalked hash
+equals the natural file SHA-256.
+
+**Refusals.** Files with a header that fails JSON parse are passed to
+the sidecar codec.
+
+### gguf
+
+**Container shape.** `[magic "GGUF"][u32 version][u64 tensor_count][u64
+kv_count][KV pairs][tensor info][padding][tensor data]`. KV pairs are
+typed (string, int, array, …). Tensor info offsets are relative to
+the post-padding data section start, so growing KV requires
+recomputing alignment.
+
+**Mark insertion.** Append a string KV pair `chalk.mark` =
+`<mark JSON>` to the KV section, increment `kv_count`, regenerate
+alignment padding. Atomic temp-file rename.
+
+**Mark extraction.** Walk KV pairs looking for `chalk.mark`.
+
+**Unchalked hash.** SHA-256 of the file with the `chalk.mark` KV pair
+removed and `kv_count` decremented (then rerun alignment recompute
+for the canonical form). Stable across remarks. If `chalk.mark` is
+absent the unchalked hash equals the natural file SHA-256.
+
+**Versions.** v2 and v3 only; v1 (deprecated) is refused, dropped to
+sidecar.
+
+### PyTorch / Keras via `codecZip`
+
+**Container shape.** Both formats are ZIP archives — modern PyTorch
+since 1.6 (the `zipfile_serialization` default), Keras 3 always.
+
+**Strategy.** Extend the existing `zip_extensions` config in
+`base_init.c4m` (or wherever `codecZip` reads it) from `["zip", "jar",
+"war", "ear"]` to add `"pt"`, `"pth"`, `"keras"`. The codec already
+inserts a top-level `chalk.json` archive entry, which both formats'
+loaders ignore.
+
+**Validation step before merge.** Confirm a roundtripped chalk-marked
+artifact still loads:
+
+- PyTorch: `torch.load(path)` returns the same state_dict.
+- Keras: `keras.models.load_model(path)` returns an equivalent model.
+
+If either rejects the modified archive, that format is escalated to
+its own codec. (Anticipated outcome: both pass; the loaders only
+inspect known archive members.)
+
+**ARTIFACT_TYPE differentiation.** A small `codecModelZip` wrapper
+plugin (or a minor extension to `codecZip`'s `ctArtCallback`) emits
+`"PyTorch checkpoint"` for `.pt`/`.pth` and `"Keras model"` for
+`.keras`; existing `.jar`/`.war`/`.ear` mapping is preserved.
+
+**Out of scope: legacy `.pt`.** `.pt` files saved before
+torch ≥ 1.6 (or with `_use_new_zipfile_serialization=False`) are pure
+pickle, not ZIP. They land on the sidecar codec.
+
+### Sidecar fallback
+
+Last-resort codec for files that don't match any in-band format.
+Writes `<path>.chalk` next to the artifact containing the mark JSON,
+one line, terminated. Lower priority (lower number) than every
+format-specific codec, but still extension-gated to a configured
+`sidecar_extensions` list — the codec is not a global fallthrough,
+it's a deliberate "we recognize this as an ML model but cannot mark
+in-band" path.
+
+Default `sidecar_extensions`: `["onnx", "bin"]`. PyTorch legacy
+`.pt`/`.pth` pickle files are picked up if `codecZip`'s scan refuses
+them (magic mismatch).
+
+Mark JSON is identical to in-band marks — same keys, same `HASH`
+semantics (sidecar's `HASH` is the natural file SHA-256, since
+nothing is mutated). Read path: `chalk extract <model.bin>` looks for
+`<path>.chalk` and parses it.
+
+## Repo layout
+
+Mirroring the Mach-O codec precedent (`docs/design-macho-codec.md`).
+
+| Path | What |
+|---|---|
+| `src/codecs/safetensors/{include,src}/` | C library (parse, mark insert/remove/extract, unchalked hash). C23, libcrypto for SHA-256. |
+| `src/codecs/gguf/{include,src}/` | Same shape, GGUF-specific. |
+| `src/utils/safetensors.nim`, `src/utils/gguf.nim` | FFI bindings, compile the C via `{.compile.}`. |
+| `src/plugins/codecSafetensors.nim`, `codecGguf.nim`, `codecModelSidecar.nim` | Codec plugins. |
+| `src/plugins/codecZip.nim` | Touched only for the `.pt`/`.pth`/`.keras` extension hook + `ARTIFACT_TYPE` differentiation. |
+| `src/plugin_load.nim` | Registers `codecSafetensors`, `codecGguf`, `codecModelSidecar`. |
+| `src/configs/base_plugins.c4m` | New `plugin safetensors`, `plugin gguf`, `plugin model_sidecar` blocks. Priority: safetensors `1`, gguf `1`, model_sidecar `1500` (below source/zip but above nothing). |
+| `src/configs/base_keyspecs.c4m` | New `keyspec DERIVED_FROM_CHALK_ID`. `ARTIFACT_TYPE` doc string extended. |
+| `src/types.nim` | New `artTypeSafetensors`, `artTypeGguf`, `artTypePytorchCheckpoint`, `artTypeKerasModel`, `artTypeMLModel`. |
+| `tests/unit/test_safetensors.nim`, `test_gguf.nim`, `test_model_sidecar.nim` | Nim unit tests on committed fixture artifacts. |
+| `tests/unit/test_codec_zip_models.nim` | Confirms `.pt` / `.pth` / `.keras` go through `codecZip` correctly. |
+
+## Cross-platform
+
+The C libraries have no platform-specific dependencies (libcrypto for
+SHA-256, plain POSIX file I/O). Codecs are registered as native on
+both `macosx` and `linux` — chalk on Linux can read and write both
+in-band and sidecar marks on model files produced anywhere.
+
+## Stacking
+
+This PR set stacks on top of `jtv/macho-native-codec` (the Mach-O
+codec PR). It reuses that PR's `src/codecs/` subdirectory layout
+convention and the per-codec `{.compile.}` pattern from
+`src/utils/macho.nim`.
+
+## Open follow-ups (not blockers for this PR set)
+
+- **ONNX codec.** Protobuf message has a `metadata_props` map; the
+  natural place to put a chalk mark. Out of scope here.
+- **`MODEL_FORMAT` keyspec.** If reports want to filter on model
+  format independently of `ARTIFACT_TYPE`, this is a future
+  one-line addition.
+- **Trigger-context runtime keys.** If demand emerges to capture
+  which crayon-side process triggered a chalk run *inside the chalk
+  report* (vs crayon's own NDJSON), that becomes a small set of
+  `_OP_TRIGGER_*` runtime-only keys. Today crayon's NDJSON is the
+  authoritative correlation, so no additions.
+- **Re-marking efficiency.** Per-format codecs all rewrite the file
+  on remark — same as the existing macho/elf codecs. Acceptable for
+  ML artifact sizes (most marks land at write time, not
+  repeatedly).

--- a/src/codecs/gguf/include/gguf.h
+++ b/src/codecs/gguf/include/gguf.h
@@ -1,0 +1,140 @@
+/**
+ * @file gguf.h
+ * @brief Chalk's GGUF codec — parse, mark, extract.
+ *
+ * GGUF layout
+ * (https://github.com/ggerganov/ggml/blob/master/docs/gguf.md):
+ *
+ *     [4B "GGUF"][u32 version][u64 tensor_count][u64 kv_count]
+ *     [kv_count KV pairs]
+ *     [tensor_count tensor_info entries]
+ *     [alignment padding]
+ *     [tensor data]
+ *
+ * Tensor `offset` fields are relative to the data section start, so
+ * adding a KV pair is safe as long as the alignment padding is
+ * recomputed: the data section start shifts as a unit and the
+ * relative offsets stay valid.
+ *
+ * Chalk inserts a string KV pair `chalk.mark` whose value is the
+ * mark JSON.  v2 and v3 are supported; v1 is refused.
+ *
+ * The unchalked hash is the SHA-256 of the canonical form: header
+ * with `kv_count - 1`, KV pairs with `chalk.mark` removed, tensor
+ * info unchanged, padding recomputed, tensor data unchanged.  Stable
+ * across remarks with payloads of any length.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// ============================================================================
+// Status codes
+// ============================================================================
+
+typedef enum {
+    CHALK_GGUF_OK              =  0,
+    CHALK_GGUF_ERR_NULL        = -1,  ///< NULL handle.
+    CHALK_GGUF_ERR_TRUNCATED   = -2,  ///< Truncated header / KV / tensor info.
+    CHALK_GGUF_ERR_BAD_MAGIC   = -3,  ///< First 4 bytes != "GGUF".
+    CHALK_GGUF_ERR_BAD_VERSION = -4,  ///< Version not in [2, 3].
+    CHALK_GGUF_ERR_BAD_KV      = -5,  ///< KV section parse failed.
+    CHALK_GGUF_ERR_NO_CHALK    = -6,  ///< remove: nothing to do.
+    CHALK_GGUF_ERR_INTERNAL    = -7,
+} chalk_gguf_status_t;
+
+// ============================================================================
+// Opaque handle
+// ============================================================================
+
+typedef struct chalk_gguf chalk_gguf_t;
+
+/**
+ * @brief Parse a GGUF file from raw bytes.
+ *
+ * The codec takes its own copy of `bytes`.  Subsequent mutation
+ * operates on the internal copy.
+ *
+ * @return Owned handle (free with chalk_gguf_free), or NULL on parse
+ *         failure (truncated, bad magic, unsupported version,
+ *         malformed KV section).
+ */
+extern chalk_gguf_t *chalk_gguf_parse(const uint8_t *bytes, size_t length);
+
+/// Release a handle.  NULL-safe.
+extern void chalk_gguf_free(chalk_gguf_t *g);
+
+// ============================================================================
+// Read API
+// ============================================================================
+
+/**
+ * @brief Return the chalk mark payload, or NULL if absent.
+ *
+ * The returned pointer aliases the handle's internal buffer; callers
+ * MUST NOT free it and MUST NOT use it after chalk_gguf_free.  No
+ * NUL terminator is appended; use `out_size`.
+ */
+extern const char *chalk_gguf_get_payload(chalk_gguf_t *g, size_t *out_size);
+
+// ============================================================================
+// Mutation API
+// ============================================================================
+
+/**
+ * @brief Insert or replace the `chalk.mark` KV pair.
+ *
+ * On success the handle's internal buffer reflects the mutated file
+ * with alignment padding recomputed.
+ *
+ * @param g            Parsed handle.
+ * @param mark         Mark bytes (no quoting; stored verbatim as the
+ *                     KV value).
+ * @param mark_length  Mark byte length.
+ * @return CHALK_GGUF_OK or CHALK_GGUF_ERR_*.
+ */
+extern chalk_gguf_status_t chalk_gguf_set_chalk(chalk_gguf_t *g,
+                                                const char   *mark,
+                                                size_t        mark_length);
+
+/**
+ * @brief Remove the `chalk.mark` KV pair (and recompute padding).
+ *
+ * @return CHALK_GGUF_OK on removal, CHALK_GGUF_ERR_NO_CHALK if absent.
+ */
+extern chalk_gguf_status_t chalk_gguf_remove_chalk(chalk_gguf_t *g);
+
+/**
+ * @brief Retrieve the (possibly mutated) raw bytes for write-back.
+ *
+ * The pointer aliases the handle; lifetime ends with chalk_gguf_free.
+ */
+extern const uint8_t *chalk_gguf_get_buffer(chalk_gguf_t *g, size_t *out_size);
+
+// ============================================================================
+// Unchalked hash
+// ============================================================================
+
+/**
+ * @brief Compute the unchalked SHA-256 of the file in canonical form.
+ *
+ * Canonical form: KV section with `chalk.mark` removed, kv_count
+ * decremented, padding recomputed for the resulting layout.  Stable
+ * across remarks.  If no chalk mark is present, equals the natural
+ * file SHA-256.
+ *
+ * @param out_hex  Caller-provided ≥65-byte buffer; receives 64 hex
+ *                 chars + NUL on success.
+ */
+extern chalk_gguf_status_t chalk_gguf_unchalked_hash(chalk_gguf_t *g,
+                                                     char          out_hex[65]);
+
+// ============================================================================
+// Diagnostics
+//
+// chalk_gguf_warn(const char *msg) is the diagnostic sink.  Default
+// implementation lives in gguf.c (weak fprintf-to-stderr); the nim
+// FFI wrapper provides a strong override at link time.
+// ============================================================================

--- a/src/codecs/gguf/src/gguf.c
+++ b/src/codecs/gguf/src/gguf.c
@@ -1,0 +1,613 @@
+/**
+ * @file gguf.c
+ * @brief Implementation of chalk's GGUF codec.
+ *
+ * GGUF is a simple typed-KV-pair container; the parser walks the KV
+ * section once to locate the `chalk.mark` pair (if any), the
+ * `general.alignment` pair (if any), and the byte boundary of the KV
+ * section.  Mutation rebuilds the file with `chalk.mark` set/removed
+ * and the alignment padding recomputed for the new layout — adding a
+ * KV pair shifts the data section start by a non-aligned amount, so
+ * leaving the original padding in place would break tensor offsets.
+ */
+#include "gguf.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern unsigned char *SHA256(const unsigned char *d, size_t n,
+                              unsigned char *md);
+#define CHALK_GGUF_SHA256_LEN 32
+
+#define GGUF_MAGIC          "GGUF"
+#define GGUF_HEADER_SIZE    24      // magic + version + tensor_count + kv_count
+#define GGUF_DEFAULT_ALIGN  32
+
+// GGUF value types (subset chalk needs to skip).
+#define GGUF_TYPE_UINT8    0
+#define GGUF_TYPE_INT8     1
+#define GGUF_TYPE_UINT16   2
+#define GGUF_TYPE_INT16    3
+#define GGUF_TYPE_UINT32   4
+#define GGUF_TYPE_INT32    5
+#define GGUF_TYPE_FLOAT32  6
+#define GGUF_TYPE_BOOL     7
+#define GGUF_TYPE_STRING   8
+#define GGUF_TYPE_ARRAY    9
+#define GGUF_TYPE_UINT64  10
+#define GGUF_TYPE_INT64   11
+#define GGUF_TYPE_FLOAT64 12
+
+#define CHALK_KV_KEY      "chalk.mark"
+#define CHALK_KV_KEY_LEN  10
+#define ALIGN_KV_KEY      "general.alignment"
+#define ALIGN_KV_KEY_LEN  17
+
+// Diagnostic sink.
+__attribute__((weak))
+void chalk_gguf_warn(const char *msg) {
+    fprintf(stderr, "chalk_gguf: %s\n", msg);
+}
+extern void chalk_gguf_warn(const char *msg);
+
+// =============================================================================
+// Handle
+// =============================================================================
+
+struct chalk_gguf {
+    uint8_t *bytes;
+    size_t   length;
+    size_t   capacity;
+
+    uint32_t version;
+    uint64_t tensor_count;
+    uint64_t kv_count;
+
+    size_t   kv_section_off;     // == GGUF_HEADER_SIZE
+    size_t   kv_section_end;     // start of tensor info section
+    size_t   tensor_info_end;    // start of alignment padding
+    size_t   data_off;           // first byte of tensor data
+
+    uint32_t alignment;          // typically 32
+
+    // Located chalk.mark pair, if present.
+    bool     has_chalk;
+    size_t   chalk_kv_off;       // start of pair
+    size_t   chalk_kv_size;      // end - start
+};
+
+// =============================================================================
+// LE primitive readers
+// =============================================================================
+
+static inline uint32_t r_u32(const uint8_t *p) {
+    return  (uint32_t)p[0]
+          | ((uint32_t)p[1] << 8)
+          | ((uint32_t)p[2] << 16)
+          | ((uint32_t)p[3] << 24);
+}
+
+static inline uint64_t r_u64(const uint8_t *p) {
+    return  (uint64_t)p[0]
+          | ((uint64_t)p[1] << 8)
+          | ((uint64_t)p[2] << 16)
+          | ((uint64_t)p[3] << 24)
+          | ((uint64_t)p[4] << 32)
+          | ((uint64_t)p[5] << 40)
+          | ((uint64_t)p[6] << 48)
+          | ((uint64_t)p[7] << 56);
+}
+
+static inline void w_u32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v);
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+}
+
+static inline void w_u64(uint8_t *p, uint64_t v) {
+    p[0] = (uint8_t)(v);
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+    p[4] = (uint8_t)(v >> 32);
+    p[5] = (uint8_t)(v >> 40);
+    p[6] = (uint8_t)(v >> 48);
+    p[7] = (uint8_t)(v >> 56);
+}
+
+// =============================================================================
+// KV parsing
+//
+// Skip a single typed value at `*pos` within [base, end).  On success
+// advances *pos past the value and returns true.
+// =============================================================================
+
+static bool skip_value(const uint8_t *base, size_t end,
+                       size_t *pos, uint32_t type);
+
+static bool skip_simple(size_t *pos, size_t end, size_t bytes) {
+    if (*pos + bytes > end) {
+        return false;
+    }
+    *pos += bytes;
+    return true;
+}
+
+static bool skip_string(const uint8_t *base, size_t end, size_t *pos) {
+    if (*pos + 8 > end) {
+        return false;
+    }
+    uint64_t len = r_u64(base + *pos);
+    *pos += 8;
+    if (*pos + len < *pos || *pos + len > end) {
+        return false;
+    }
+    *pos += (size_t)len;
+    return true;
+}
+
+static bool skip_value(const uint8_t *base, size_t end,
+                       size_t *pos, uint32_t type) {
+    switch (type) {
+    case GGUF_TYPE_UINT8:
+    case GGUF_TYPE_INT8:
+    case GGUF_TYPE_BOOL:
+        return skip_simple(pos, end, 1);
+    case GGUF_TYPE_UINT16:
+    case GGUF_TYPE_INT16:
+        return skip_simple(pos, end, 2);
+    case GGUF_TYPE_UINT32:
+    case GGUF_TYPE_INT32:
+    case GGUF_TYPE_FLOAT32:
+        return skip_simple(pos, end, 4);
+    case GGUF_TYPE_UINT64:
+    case GGUF_TYPE_INT64:
+    case GGUF_TYPE_FLOAT64:
+        return skip_simple(pos, end, 8);
+    case GGUF_TYPE_STRING:
+        return skip_string(base, end, pos);
+    case GGUF_TYPE_ARRAY: {
+        if (*pos + 4 + 8 > end) {
+            return false;
+        }
+        uint32_t elem_type = r_u32(base + *pos);
+        *pos += 4;
+        uint64_t count = r_u64(base + *pos);
+        *pos += 8;
+        for (uint64_t i = 0; i < count; i++) {
+            if (!skip_value(base, end, pos, elem_type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    default:
+        return false;
+    }
+}
+
+// Skip a tensor_info entry: name(string) + n_dims(u32) + n_dims*u64
+// dims + type(u32) + offset(u64).
+static bool skip_tensor_info(const uint8_t *base, size_t end, size_t *pos) {
+    if (!skip_string(base, end, pos)) {
+        return false;
+    }
+    if (*pos + 4 > end) {
+        return false;
+    }
+    uint32_t n_dims = r_u32(base + *pos);
+    *pos += 4;
+    // n_dims is bounded in practice; defend against garbage.
+    if (n_dims > 1024) {
+        return false;
+    }
+    if (*pos + (size_t)n_dims * 8 > end) {
+        return false;
+    }
+    *pos += (size_t)n_dims * 8;
+    if (*pos + 4 + 8 > end) {
+        return false;
+    }
+    *pos += 4 + 8;  // dtype + offset
+    return true;
+}
+
+// =============================================================================
+// Parse / free
+// =============================================================================
+
+static size_t aligned_up(size_t v, uint32_t a) {
+    if (a == 0) {
+        return v;
+    }
+    return (v + a - 1) / a * a;
+}
+
+extern chalk_gguf_t *chalk_gguf_parse(const uint8_t *bytes, size_t length) {
+    if (!bytes || length < GGUF_HEADER_SIZE) {
+        return NULL;
+    }
+    if (memcmp(bytes, GGUF_MAGIC, 4) != 0) {
+        return NULL;
+    }
+    uint32_t version      = r_u32(bytes + 4);
+    uint64_t tensor_count = r_u64(bytes + 8);
+    uint64_t kv_count     = r_u64(bytes + 16);
+    if (version < 2 || version > 3) {
+        return NULL;
+    }
+
+    chalk_gguf_t *g = calloc(1, sizeof(*g));
+    if (!g) {
+        return NULL;
+    }
+    g->bytes        = malloc(length);
+    if (!g->bytes) {
+        free(g);
+        return NULL;
+    }
+    memcpy(g->bytes, bytes, length);
+    g->length         = length;
+    g->capacity       = length;
+    g->version        = version;
+    g->tensor_count   = tensor_count;
+    g->kv_count       = kv_count;
+    g->kv_section_off = GGUF_HEADER_SIZE;
+    g->alignment      = GGUF_DEFAULT_ALIGN;
+    g->has_chalk      = false;
+
+    // Walk the KV section: locate boundary, chalk.mark, alignment.
+    size_t pos = GGUF_HEADER_SIZE;
+    for (uint64_t i = 0; i < kv_count; i++) {
+        size_t pair_start = pos;
+
+        if (pos + 8 > length) {
+            chalk_gguf_free(g);
+            return NULL;
+        }
+        uint64_t key_len = r_u64(g->bytes + pos);
+        pos += 8;
+        if (pos + key_len < pos || pos + key_len > length) {
+            chalk_gguf_free(g);
+            return NULL;
+        }
+        bool is_chalk_key =
+            (key_len == CHALK_KV_KEY_LEN)
+            && memcmp(g->bytes + pos, CHALK_KV_KEY, CHALK_KV_KEY_LEN) == 0;
+        bool is_align_key =
+            (key_len == ALIGN_KV_KEY_LEN)
+            && memcmp(g->bytes + pos, ALIGN_KV_KEY, ALIGN_KV_KEY_LEN) == 0;
+        pos += (size_t)key_len;
+
+        if (pos + 4 > length) {
+            chalk_gguf_free(g);
+            return NULL;
+        }
+        uint32_t vtype = r_u32(g->bytes + pos);
+        pos += 4;
+
+        size_t value_start = pos;
+
+        if (!skip_value(g->bytes, length, &pos, vtype)) {
+            chalk_gguf_free(g);
+            return NULL;
+        }
+
+        if (is_chalk_key) {
+            if (vtype != GGUF_TYPE_STRING) {
+                chalk_gguf_warn("chalk.mark KV is not a string; ignoring");
+            } else {
+                g->has_chalk     = true;
+                g->chalk_kv_off  = pair_start;
+                g->chalk_kv_size = pos - pair_start;
+            }
+        }
+        if (is_align_key && vtype == GGUF_TYPE_UINT32) {
+            uint32_t a = r_u32(g->bytes + value_start);
+            if (a > 0 && a <= (1U << 30)) {
+                g->alignment = a;
+            }
+        }
+    }
+    g->kv_section_end = pos;
+
+    // Walk tensor info.
+    for (uint64_t i = 0; i < tensor_count; i++) {
+        if (!skip_tensor_info(g->bytes, length, &pos)) {
+            chalk_gguf_free(g);
+            return NULL;
+        }
+    }
+    g->tensor_info_end = pos;
+
+    // Tensor data starts at the first multiple of `alignment` at or
+    // after tensor_info_end.
+    g->data_off = aligned_up(pos, g->alignment);
+    if (g->data_off > length) {
+        // Padding spec said data starts past EOF; reject.
+        chalk_gguf_free(g);
+        return NULL;
+    }
+
+    return g;
+}
+
+extern void chalk_gguf_free(chalk_gguf_t *g) {
+    if (!g) {
+        return;
+    }
+    free(g->bytes);
+    free(g);
+}
+
+// =============================================================================
+// Read
+// =============================================================================
+
+extern const char *chalk_gguf_get_payload(chalk_gguf_t *g, size_t *out_size) {
+    if (!g || !g->has_chalk) {
+        return NULL;
+    }
+    // Pair layout: [u64 key_len][key bytes][u32 type][u64 val_len][val bytes]
+    size_t off = g->chalk_kv_off;
+    if (off + 8 > g->length) {
+        return NULL;
+    }
+    uint64_t key_len = r_u64(g->bytes + off);
+    off += 8 + (size_t)key_len + 4;  // skip key + type
+    if (off + 8 > g->length) {
+        return NULL;
+    }
+    uint64_t val_len = r_u64(g->bytes + off);
+    off += 8;
+    if (off + val_len < off || off + val_len > g->length) {
+        return NULL;
+    }
+    if (out_size) {
+        *out_size = (size_t)val_len;
+    }
+    return (const char *)(g->bytes + off);
+}
+
+// =============================================================================
+// Mutation
+// =============================================================================
+
+// Build a fresh buffer with the supplied layout:
+//   header (kv_count = new_kv_count, tensor_count unchanged, version
+//   unchanged) || existing_kv_section (with optional chalk pair
+//   removed) || optional new chalk pair || tensor_info ||
+//   recomputed_padding || tensor_data
+//
+// `chalk_payload` may be NULL/0 to omit; otherwise a string KV pair
+// for chalk.mark is appended at the end of the KV section (after
+// other existing pairs) before tensor info.
+static chalk_gguf_status_t rebuild(chalk_gguf_t *g,
+                                   const char   *chalk_payload,
+                                   size_t        chalk_payload_len) {
+    // --- KV section (existing minus current chalk pair) ---
+    size_t  src_kv_off  = g->kv_section_off;
+    size_t  src_kv_end  = g->kv_section_end;
+    size_t  src_kv_len  = src_kv_end - src_kv_off;
+    size_t  hole_off    = g->has_chalk ? (g->chalk_kv_off  - src_kv_off) : 0;
+    size_t  hole_len    = g->has_chalk ?  g->chalk_kv_size              : 0;
+    size_t  base_kv_len = src_kv_len - hole_len;
+
+    // --- New chalk pair size ---
+    size_t  new_kv_pair_len = 0;
+    if (chalk_payload != NULL) {
+        // [u64 key_len][key][u32 type][u64 val_len][val]
+        new_kv_pair_len = 8 + CHALK_KV_KEY_LEN + 4 + 8 + chalk_payload_len;
+    }
+
+    uint64_t new_kv_count = g->kv_count
+                            - (g->has_chalk      ? 1 : 0)
+                            + (chalk_payload != NULL ? 1 : 0);
+
+    // --- Tensor info ---
+    size_t   ti_len      = g->tensor_info_end - g->kv_section_end;
+
+    // --- New layout offsets ---
+    size_t   new_kv_section_end = GGUF_HEADER_SIZE + base_kv_len + new_kv_pair_len;
+    size_t   new_ti_end         = new_kv_section_end + ti_len;
+    size_t   new_data_off       = aligned_up(new_ti_end, g->alignment);
+    size_t   pad_len            = new_data_off - new_ti_end;
+
+    // --- Tensor data ---
+    size_t   data_len = (g->length > g->data_off) ? (g->length - g->data_off) : 0;
+
+    size_t   new_total = new_data_off + data_len;
+
+    uint8_t *out = malloc(new_total);
+    if (!out) {
+        return CHALK_GGUF_ERR_INTERNAL;
+    }
+
+    // Header.
+    memcpy(out, GGUF_MAGIC, 4);
+    w_u32(out + 4,  g->version);
+    w_u64(out + 8,  g->tensor_count);
+    w_u64(out + 16, new_kv_count);
+
+    // KV section minus existing chalk pair.
+    size_t op = GGUF_HEADER_SIZE;
+    if (hole_len == 0) {
+        memcpy(out + op, g->bytes + src_kv_off, src_kv_len);
+        op += src_kv_len;
+    } else {
+        // Bytes before the hole.
+        memcpy(out + op, g->bytes + src_kv_off, hole_off);
+        op += hole_off;
+        // Bytes after the hole.
+        size_t after_hole_off = src_kv_off + hole_off + hole_len;
+        size_t after_hole_len = src_kv_end - after_hole_off;
+        memcpy(out + op, g->bytes + after_hole_off, after_hole_len);
+        op += after_hole_len;
+    }
+
+    // New chalk pair (string KV).
+    if (chalk_payload != NULL) {
+        w_u64(out + op, (uint64_t)CHALK_KV_KEY_LEN);
+        op += 8;
+        memcpy(out + op, CHALK_KV_KEY, CHALK_KV_KEY_LEN);
+        op += CHALK_KV_KEY_LEN;
+        w_u32(out + op, GGUF_TYPE_STRING);
+        op += 4;
+        w_u64(out + op, (uint64_t)chalk_payload_len);
+        op += 8;
+        if (chalk_payload_len) {
+            memcpy(out + op, chalk_payload, chalk_payload_len);
+            op += chalk_payload_len;
+        }
+    }
+
+    // Tensor info.
+    memcpy(out + op, g->bytes + g->kv_section_end, ti_len);
+    op += ti_len;
+
+    // Recomputed padding (zeroed).
+    if (pad_len) {
+        memset(out + op, 0, pad_len);
+        op += pad_len;
+    }
+
+    // Tensor data.
+    if (data_len) {
+        memcpy(out + op, g->bytes + g->data_off, data_len);
+        op += data_len;
+    }
+
+    if (op != new_total) {
+        free(out);
+        return CHALK_GGUF_ERR_INTERNAL;
+    }
+
+    // Replace handle's buffer and re-parse offsets.
+    free(g->bytes);
+    g->bytes        = out;
+    g->length       = new_total;
+    g->capacity     = new_total;
+    g->kv_count     = new_kv_count;
+    g->kv_section_end  = new_kv_section_end;
+    g->tensor_info_end = new_ti_end;
+    g->data_off        = new_data_off;
+    g->has_chalk       = (chalk_payload != NULL);
+    if (g->has_chalk) {
+        // Recompute chalk pair location: it sits at the end of the KV
+        // section (we appended it).
+        g->chalk_kv_off  = new_kv_section_end - new_kv_pair_len;
+        g->chalk_kv_size = new_kv_pair_len;
+    } else {
+        g->chalk_kv_off  = 0;
+        g->chalk_kv_size = 0;
+    }
+
+    return CHALK_GGUF_OK;
+}
+
+extern chalk_gguf_status_t chalk_gguf_set_chalk(chalk_gguf_t *g,
+                                                const char   *mark,
+                                                size_t        mark_length) {
+    if (!g || !mark) {
+        return CHALK_GGUF_ERR_NULL;
+    }
+    return rebuild(g, mark, mark_length);
+}
+
+extern chalk_gguf_status_t chalk_gguf_remove_chalk(chalk_gguf_t *g) {
+    if (!g) {
+        return CHALK_GGUF_ERR_NULL;
+    }
+    if (!g->has_chalk) {
+        return CHALK_GGUF_ERR_NO_CHALK;
+    }
+    return rebuild(g, NULL, 0);
+}
+
+extern const uint8_t *chalk_gguf_get_buffer(chalk_gguf_t *g, size_t *out_size) {
+    if (!g) {
+        return NULL;
+    }
+    if (out_size) {
+        *out_size = g->length;
+    }
+    return g->bytes;
+}
+
+// =============================================================================
+// Unchalked hash
+// =============================================================================
+
+extern chalk_gguf_status_t chalk_gguf_unchalked_hash(chalk_gguf_t *g,
+                                                     char          out_hex[65]) {
+    if (!g || !out_hex) {
+        return CHALK_GGUF_ERR_NULL;
+    }
+
+    uint8_t *canon;
+    size_t   canon_len;
+
+    if (!g->has_chalk) {
+        canon     = g->bytes;
+        canon_len = g->length;
+    } else {
+        // Mirror rebuild() with chalk_payload = NULL.
+        size_t  src_kv_off  = g->kv_section_off;
+        size_t  src_kv_end  = g->kv_section_end;
+        size_t  src_kv_len  = src_kv_end - src_kv_off;
+        size_t  hole_off    = g->chalk_kv_off - src_kv_off;
+        size_t  hole_len    = g->chalk_kv_size;
+        size_t  base_kv_len = src_kv_len - hole_len;
+
+        size_t  ti_len    = g->tensor_info_end - g->kv_section_end;
+        size_t  new_kv_section_end = GGUF_HEADER_SIZE + base_kv_len;
+        size_t  new_ti_end         = new_kv_section_end + ti_len;
+        size_t  new_data_off       = aligned_up(new_ti_end, g->alignment);
+        size_t  pad_len            = new_data_off - new_ti_end;
+        size_t  data_len  = g->length > g->data_off ? g->length - g->data_off : 0;
+
+        canon_len = new_data_off + data_len;
+        canon     = malloc(canon_len);
+        if (!canon) {
+            return CHALK_GGUF_ERR_INTERNAL;
+        }
+        memcpy(canon, GGUF_MAGIC, 4);
+        w_u32(canon + 4,  g->version);
+        w_u64(canon + 8,  g->tensor_count);
+        w_u64(canon + 16, g->kv_count - 1);
+
+        size_t op = GGUF_HEADER_SIZE;
+        memcpy(canon + op, g->bytes + src_kv_off, hole_off);
+        op += hole_off;
+        size_t after_off = src_kv_off + hole_off + hole_len;
+        size_t after_len = src_kv_end - after_off;
+        memcpy(canon + op, g->bytes + after_off, after_len);
+        op += after_len;
+
+        memcpy(canon + op, g->bytes + g->kv_section_end, ti_len);
+        op += ti_len;
+        if (pad_len) {
+            memset(canon + op, 0, pad_len);
+            op += pad_len;
+        }
+        if (data_len) {
+            memcpy(canon + op, g->bytes + g->data_off, data_len);
+        }
+    }
+
+    uint8_t digest[CHALK_GGUF_SHA256_LEN];
+    SHA256(canon, canon_len, digest);
+    if (canon != g->bytes) {
+        free(canon);
+    }
+
+    static const char hex[] = "0123456789abcdef";
+    for (int i = 0; i < CHALK_GGUF_SHA256_LEN; i++) {
+        out_hex[i * 2]     = hex[digest[i] >> 4];
+        out_hex[i * 2 + 1] = hex[digest[i] & 0xf];
+    }
+    out_hex[64] = '\0';
+    return CHALK_GGUF_OK;
+}

--- a/src/codecs/safetensors/include/safetensors.h
+++ b/src/codecs/safetensors/include/safetensors.h
@@ -1,0 +1,145 @@
+/**
+ * @file safetensors.h
+ * @brief Chalk's SafeTensors codec — parse, mark, extract.
+ *
+ * SafeTensors layout (https://github.com/huggingface/safetensors):
+ *
+ *     [u64 LE header_size][JSON header bytes][tensor data bytes]
+ *
+ * Tensor `data_offsets` are relative to the data section start, so
+ * the header may grow without breaking offsets.  Chalk inserts its
+ * mark as a string value under `__metadata__.chalk`, creating
+ * `__metadata__` if absent.
+ *
+ * The unchalked hash is the SHA-256 of the canonical form: the file
+ * with the entire `chalk` key/value pair structurally removed from
+ * `__metadata__` and `header_size` recomputed.  Stable across remarks
+ * with payloads of any length.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// ============================================================================
+// Status codes
+// ============================================================================
+
+typedef enum {
+    CHALK_ST_OK              =  0,
+    CHALK_ST_ERR_NULL        = -1,  ///< NULL handle.
+    CHALK_ST_ERR_TRUNCATED   = -2,  ///< File shorter than minimum.
+    CHALK_ST_ERR_BAD_HEADER  = -3,  ///< header_size implausible / parse fail.
+    CHALK_ST_ERR_NOT_OBJECT  = -4,  ///< Header isn't a JSON object.
+    CHALK_ST_ERR_NO_CHALK    = -5,  ///< remove_chalk: nothing to do.
+    CHALK_ST_ERR_INTERNAL    = -6,
+} chalk_st_status_t;
+
+// ============================================================================
+// Opaque handle
+// ============================================================================
+
+typedef struct chalk_st chalk_st_t;
+
+/**
+ * @brief Parse a SafeTensors file from raw bytes.
+ *
+ * The codec takes its own copy of `bytes` (caller may free or reuse
+ * the input buffer immediately on return).  Subsequent
+ * set/remove_chalk calls mutate the internal copy in place.
+ *
+ * @return Owned handle (free with chalk_st_free), or NULL on parse
+ *         failure (truncated, bogus header_size, malformed JSON).
+ */
+extern chalk_st_t *chalk_st_parse(const uint8_t *bytes, size_t length);
+
+/// Release a handle.  NULL-safe.
+extern void chalk_st_free(chalk_st_t *st);
+
+// ============================================================================
+// Read API
+// ============================================================================
+
+/**
+ * @brief Return the chalk mark payload, or NULL if absent.
+ *
+ * The returned pointer aliases the handle's internal buffer; callers
+ * MUST NOT free it and MUST NOT use it after chalk_st_free.  The
+ * payload bytes are JSON-unescaped from the header's string value.
+ *
+ * @param st        Parsed handle.
+ * @param out_size  Receives payload byte length (excludes any
+ *                  internal NUL terminator).
+ * @return Pointer to caller-readable bytes, or NULL.
+ */
+extern char *chalk_st_get_payload(chalk_st_t *st, size_t *out_size);
+
+// ============================================================================
+// Mutation API
+// ============================================================================
+
+/**
+ * @brief Insert or replace the chalk mark in the header.
+ *
+ * If `__metadata__` is absent, it is created with a single key
+ * `chalk`.  If present without a `chalk` member, the member is
+ * appended.  If `chalk` is already there, its value is replaced.
+ * On success the handle's internal buffer reflects the mutated file.
+ *
+ * @param st           Parsed handle.
+ * @param mark         Mark JSON bytes (no surrounding quotes; this
+ *                     function escapes for embedding as a string
+ *                     value).
+ * @param mark_length  Mark byte length.
+ * @return CHALK_ST_OK or CHALK_ST_ERR_*.
+ */
+extern chalk_st_status_t chalk_st_set_chalk(chalk_st_t    *st,
+                                            const char    *mark,
+                                            size_t         mark_length);
+
+/**
+ * @brief Remove the chalk mark, leaving `__metadata__` itself in
+ *        place (possibly empty).
+ *
+ * @return CHALK_ST_OK on removal, CHALK_ST_ERR_NO_CHALK if absent,
+ *         CHALK_ST_ERR_* otherwise.
+ */
+extern chalk_st_status_t chalk_st_remove_chalk(chalk_st_t *st);
+
+/**
+ * @brief Retrieve the (possibly mutated) raw bytes for write-back.
+ *
+ * The pointer aliases the handle; lifetime ends with chalk_st_free.
+ */
+extern const uint8_t *chalk_st_get_buffer(chalk_st_t *st, size_t *out_size);
+
+// ============================================================================
+// Unchalked hash
+// ============================================================================
+
+/**
+ * @brief Compute the unchalked SHA-256 of the file in canonical form.
+ *
+ * Canonical form: header has the chalk key/value pair structurally
+ * removed; header_size is recomputed; then SHA-256 of (header_size_le
+ * || canonical_header || tensor_data).  Stable across remarks with
+ * payloads of any length.  If no chalk mark is present, equals the
+ * natural file SHA-256.
+ *
+ * @param st       Parsed handle (any chalk-state — pre, post, never).
+ * @param out_hex  Caller-provided ≥65-byte buffer; receives 64 hex
+ *                 chars + NUL on success.
+ */
+extern chalk_st_status_t chalk_st_unchalked_hash(chalk_st_t *st,
+                                                 char        out_hex[65]);
+
+// ============================================================================
+// Diagnostics
+//
+// chalk_st_warn(const char *msg) is the diagnostic sink.  Default
+// implementation lives in safetensors.c (weak fprintf-to-stderr); the
+// nim FFI wrapper provides a strong override that routes into chalk's
+// `warn` template at link time, mirroring the chalk_macho_warn
+// convention.
+// ============================================================================

--- a/src/codecs/safetensors/src/safetensors.c
+++ b/src/codecs/safetensors/src/safetensors.c
@@ -1,0 +1,781 @@
+/**
+ * @file safetensors.c
+ * @brief Implementation of chalk's SafeTensors codec.
+ *
+ * Hand-rolled JSON scanner over the file header — the codec needs only
+ * structural location of the `__metadata__.chalk` key/value pair, not
+ * a full JSON model.  Strings, escapes, and nested objects are scanned
+ * properly so that a tensor name happening to contain `__metadata__`
+ * or `chalk` cannot hijack the search.
+ */
+#include "safetensors.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// libcrypto via the static link wired in chalk's config.nims.
+extern unsigned char *SHA256(const unsigned char *d, size_t n,
+                              unsigned char *md);
+#define CHALK_ST_SHA256_DIGEST_LEN 32
+
+#define CHALK_KEY      "chalk"
+#define CHALK_KEY_LEN  5
+#define META_KEY       "__metadata__"
+#define META_KEY_LEN   12
+
+#define MAX_HEADER_SIZE  (100ULL * 1024ULL * 1024ULL)  // 100 MB sanity cap
+
+// Diagnostic sink — weak default; the nim FFI overrides at link time.
+__attribute__((weak))
+void chalk_st_warn(const char *msg) {
+    fprintf(stderr, "chalk_st: %s\n", msg);
+}
+extern void chalk_st_warn(const char *msg);
+
+// =============================================================================
+// Handle
+// =============================================================================
+
+struct chalk_st {
+    uint8_t *bytes;       // owned
+    size_t   length;
+    size_t   capacity;
+    uint64_t header_size; // value of the leading u64 LE
+};
+
+// =============================================================================
+// Small helpers
+// =============================================================================
+
+static inline uint64_t read_u64_le(const uint8_t *p) {
+    return  (uint64_t)p[0]
+          | ((uint64_t)p[1] << 8)
+          | ((uint64_t)p[2] << 16)
+          | ((uint64_t)p[3] << 24)
+          | ((uint64_t)p[4] << 32)
+          | ((uint64_t)p[5] << 40)
+          | ((uint64_t)p[6] << 48)
+          | ((uint64_t)p[7] << 56);
+}
+
+static inline void write_u64_le(uint8_t *p, uint64_t v) {
+    p[0] = (uint8_t)(v);
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+    p[4] = (uint8_t)(v >> 32);
+    p[5] = (uint8_t)(v >> 40);
+    p[6] = (uint8_t)(v >> 48);
+    p[7] = (uint8_t)(v >> 56);
+}
+
+// =============================================================================
+// JSON scanner
+//
+// All scanning operates on [p, end).  Returns one-past-the-token or
+// NULL on syntax error.
+// =============================================================================
+
+static const char *skip_ws(const char *p, const char *end) {
+    while (p < end && (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')) {
+        p++;
+    }
+    return p;
+}
+
+// Skip a JSON string literal.  p points at the opening '"'.
+static const char *skip_str(const char *p, const char *end) {
+    if (p >= end || *p != '"') {
+        return NULL;
+    }
+    p++;
+    while (p < end) {
+        char c = *p;
+        if (c == '\\') {
+            if (p + 1 >= end) {
+                return NULL;
+            }
+            p += 2;
+            continue;
+        }
+        if (c == '"') {
+            return p + 1;
+        }
+        p++;
+    }
+    return NULL;
+}
+
+static const char *skip_value(const char *p, const char *end);
+
+// Skip a JSON object.  p points at the opening '{'.
+static const char *skip_object(const char *p, const char *end) {
+    if (p >= end || *p != '{') {
+        return NULL;
+    }
+    p++;
+    p = skip_ws(p, end);
+    if (p < end && *p == '}') {
+        return p + 1;
+    }
+    while (p < end) {
+        p = skip_str(p, end);
+        if (!p) {
+            return NULL;
+        }
+        p = skip_ws(p, end);
+        if (p >= end || *p != ':') {
+            return NULL;
+        }
+        p++;
+        p = skip_ws(p, end);
+        p = skip_value(p, end);
+        if (!p) {
+            return NULL;
+        }
+        p = skip_ws(p, end);
+        if (p >= end) {
+            return NULL;
+        }
+        if (*p == ',') {
+            p++;
+            p = skip_ws(p, end);
+            continue;
+        }
+        if (*p == '}') {
+            return p + 1;
+        }
+        return NULL;
+    }
+    return NULL;
+}
+
+// Skip a JSON array.  p points at the opening '['.
+static const char *skip_array(const char *p, const char *end) {
+    if (p >= end || *p != '[') {
+        return NULL;
+    }
+    p++;
+    p = skip_ws(p, end);
+    if (p < end && *p == ']') {
+        return p + 1;
+    }
+    while (p < end) {
+        p = skip_value(p, end);
+        if (!p) {
+            return NULL;
+        }
+        p = skip_ws(p, end);
+        if (p >= end) {
+            return NULL;
+        }
+        if (*p == ',') {
+            p++;
+            p = skip_ws(p, end);
+            continue;
+        }
+        if (*p == ']') {
+            return p + 1;
+        }
+        return NULL;
+    }
+    return NULL;
+}
+
+static const char *skip_value(const char *p, const char *end) {
+    if (p >= end) {
+        return NULL;
+    }
+    char c = *p;
+    if (c == '"') {
+        return skip_str(p, end);
+    }
+    if (c == '{') {
+        return skip_object(p, end);
+    }
+    if (c == '[') {
+        return skip_array(p, end);
+    }
+    // Number, true, false, null — scan until terminator.
+    while (p < end) {
+        char ch = *p;
+        if (ch == ',' || ch == '}' || ch == ']'
+            || ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+            return p;
+        }
+        p++;
+    }
+    return p;
+}
+
+// =============================================================================
+// Pair location
+//
+// Locate `key` within the top-level object that begins at `obj_start`
+// (which must point at '{').  On hit:
+//   *key_quote     — opening quote of the key
+//   *value_start   — first byte of the value
+//   *value_end     — one past the value
+//   *removable_lo  — leading offset of the span to remove for unmark
+//                    (covers a leading comma if the pair has one;
+//                    otherwise points at the key quote)
+//   *removable_hi  — trailing offset of the span to remove (covers a
+//                    trailing comma if the pair has one; otherwise
+//                    equals value_end after stripping trailing ws)
+// Returns true if found.
+// =============================================================================
+
+static bool find_pair(const char  *obj_start,
+                      const char  *obj_end,
+                      const char  *key,
+                      size_t       key_len,
+                      const char **key_quote,
+                      const char **value_start,
+                      const char **value_end,
+                      const char **removable_lo,
+                      const char **removable_hi) {
+    if (obj_start >= obj_end || *obj_start != '{') {
+        return false;
+    }
+    const char *p = obj_start + 1;
+    p = skip_ws(p, obj_end);
+    if (p < obj_end && *p == '}') {
+        return false;
+    }
+
+    // Track the previous comma (if any) and start of the current key,
+    // so when we find a hit we know whether a leading comma exists.
+    const char *prev_comma = NULL;
+
+    while (p < obj_end) {
+        const char *this_key = p;
+        const char *after_key = skip_str(p, obj_end);
+        if (!after_key) {
+            return false;
+        }
+
+        // Compare key text — between this_key+1 and after_key-1.
+        size_t this_key_len = (size_t)(after_key - this_key) - 2;
+        bool   matches      = (this_key_len == key_len)
+                              && memcmp(this_key + 1, key, key_len) == 0;
+
+        p = skip_ws(after_key, obj_end);
+        if (p >= obj_end || *p != ':') {
+            return false;
+        }
+        p++;
+        p = skip_ws(p, obj_end);
+        const char *vstart = p;
+        const char *vend   = skip_value(p, obj_end);
+        if (!vend) {
+            return false;
+        }
+
+        // Look ahead past whitespace to the next comma or close-brace.
+        const char *after_v = skip_ws(vend, obj_end);
+        if (after_v >= obj_end) {
+            return false;
+        }
+        bool has_trailing_comma = (*after_v == ',');
+
+        if (matches) {
+            *key_quote   = this_key;
+            *value_start = vstart;
+            *value_end   = vend;
+            // Removable span:
+            // - If a trailing comma exists: [key_quote, after_v+1)
+            //   so the next key takes the position naturally.
+            // - Else if a leading comma exists: [prev_comma, vend) but
+            //   trim trailing ws back so we don't strand whitespace
+            //   before the closing brace.
+            // - Else (sole pair, no commas): [key_quote, vend).
+            if (has_trailing_comma) {
+                *removable_lo = this_key;
+                *removable_hi = after_v + 1;
+            } else if (prev_comma) {
+                *removable_lo = prev_comma;
+                *removable_hi = vend;
+            } else {
+                *removable_lo = this_key;
+                *removable_hi = vend;
+            }
+            return true;
+        }
+
+        if (!has_trailing_comma) {
+            return false;
+        }
+        prev_comma = after_v;
+        p = after_v + 1;
+        p = skip_ws(p, obj_end);
+    }
+    return false;
+}
+
+// =============================================================================
+// JSON unescape into caller buffer (returns NUL-terminated; out must
+// be at least input length + 1).  Returns final length.
+// =============================================================================
+
+static size_t json_unescape(const char *in, size_t in_len, char *out) {
+    size_t o = 0;
+    for (size_t i = 0; i < in_len; i++) {
+        char c = in[i];
+        if (c == '\\' && i + 1 < in_len) {
+            char n = in[i + 1];
+            i++;
+            switch (n) {
+            case 'n':  out[o++] = '\n'; break;
+            case 'r':  out[o++] = '\r'; break;
+            case 't':  out[o++] = '\t'; break;
+            case '"':  out[o++] = '"';  break;
+            case '\\': out[o++] = '\\'; break;
+            case '/':  out[o++] = '/';  break;
+            case 'b':  out[o++] = '\b'; break;
+            case 'f':  out[o++] = '\f'; break;
+            case 'u':
+                if (i + 4 < in_len) {
+                    // Minimal UTF-8 encoder for BMP escapes.  Marks are
+                    // ASCII JSON in practice; surrogate pairs are
+                    // ignored (escape passed through literally).
+                    unsigned int cp = 0;
+                    bool ok = true;
+                    for (int k = 1; k <= 4; k++) {
+                        char h = in[i + k];
+                        cp <<= 4;
+                        if      (h >= '0' && h <= '9') cp |= (unsigned)(h - '0');
+                        else if (h >= 'a' && h <= 'f') cp |= (unsigned)(h - 'a' + 10);
+                        else if (h >= 'A' && h <= 'F') cp |= (unsigned)(h - 'A' + 10);
+                        else { ok = false; break; }
+                    }
+                    if (!ok) {
+                        out[o++] = '\\';
+                        out[o++] = 'u';
+                    } else {
+                        i += 4;
+                        if (cp < 0x80) {
+                            out[o++] = (char)cp;
+                        } else if (cp < 0x800) {
+                            out[o++] = (char)(0xC0 | (cp >> 6));
+                            out[o++] = (char)(0x80 | (cp & 0x3F));
+                        } else {
+                            out[o++] = (char)(0xE0 | (cp >> 12));
+                            out[o++] = (char)(0x80 | ((cp >> 6) & 0x3F));
+                            out[o++] = (char)(0x80 | (cp & 0x3F));
+                        }
+                    }
+                } else {
+                    out[o++] = '\\';
+                    out[o++] = 'u';
+                }
+                break;
+            default:
+                out[o++] = n;
+                break;
+            }
+        } else {
+            out[o++] = c;
+        }
+    }
+    out[o] = '\0';
+    return o;
+}
+
+// JSON-escape into caller buffer.  Returns final length.  Caller must
+// provide a buffer of at least 2*in_len bytes (worst case).
+static size_t json_escape(const char *in, size_t in_len, char *out) {
+    size_t o = 0;
+    for (size_t i = 0; i < in_len; i++) {
+        char c = in[i];
+        switch (c) {
+        case '"':  out[o++] = '\\'; out[o++] = '"';  break;
+        case '\\': out[o++] = '\\'; out[o++] = '\\'; break;
+        case '\n': out[o++] = '\\'; out[o++] = 'n';  break;
+        case '\r': out[o++] = '\\'; out[o++] = 'r';  break;
+        case '\t': out[o++] = '\\'; out[o++] = 't';  break;
+        default:
+            if ((unsigned char)c < 0x20) {
+                o += (size_t)snprintf(out + o, 8, "\\u%04x", (unsigned)c);
+            } else {
+                out[o++] = c;
+            }
+        }
+    }
+    return o;
+}
+
+// =============================================================================
+// Parse / free
+// =============================================================================
+
+extern chalk_st_t *chalk_st_parse(const uint8_t *bytes, size_t length) {
+    if (!bytes || length < 8) {
+        return NULL;
+    }
+    uint64_t hsz = read_u64_le(bytes);
+    if (hsz == 0 || hsz > MAX_HEADER_SIZE || hsz > length - 8) {
+        return NULL;
+    }
+
+    // Header must parse as a JSON object.
+    const char *hdr     = (const char *)bytes + 8;
+    const char *hdr_end = hdr + hsz;
+    const char *p       = skip_ws(hdr, hdr_end);
+    if (p >= hdr_end || *p != '{') {
+        return NULL;
+    }
+    const char *closed  = skip_object(p, hdr_end);
+    if (!closed) {
+        return NULL;
+    }
+
+    chalk_st_t *st = calloc(1, sizeof(*st));
+    if (!st) {
+        return NULL;
+    }
+    st->bytes = malloc(length);
+    if (!st->bytes) {
+        free(st);
+        return NULL;
+    }
+    memcpy(st->bytes, bytes, length);
+    st->length      = length;
+    st->capacity    = length;
+    st->header_size = hsz;
+    return st;
+}
+
+extern void chalk_st_free(chalk_st_t *st) {
+    if (!st) {
+        return;
+    }
+    free(st->bytes);
+    free(st);
+}
+
+// =============================================================================
+// Read API
+// =============================================================================
+
+// Internal: locate __metadata__.chalk pair within st's header.
+// Returns pointers in the *removable* form so the same helper backs
+// both read and remove paths.
+static bool locate_chalk(chalk_st_t  *st,
+                         const char **value_start,
+                         const char **value_end,
+                         const char **rm_lo,
+                         const char **rm_hi) {
+    const char *hdr     = (const char *)st->bytes + 8;
+    const char *hdr_end = hdr + st->header_size;
+    const char *p       = skip_ws(hdr, hdr_end);
+    if (p >= hdr_end || *p != '{') {
+        return false;
+    }
+
+    const char *meta_key_quote, *meta_v_start, *meta_v_end;
+    const char *meta_rm_lo, *meta_rm_hi;
+    if (!find_pair(p, hdr_end, META_KEY, META_KEY_LEN,
+                   &meta_key_quote, &meta_v_start, &meta_v_end,
+                   &meta_rm_lo, &meta_rm_hi)) {
+        return false;
+    }
+    if (meta_v_start >= meta_v_end || *meta_v_start != '{') {
+        return false;
+    }
+
+    const char *ck_key_quote;
+    return find_pair(meta_v_start, meta_v_end,
+                     CHALK_KEY, CHALK_KEY_LEN,
+                     &ck_key_quote, value_start, value_end,
+                     rm_lo, rm_hi);
+}
+
+extern char *chalk_st_get_payload(chalk_st_t *st, size_t *out_size) {
+    if (!st) {
+        return NULL;
+    }
+    const char *vs, *ve, *rl, *rh;
+    if (!locate_chalk(st, &vs, &ve, &rl, &rh)) {
+        return NULL;
+    }
+    // value is a quoted JSON string: vs..ve includes both quotes.
+    if (vs >= ve || *vs != '"' || *(ve - 1) != '"') {
+        return NULL;
+    }
+    size_t in_len = (size_t)(ve - vs) - 2;
+    char  *out    = malloc(in_len + 1);
+    if (!out) {
+        return NULL;
+    }
+    size_t n = json_unescape(vs + 1, in_len, out);
+    if (out_size) {
+        *out_size = n;
+    }
+    return out;
+}
+
+// =============================================================================
+// Mutation
+// =============================================================================
+
+// Build a fresh buffer for st->bytes by replacing the header text.
+// new_header_text + new_header_len describe the new header bytes.
+// Tensor data is preserved verbatim from the old buffer.
+static chalk_st_status_t replace_header(chalk_st_t *st,
+                                        const char *new_header_text,
+                                        size_t      new_header_len) {
+    if (new_header_len > MAX_HEADER_SIZE) {
+        return CHALK_ST_ERR_BAD_HEADER;
+    }
+    size_t   old_data_off = 8 + (size_t)st->header_size;
+    if (old_data_off > st->length) {
+        return CHALK_ST_ERR_INTERNAL;
+    }
+    size_t   data_len     = st->length - old_data_off;
+    size_t   new_total    = 8 + new_header_len + data_len;
+
+    uint8_t *fresh = malloc(new_total);
+    if (!fresh) {
+        return CHALK_ST_ERR_INTERNAL;
+    }
+    write_u64_le(fresh, (uint64_t)new_header_len);
+    memcpy(fresh + 8, new_header_text, new_header_len);
+    if (data_len) {
+        memcpy(fresh + 8 + new_header_len,
+               st->bytes + old_data_off, data_len);
+    }
+    free(st->bytes);
+    st->bytes       = fresh;
+    st->length      = new_total;
+    st->capacity    = new_total;
+    st->header_size = (uint64_t)new_header_len;
+    return CHALK_ST_OK;
+}
+
+extern chalk_st_status_t chalk_st_set_chalk(chalk_st_t *st,
+                                            const char *mark,
+                                            size_t      mark_length) {
+    if (!st || !mark) {
+        return CHALK_ST_ERR_NULL;
+    }
+    const char *hdr     = (const char *)st->bytes + 8;
+    const char *hdr_end = hdr + st->header_size;
+    size_t      hdr_len = (size_t)st->header_size;
+
+    // Escape the mark for JSON-string embedding.
+    char  *escaped = malloc(mark_length * 2 + 1);
+    if (!escaped) {
+        return CHALK_ST_ERR_INTERNAL;
+    }
+    size_t escaped_len = json_escape(mark, mark_length, escaped);
+
+    // Worst-case new header size: existing + the new pair (key+value+
+    // separator) + a few bytes of slack for braces/comma when adding
+    // __metadata__.
+    size_t worst = hdr_len + escaped_len + 64;
+    char  *out   = malloc(worst);
+    if (!out) {
+        free(escaped);
+        return CHALK_ST_ERR_INTERNAL;
+    }
+    size_t op = 0;
+
+    // 1. Existing chalk → replace the value in place.
+    const char *cv_start, *cv_end, *crm_lo, *crm_hi;
+    if (locate_chalk(st, &cv_start, &cv_end, &crm_lo, &crm_hi)) {
+        size_t prefix_len = (size_t)(cv_start - hdr);
+        memcpy(out + op, hdr, prefix_len);
+        op += prefix_len;
+        out[op++] = '"';
+        memcpy(out + op, escaped, escaped_len);
+        op += escaped_len;
+        out[op++] = '"';
+        size_t suffix_off = (size_t)(cv_end - hdr);
+        memcpy(out + op, hdr + suffix_off, hdr_len - suffix_off);
+        op += hdr_len - suffix_off;
+        free(escaped);
+        chalk_st_status_t st_ = replace_header(st, out, op);
+        free(out);
+        return st_;
+    }
+
+    // 2. No existing chalk.  Find or create __metadata__.
+    const char *p = skip_ws(hdr, hdr_end);
+    if (p >= hdr_end || *p != '{') {
+        free(escaped);
+        free(out);
+        return CHALK_ST_ERR_NOT_OBJECT;
+    }
+    const char *mk, *mv_start, *mv_end, *mrm_lo, *mrm_hi;
+    if (find_pair(p, hdr_end, META_KEY, META_KEY_LEN,
+                  &mk, &mv_start, &mv_end, &mrm_lo, &mrm_hi)) {
+        // __metadata__ exists.  Inject `,"chalk":"<escaped>"` just
+        // before the closing '}' (or as the sole member if empty).
+        if (mv_start >= mv_end || *mv_start != '{' || *(mv_end - 1) != '}') {
+            free(escaped);
+            free(out);
+            return CHALK_ST_ERR_BAD_HEADER;
+        }
+
+        // Detect whether the inner object is empty (only whitespace
+        // between '{' and '}').
+        bool empty = true;
+        for (const char *q = mv_start + 1; q < mv_end - 1; q++) {
+            if (*q != ' ' && *q != '\t' && *q != '\n' && *q != '\r') {
+                empty = false;
+                break;
+            }
+        }
+
+        size_t prefix_len = (size_t)(mv_end - 1 - hdr);
+        memcpy(out + op, hdr, prefix_len);
+        op += prefix_len;
+        if (!empty) {
+            out[op++] = ',';
+        }
+        op += (size_t)snprintf(out + op, worst - op,
+                               "\"%s\":\"", CHALK_KEY);
+        memcpy(out + op, escaped, escaped_len);
+        op += escaped_len;
+        out[op++] = '"';
+        // Copy from the closing '}' of __metadata__ to end of header.
+        size_t suffix_off = (size_t)(mv_end - 1 - hdr);
+        memcpy(out + op, hdr + suffix_off, hdr_len - suffix_off);
+        op += hdr_len - suffix_off;
+    } else {
+        // No __metadata__ — insert one at the start of the root
+        // object.  Keeping the new key first reads the same JSON the
+        // hand-rolled scanner finds on the next pass.
+        if (*p != '{') {
+            free(escaped);
+            free(out);
+            return CHALK_ST_ERR_NOT_OBJECT;
+        }
+        size_t lead_len = (size_t)(p - hdr) + 1;  // include '{'
+        memcpy(out + op, hdr, lead_len);
+        op += lead_len;
+
+        // Detect whether root object is empty (no other keys).
+        const char *q = skip_ws(p + 1, hdr_end);
+        bool empty_root = (q < hdr_end && *q == '}');
+
+        op += (size_t)snprintf(out + op, worst - op,
+                               "\"%s\":{\"%s\":\"",
+                               META_KEY, CHALK_KEY);
+        memcpy(out + op, escaped, escaped_len);
+        op += escaped_len;
+        out[op++] = '"';
+        out[op++] = '}';
+        if (!empty_root) {
+            out[op++] = ',';
+        }
+        size_t suffix_off = (size_t)(p - hdr) + 1;
+        memcpy(out + op, hdr + suffix_off, hdr_len - suffix_off);
+        op += hdr_len - suffix_off;
+    }
+
+    free(escaped);
+    chalk_st_status_t r = replace_header(st, out, op);
+    free(out);
+    return r;
+}
+
+extern chalk_st_status_t chalk_st_remove_chalk(chalk_st_t *st) {
+    if (!st) {
+        return CHALK_ST_ERR_NULL;
+    }
+    const char *vs, *ve, *rl, *rh;
+    if (!locate_chalk(st, &vs, &ve, &rl, &rh)) {
+        return CHALK_ST_ERR_NO_CHALK;
+    }
+    const char *hdr     = (const char *)st->bytes + 8;
+    size_t      hdr_len = (size_t)st->header_size;
+    size_t      lo_off  = (size_t)(rl - hdr);
+    size_t      hi_off  = (size_t)(rh - hdr);
+    size_t      new_len = hdr_len - (hi_off - lo_off);
+    char       *out     = malloc(new_len);
+    if (!out) {
+        return CHALK_ST_ERR_INTERNAL;
+    }
+    memcpy(out, hdr, lo_off);
+    memcpy(out + lo_off, hdr + hi_off, hdr_len - hi_off);
+    chalk_st_status_t r = replace_header(st, out, new_len);
+    free(out);
+    return r;
+}
+
+extern const uint8_t *chalk_st_get_buffer(chalk_st_t *st, size_t *out_size) {
+    if (!st) {
+        return NULL;
+    }
+    if (out_size) {
+        *out_size = st->length;
+    }
+    return st->bytes;
+}
+
+// =============================================================================
+// Unchalked hash
+// =============================================================================
+
+extern chalk_st_status_t chalk_st_unchalked_hash(chalk_st_t *st,
+                                                 char        out_hex[65]) {
+    if (!st || !out_hex) {
+        return CHALK_ST_ERR_NULL;
+    }
+
+    const char *vs, *ve, *rl, *rh;
+    bool        has_chalk = locate_chalk(st, &vs, &ve, &rl, &rh);
+
+    // Build a single contiguous canonical buffer to feed to SHA256().
+    // The libcrypto SHA256() wrapper takes one buffer; chunked
+    // hashing needs the *_CTX functions which we'd have to declare
+    // separately.  Canonical form is small (header + tensor data),
+    // so a single allocation is fine.
+    uint8_t *canon;
+    size_t   canon_len;
+
+    if (!has_chalk) {
+        canon     = st->bytes;
+        canon_len = st->length;
+    } else {
+        const char *hdr     = (const char *)st->bytes + 8;
+        size_t      hdr_len = (size_t)st->header_size;
+        size_t      lo_off  = (size_t)(rl - hdr);
+        size_t      hi_off  = (size_t)(rh - hdr);
+        size_t      new_hdr_len = hdr_len - (hi_off - lo_off);
+        size_t      data_off    = 8 + hdr_len;
+        size_t      data_len    = st->length > data_off
+                                  ? st->length - data_off : 0;
+
+        canon_len = 8 + new_hdr_len + data_len;
+        canon     = malloc(canon_len);
+        if (!canon) {
+            return CHALK_ST_ERR_INTERNAL;
+        }
+        write_u64_le(canon, (uint64_t)new_hdr_len);
+        memcpy(canon + 8, hdr, lo_off);
+        if (hdr_len > hi_off) {
+            memcpy(canon + 8 + lo_off, hdr + hi_off, hdr_len - hi_off);
+        }
+        if (data_len) {
+            memcpy(canon + 8 + new_hdr_len,
+                   st->bytes + data_off, data_len);
+        }
+    }
+
+    uint8_t digest[CHALK_ST_SHA256_DIGEST_LEN];
+    SHA256(canon, canon_len, digest);
+    if (canon != st->bytes) {
+        free(canon);
+    }
+
+    static const char hex[] = "0123456789abcdef";
+    for (int i = 0; i < CHALK_ST_SHA256_DIGEST_LEN; i++) {
+        out_hex[i * 2]     = hex[digest[i] >> 4];
+        out_hex[i * 2 + 1] = hex[digest[i] & 0xf];
+    }
+    out_hex[64] = '\0';
+    return CHALK_ST_OK;
+}

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -128,6 +128,10 @@ or vice versa.
   key.DOCKER_BASE_IMAGE_CHALK.use             = true
   key.DOCKER_BASE_IMAGES.use                  = true
   key.DOCKER_COPY_IMAGES.use                  = true
+  key.CALLER_ATTESTED_INFO.use                = true
+  key.CALLER_ATTESTED_HOST_INFO.use           = true
+  key.CALLER_ATTESTED_BUILD_INFO.use          = true
+  key.CALLER_ATTESTED_ARTIFACT_INFO.use       = true
 }
 
 mark_template mark_large {
@@ -246,6 +250,10 @@ mark_template mark_large {
   key.DOCKER_BASE_IMAGE_CHALK.use             = true
   key.DOCKER_BASE_IMAGES.use                  = true
   key.DOCKER_COPY_IMAGES.use                  = true
+  key.CALLER_ATTESTED_INFO.use                = true
+  key.CALLER_ATTESTED_HOST_INFO.use           = true
+  key.CALLER_ATTESTED_BUILD_INFO.use          = true
+  key.CALLER_ATTESTED_ARTIFACT_INFO.use       = true
   key.$CHALK_CONFIG.use                       = true
   key.$CHALK_IMPLEMENTATION_NAME.use          = true
   key.$CHALK_LOAD_COUNT.use                   = true
@@ -341,6 +349,10 @@ use the mark template named `reproducable`.
   key.DOCKER_BASE_IMAGE_CHALK.use             = true
   key.DOCKER_BASE_IMAGES.use                  = true
   key.DOCKER_COPY_IMAGES.use                  = true
+  key.CALLER_ATTESTED_INFO.use                = true
+  key.CALLER_ATTESTED_HOST_INFO.use           = true
+  key.CALLER_ATTESTED_BUILD_INFO.use          = true
+  key.CALLER_ATTESTED_ARTIFACT_INFO.use       = true
   key.$CHALK_CONFIG.use                       = true
   key.$CHALK_IMPLEMENTATION_NAME.use          = true
   key.$CHALK_LOAD_COUNT.use                   = true

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -564,6 +564,34 @@ For items chalked when they were in a embedded into a ZIP file, this is the
 """
 }
 
+keyspec DERIVED_FROM_CHALK_ID {
+    kind:             ChalkTimeArtifact
+    never_early:      true
+    type:             string
+    standard:         true
+    since:            "1.1.0"
+    shortdoc:         "CHALK_ID of an upstream artifact this one was derived from"
+    doc:              """
+When a chalked artifact is produced as an in-place transformation of
+another chalked artifact, this field carries the `CHALK_ID` of the
+source.
+
+The motivating case is ML model conversion — for example, a GGUF file
+produced by quantizing a SafeTensors model. The newly chalked GGUF
+records its source's `CHALK_ID` here so downstream tooling can walk
+the lineage chain back to the original artifact, even after format
+conversion has changed the file's bytes entirely.
+
+This is distinct from `CONTAINING_ARTIFACT_WHEN_CHALKED`, which
+references a chalked container the artifact lives *inside*; here the
+referenced artifact is upstream in time and no longer present.
+
+The field is set when the chalking tool can identify a source
+artifact (typically by recognizing that the same process recently
+opened a different chalked file). It is left unset otherwise.
+"""
+}
+
 keyspec ARTIFACT_TYPE {
     kind:             ChalkTimeArtifact
     never_early:      true
@@ -587,6 +615,11 @@ chalk mark was added. Values can include:
  - JAR
  - WAR
  - EAR
+ - SafeTensors model
+ - GGUF model
+ - PyTorch checkpoint
+ - Keras model
+ - ML model
 
 """
 }

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -405,6 +405,97 @@ chalk time.
 """
 }
 
+keyspec CALLER_ATTESTED_INFO {
+    kind:             ChalkTimeHost
+    type:             `x
+    standard:         true
+    since:            "1.1.0"
+    shortdoc:         "Identifying info about the attestor process"
+    doc:              """
+Free-form metadata about the process that supplied the attestation
+envelope to chalk (typically a system-spawned endpoint agent such as
+Crayon).  The value is whatever the caller passes under
+`CALLER_ATTESTED_INFO` in `CHALK_CALLER_ATTESTATION` /
+`CHALK_CALLER_ATTESTATION_FILE`; chalk does not destructure or
+validate the inner shape.
+
+See `docs/design-caller-attestation.md` for the protocol.
+"""
+}
+
+keyspec CALLER_ATTESTED_HOST_INFO {
+    kind:             ChalkTimeHost
+    type:             `x
+    standard:         true
+    since:            "1.1.0"
+    shortdoc:         "Free-form host attestation from the caller"
+    doc:              """
+Free-form host-level attestation passed in by the caller via
+`CHALK_CALLER_ATTESTATION` / `CHALK_CALLER_ATTESTATION_FILE`.  The
+inner shape is opaque to chalk; chalk proxies it through unchanged.
+
+See `docs/design-caller-attestation.md` for the protocol.
+"""
+}
+
+keyspec CALLER_ATTESTED_BUILD_INFO {
+    kind:             ChalkTimeHost
+    type:             `x
+    standard:         true
+    since:            "1.1.0"
+    shortdoc:         "Free-form build attestation from the caller"
+    doc:              """
+Free-form build-level attestation passed in by the caller via
+`CHALK_CALLER_ATTESTATION` / `CHALK_CALLER_ATTESTATION_FILE`.  The
+inner shape is opaque to chalk; chalk proxies it through unchanged.
+
+See `docs/design-caller-attestation.md` for the protocol.
+"""
+}
+
+keyspec CALLER_ATTESTED_ARTIFACT_INFO {
+    kind:             ChalkTimeArtifact
+    type:             `x
+    standard:         true
+    since:            "1.1.0"
+    shortdoc:         "Caller's per-artifact attestation, status-wrapped"
+    doc:              """
+Caller-supplied attestation for the specific artifact this key
+appears under, wrapped with chalk's verification status.  Shape:
+
+```json
+{ "status": "match",      "info": { ... } }
+{ "status": "mismatch",   "attested_sha256": "...",
+                          "observed_sha256": "...", "info": { ... } }
+{ "status": "unverified", "attested_sha256": "...", "info": { ... } }
+```
+
+`attested_sha256` and `observed_sha256` only surface on `mismatch`
+or `unverified`; on `match` chalk has independently confirmed the
+attested hash and there is no value in echoing it.
+
+See `docs/design-caller-attestation.md` for the protocol.
+"""
+}
+
+keyspec CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO {
+    kind:             RunTimeHost
+    type:             `x
+    standard:         true
+    since:            "1.1.0"
+    shortdoc:         "Caller attestations for paths chalk did not track"
+    doc:              """
+Aggregate of caller-supplied per-artifact attestations whose paths
+were not matched against any artifact chalk processed during this
+operation.  Keys are paths, values are the raw `{sha256, info}`
+objects from the caller envelope (no status wrapper, since chalk
+never observed the file).
+
+Each entry that lands here also generates a `warn`-level log line.
+See `docs/design-caller-attestation.md`.
+"""
+}
+
 keyspec TENANT_ID_WHEN_CHALKED {
     kind:             ChalkTimeHost
     type:             string

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -455,7 +455,7 @@ See `docs/design-caller-attestation.md` for the protocol.
 
 keyspec CALLER_ATTESTED_ARTIFACT_INFO {
     kind:             ChalkTimeArtifact
-    type:             `x
+    type:             dict[string, `x]
     standard:         true
     since:            "1.1.0"
     shortdoc:         "Caller's per-artifact attestation, status-wrapped"
@@ -480,7 +480,7 @@ See `docs/design-caller-attestation.md` for the protocol.
 
 keyspec CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO {
     kind:             RunTimeHost
-    type:             `x
+    type:             dict[string, `x]
     standard:         true
     since:            "1.1.0"
     shortdoc:         "Caller attestations for paths chalk did not track"

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -796,6 +796,33 @@ configuration variable.
 """
 }
 
+plugin safetensors {
+    codec:           true
+    priority:        1
+    enabled:         true
+    pre_chalk_keys:  ["ARTIFACT_TYPE", "DERIVED_FROM_CHALK_ID"]
+    post_chalk_keys: ["_CURRENT_HASH", "_OP_ARTIFACT_TYPE"]
+    doc: """
+This codec marks `.safetensors` ML model files in place.  The chalk
+mark is inserted as a string value under `__metadata__.chalk` in the
+file's JSON header — which is the location the SafeTensors format
+reserves for arbitrary user metadata.  Tensor `data_offsets` are
+relative to the data section start, so the header may grow without
+breaking offsets.
+<p>
+The unchalked hash is the SHA-256 of the file with the chalk
+key/value pair structurally removed from the JSON header (and the
+header_size field recomputed).  Re-marking with payloads of any
+length leaves the unchalked hash unchanged.
+<p>
+The codec defers to the next codec at lower priority when the file
+isn't a valid SafeTensors archive (truncated, header out of range,
+malformed JSON header).  ML model files in other formats (`.gguf`,
+`.pt`, `.pth`, `.keras`, `.onnx`, etc.) are handled by their own
+codecs or by the sidecar fallback.
+"""
+}
+
 plugin certs {
   enabled:         true
   codec:           true

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -752,17 +752,21 @@ plugin zip {
     codec:           true
     priority:        1
     enabled:         true
-    pre_chalk_keys:  ["EMBEDDED_CHALK", "EMBEDDED_TMPDIR", "ARTIFACT_TYPE"]
+    pre_chalk_keys:  ["EMBEDDED_CHALK", "EMBEDDED_TMPDIR", "ARTIFACT_TYPE",
+                      "DERIVED_FROM_CHALK_ID"]
     post_chalk_keys: ["_CURRENT_HASH", "_OP_ARTIFACT_TYPE"]
     doc: """
 The `zip` codec is responsible for manipulating Chalk marks in any
 executable content packaged using the ZIP file format under the hood,
-including all common Java formats, and some popular formats for
-bundling serverless content.
+including all common Java formats, some popular formats for bundling
+serverless content, and modern PyTorch / Keras model checkpoints
+(`.pt`, `.pth`, `.keras` — both formats use ZIP archives under the
+hood since PyTorch 1.6 and Keras 3 respectively).
 <p>
 Currently the codec will only process files with a file extension
 named in the `zip_extensions` configuration field. By default, we
-process the extensions: "zip", "jar", "war" and "ear".
+process the extensions: "zip", "jar", "war", "ear", "pt", "pth", and
+"keras".
 <p>
 This codec can be configured to collect chalk marks for artifacts
 placed into the ZIP file as well, if the configuration variabe

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -93,6 +93,29 @@ such as the overall chalk run time.
 }
 
 
+plugin caller_attestation {
+    ~enabled:         true
+    pre_run_keys:     ["CALLER_ATTESTED_INFO",
+                       "CALLER_ATTESTED_HOST_INFO",
+                       "CALLER_ATTESTED_BUILD_INFO"]
+    pre_chalk_keys:   ["CALLER_ATTESTED_ARTIFACT_INFO"]
+    post_run_keys:    ["CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO"]
+    ~priority:        200
+    doc: """
+Ingests a caller-supplied attestation envelope from the spawning
+process — `CHALK_CALLER_ATTESTATION` env var, falling back to a file
+path in `CHALK_CALLER_ATTESTATION_FILE` for payloads that won't fit
+in `ARG_MAX`.  Validates the envelope's outer shape, distributes
+host/build/process buckets to top-level keys, status-wraps each
+matched per-artifact attestation against chalk's own unchalked
+hash, and aggregates unmatched paths into
+`CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO` with a `warn` log.
+
+See `docs/design-caller-attestation.md` for the protocol.
+"""
+}
+
+
 # Probably should add file time of artifact, date of branch
 # and any tag associated.
 plugin vctl_git {

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -824,6 +824,31 @@ truncated KV section).  GGUF v1 (deprecated) is refused.
 """
 }
 
+plugin model_sidecar {
+    codec:           true
+    enabled:         true
+    pre_chalk_keys:  ["ARTIFACT_TYPE", "DERIVED_FROM_CHALK_ID"]
+    post_chalk_keys: ["_CURRENT_HASH", "_OP_ARTIFACT_TYPE"]
+    priority:        1500
+    doc: """
+Last-resort codec for ML model files that can't be marked in-band.
+The codec writes a `<path>.chalk` sidecar file alongside the
+artifact containing the chalk-mark JSON; the artifact's bytes are
+not modified.  On extract the sidecar is read back as the mark.
+<p>
+The codec is gated on the `sidecar_extensions` config list (default:
+`onnx`, `bin`, `pt`, `pth`).  It runs at priority 1500 — below every
+format-specific codec, so safetensors / gguf / zip get first chance
+on their respective formats.  ONNX (until a protobuf-aware codec
+lands), Ollama-style raw `.bin` blobs, and legacy non-ZIP PyTorch
+checkpoints (pre-`zipfile_serialization`) end up here.
+<p>
+The unchalked hash is the natural SHA-256 of the artifact file
+itself — no canonicalization is needed because the mark lives
+outside the file.
+"""
+}
+
 plugin safetensors {
     codec:           true
     priority:        1

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -796,6 +796,30 @@ configuration variable.
 """
 }
 
+plugin gguf {
+    codec:           true
+    priority:        1
+    enabled:         true
+    pre_chalk_keys:  ["ARTIFACT_TYPE", "DERIVED_FROM_CHALK_ID"]
+    post_chalk_keys: ["_CURRENT_HASH", "_OP_ARTIFACT_TYPE"]
+    doc: """
+This codec marks `.gguf` (GGUF v2/v3) ML model files in place.  The
+chalk mark is inserted as a string KV pair `chalk.mark` in the
+metadata section.  GGUF tensor data offsets are relative to the data
+section start, so the codec recomputes the alignment padding when
+the KV section size changes — leaving offsets valid.
+<p>
+The unchalked hash is the SHA-256 of the file with the `chalk.mark`
+KV pair removed, kv_count decremented, and alignment padding
+recomputed.  Re-marking with payloads of any length leaves the
+unchalked hash unchanged.
+<p>
+The codec defers to the next codec at lower priority when the file
+isn't a valid GGUF v2 or v3 archive (bad magic, unsupported version,
+truncated KV section).  GGUF v1 (deprecated) is refused.
+"""
+}
+
 plugin safetensors {
     codec:           true
     priority:        1

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -179,6 +179,11 @@ report and subtract from it.
   key.DOCKER_BASE_IMAGE_CONFIG_DIGEST.use     = true
   key.DOCKER_BASE_IMAGES.use                  = true
   key.DOCKER_COPY_IMAGES.use                  = true
+  key.CALLER_ATTESTED_INFO.use                = true
+  key.CALLER_ATTESTED_HOST_INFO.use           = true
+  key.CALLER_ATTESTED_BUILD_INFO.use          = true
+  key.CALLER_ATTESTED_ARTIFACT_INFO.use       = true
+  key.CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO.use = true
   key._OP_ARTIFACT_TYPE.use                   = true
   key._OP_ARTIFACT_CONTEXT.use                = true
   key._OP_ARTIFACT_PATH.use                   = true
@@ -830,6 +835,11 @@ doc: """
   key.DOCKER_BASE_IMAGE_CONFIG_DIGEST.use     = true
   key.DOCKER_BASE_IMAGES.use                  = true
   key.DOCKER_COPY_IMAGES.use                  = true
+  key.CALLER_ATTESTED_INFO.use                = true
+  key.CALLER_ATTESTED_HOST_INFO.use           = true
+  key.CALLER_ATTESTED_BUILD_INFO.use          = true
+  key.CALLER_ATTESTED_ARTIFACT_INFO.use       = true
+  key.CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO.use = true
   key._OP_ARTIFACT_TYPE.use                   = true
   key._OP_ARTIFACT_CONTEXT.use                = true
   key._OP_ARTIFACT_PATH.use                   = true
@@ -1363,6 +1373,11 @@ container.
   key.DOCKER_BASE_IMAGE_CONFIG_DIGEST.use     = true
   key.DOCKER_BASE_IMAGES.use                  = true
   key.DOCKER_COPY_IMAGES.use                  = true
+  key.CALLER_ATTESTED_INFO.use                = true
+  key.CALLER_ATTESTED_HOST_INFO.use           = true
+  key.CALLER_ATTESTED_BUILD_INFO.use          = true
+  key.CALLER_ATTESTED_ARTIFACT_INFO.use       = true
+  key.CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO.use = true
   key._OP_ARTIFACT_TYPE.use                   = true
   key._OP_ARTIFACT_CONTEXT.use                = true
   key._OP_ARTIFACT_PATH.use                   = true
@@ -1881,6 +1896,11 @@ and keep the run-time key.
   key.DOCKER_BASE_IMAGE_CONFIG_DIGEST.use     = true
   key.DOCKER_BASE_IMAGES.use                  = true
   key.DOCKER_COPY_IMAGES.use                  = true
+  key.CALLER_ATTESTED_INFO.use                = true
+  key.CALLER_ATTESTED_HOST_INFO.use           = true
+  key.CALLER_ATTESTED_BUILD_INFO.use          = true
+  key.CALLER_ATTESTED_ARTIFACT_INFO.use       = true
+  key.CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO.use = true
   key._OP_ARTIFACT_TYPE.use                   = true
   key._OP_ARTIFACT_CONTEXT.use                = true
   key._OP_ARTIFACT_PATH.use                   = true

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -3400,7 +3400,7 @@ By default, virtual chalk marks will get appended to the file `./virtual-chalk.j
 
   field zip_extensions {
     type:       list[string]
-    default:    ["zip", "jar", "war", "ear"]
+    default:    ["zip", "jar", "war", "ear", "pt", "pth", "keras"]
     validator:  func zip_check
     hidden:     true
     doc:        "Extensions that we assume are in ZIP format for the zip codec"

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -4357,7 +4357,7 @@ func sink_filter_check(name, filterList: list[string]) {
 
 # TODO: should add a "choices" constraint to con4m.
 func zip_check(keyname: string, value: list[string]) {
-  valid_items := ["zip", "jar", "war", "ear"]
+  valid_items := ["zip", "jar", "war", "ear", "pt", "pth", "keras"]
 
   for i from 0 to len(value) {
     if not contains(valid_items, value[i]) {

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -3414,6 +3414,13 @@ By default, virtual chalk marks will get appended to the file `./virtual-chalk.j
     doc:        "Extensions that we assume are Python bytecode files for the python .pyc codec"
   }
 
+  field sidecar_extensions {
+    type:       list[string]
+    default:    ["onnx", "bin", "pt", "pth"]
+    hidden:     true
+    doc:        "Extensions handled by the model_sidecar codec when no in-band codec claims the file. Default covers ONNX (no protobuf parser yet), Ollama-style .bin blobs, and legacy non-ZIP PyTorch checkpoints."
+  }
+
   field con4m_pinpoint {
     type:    bool
     default: true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -289,6 +289,13 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.DOCKER_BASE_IMAGE_CONFIG_DIGEST.use     = true
   ~key.DOCKER_BASE_IMAGES.use                  = true
   ~key.DOCKER_COPY_IMAGES.use                  = true
+
+  ~key.CALLER_ATTESTED_INFO.use                    = true
+  ~key.CALLER_ATTESTED_HOST_INFO.use               = true
+  ~key.CALLER_ATTESTED_BUILD_INFO.use              = true
+  ~key.CALLER_ATTESTED_ARTIFACT_INFO.use           = true
+  ~key.CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO.use = true
+
   ~key._OP_ARTIFACT_TYPE.use                   = true
   ~key._OP_ARTIFACT_CONTEXT.use                = true
   ~key._OP_ARTIFACT_PATH.use                   = true

--- a/src/plugin_load.nim
+++ b/src/plugin_load.nim
@@ -37,6 +37,7 @@ macro loadPlugins(list: static[openArray[string]]): untyped =
 loadPlugins([
   "awsEcs",
   "awsLambda",
+  "callerAttestation",
   "ciAzureDevops",
   "ciBitbucket",
   "ciBuildkite",

--- a/src/plugin_load.nim
+++ b/src/plugin_load.nim
@@ -51,6 +51,7 @@ loadPlugins([
   "codecDocker",
   "codecElf",
   "codecFallbackElf",
+  "codecGguf",
   "codecMacho",
   "codecMacOs",
   "codecPythonPyc",

--- a/src/plugin_load.nim
+++ b/src/plugin_load.nim
@@ -54,6 +54,7 @@ loadPlugins([
   "codecMacho",
   "codecMacOs",
   "codecPythonPyc",
+  "codecSafetensors",
   "codecSource",
   "codecZip",
   "conffile",

--- a/src/plugin_load.nim
+++ b/src/plugin_load.nim
@@ -54,6 +54,7 @@ loadPlugins([
   "codecGguf",
   "codecMacho",
   "codecMacOs",
+  "codecModelSidecar",
   "codecPythonPyc",
   "codecSafetensors",
   "codecSource",

--- a/src/plugins/callerAttestation.nim
+++ b/src/plugins/callerAttestation.nim
@@ -50,26 +50,16 @@ const
   recognizedTopLevel = [keyInfo, keyHostInfo, keyBuildInfo, keyArtifactInfo]
 
 type
-  ArtifactEntry* = object
+  ArtifactEntry = ref object
     sha256*: string
     info*:   JsonNode  # may be nil if caller omitted `info`
 
-  EnvelopeState* = object
-    valid*:       bool
+  EnvelopeState = ref object of RootRef
     info*:        JsonNode
     hostInfo*:    JsonNode
     buildInfo*:   JsonNode
     artifacts*:   TableRef[string, ArtifactEntry]
     matchedKeys*: HashSet[string]
-
-  ValidationResult* = object
-    state*:    EnvelopeState
-    errMsg*:   string       # non-empty → envelope rejected
-    warnings*: seq[string]  # passes that succeeded but want a warn log
-
-var
-  loaded = false
-  state: EnvelopeState
 
 # ---------------------------------------------------------------------------
 # Envelope read / validate
@@ -86,12 +76,9 @@ proc readEnvelopeBytes(): string =
     error(envFile & "=" & path &
           ": file not found; ignoring caller attestation")
     return ""
-  try:
-    return readFile(path)
-  except IOError, OSError:
-    error(envFile & "=" & path & ": " & getCurrentExceptionMsg() &
-          "; ignoring caller attestation")
-    return ""
+  result = tryToLoadFile(path)
+  if result == "":
+    error(envFile & "=" & path & ": does not contain chalk attestation")
 
 proc isHex64(s: string): bool =
   if s.len != 64:
@@ -101,113 +88,83 @@ proc isHex64(s: string): bool =
       return false
   return true
 
-proc parseAndValidate*(raw: string): ValidationResult =
+proc parseAndValidate(raw: string): EnvelopeState =
   ## Pure parser/validator over the caller-attestation envelope.  The
   ## procedure has no side effects: it returns errMsg/warnings the
   ## caller is responsible for logging.  Exposed so the unit-test
   ## suite can exercise the validation logic without dragging in the
   ## chalk plugin runtime.
-  result.state.valid       = false
-  result.state.artifacts   = newTable[string, ArtifactEntry]()
-  result.state.matchedKeys = initHashSet[string]()
-  result.warnings          = @[]
+  new result
+  result.artifacts   = newTable[string, ArtifactEntry]()
+  result.matchedKeys = initHashSet[string]()
 
   if raw.len == 0:
     return
 
-  var node: JsonNode
-  try:
-    node = parseJson(raw)
-  except JsonParsingError:
-    result.errMsg = "malformed JSON: " & getCurrentExceptionMsg()
-    return
+  let
+    node     = parseJson(raw).assertIs(JObject, "top-level must be a JSON object")
+    version  = node.assertHasKey(keyVersion)[keyVersion].assertIs(JInt).getInt()
 
-  if node.kind != JObject:
-    result.errMsg = "top-level must be a JSON object"
-    return
-
-  if not node.hasKey(keyVersion):
-    result.errMsg = "missing required `" & keyVersion & "` field"
-    return
-  let verNode = node[keyVersion]
-  if verNode.kind != JInt or verNode.getInt() != protocolVersion:
-    result.errMsg = "unsupported `" & keyVersion & "` (expected " &
-                    $protocolVersion & ")"
-    return
+  if version != protocolVersion:
+    raise newException(
+      ValueError,
+      "unsupported `" & keyVersion & "` (expected " & $protocolVersion & ")"
+    )
 
   for k, _ in node.pairs():
     if k == keyVersion or k in recognizedTopLevel:
       continue
     if k.startsWith("X-"):
       continue
-    result.warnings.add("unknown top-level key '" & k & "' (ignored)")
+    warn("unknown top-level key '" & k & "' (ignored)")
 
   for k in [keyInfo, keyHostInfo, keyBuildInfo]:
-    if node.hasKey(k) and node[k].kind != JObject:
-      result.errMsg = "'" & k & "' must be a JSON object"
-      return
+    if node.hasKey(k):
+      node[k].assertIs(JObject, "'" & k & "' must be a JSON object")
 
-  if node.hasKey(keyInfo):      result.state.info      = node[keyInfo]
-  if node.hasKey(keyHostInfo):  result.state.hostInfo  = node[keyHostInfo]
-  if node.hasKey(keyBuildInfo): result.state.buildInfo = node[keyBuildInfo]
+  result.info      = node{keyInfo}.assertIs(JObject,      keyInfo,      allowNil = true)
+  result.hostInfo  = node{keyHostInfo}.assertIs(JObject,  keyHostInfo,  allowNil = true)
+  result.buildInfo = node{keyBuildInfo}.assertIs(JObject, keyBuildInfo, allowNil = true)
 
   if node.hasKey(keyArtifactInfo):
-    let artNode = node[keyArtifactInfo]
-    if artNode.kind != JObject:
-      result.errMsg = "'" & keyArtifactInfo & "' must be a JSON object"
-      return
+    let artNode = node[keyArtifactInfo].assertIs(JObject, keyArtifactInfo)
     for path, entry in artNode.pairs():
-      if entry.kind != JObject:
-        result.errMsg = "entry for '" & path & "' must be an object"
-        return
-      if not entry.hasKey("sha256") or entry["sha256"].kind != JString:
-        result.errMsg = "entry for '" & path &
-                        "' is missing required string 'sha256'"
-        return
+      entry.assertIs(JObject, "entry for '" & path & "' must be an object")
+      entry.assertHasKey("sha256", "entry for '" & path & "' is missing required 'sha256'").assertIs(JString)
       let sha = entry["sha256"].getStr().toLowerAscii()
       if not sha.isHex64():
-        result.errMsg = "entry for '" & path &
-                        "' has invalid 'sha256' (expected 64-char " &
-                        "lowercase hex)"
-        return
+        raise newException(
+          ValueError,
+          "entry for '" & path &
+          "' has invalid 'sha256' (expected 64-char " &
+          "lowercase hex)"
+        )
       for fk, _ in entry.pairs():
         if fk != "sha256" and fk != "info":
-          result.errMsg = "entry for '" & path &
-                          "' has unexpected field '" & fk & "'"
-          return
-      var infoNode: JsonNode = nil
-      if entry.hasKey("info"):
-        infoNode = entry["info"]
-      result.state.artifacts[path] = ArtifactEntry(sha256: sha, info: infoNode)
+          raise newException(
+            ValueError,
+            "entry for '" & path &
+            "' has unexpected field '" & fk & "'"
+          )
+      let infoNode = entry{"info"}
+      result.artifacts[path] = ArtifactEntry(sha256: sha, info: infoNode)
 
-  result.state.valid = true
-
-proc loadEnvelopeOnce() =
-  if loaded:
-    return
-  loaded = true
-  let
-    raw = readEnvelopeBytes()
-    res = parseAndValidate(raw)
-  if res.errMsg.len > 0:
-    error("caller attestation: " & res.errMsg & "; envelope discarded")
-    return
-  for w in res.warnings:
-    warn("caller attestation: " & w)
-  state = res.state
-  if state.valid:
+proc loadEnvelope(self: Plugin): EnvelopeState =
+  if self.internalState != nil:
+    return EnvelopeState(self.internalState)
+  try:
+    let raw = readEnvelopeBytes()
+    result = parseAndValidate(raw)
+    self.internalState = RootRef(result)
     trace("caller_attestation: envelope loaded (" &
-          $state.artifacts.len & " artifact entries)")
+          $result.artifacts.len & " artifact entries)")
+  except:
+    error("caller attestation: " & getCurrentExceptionMsg() & "; envelope discarded")
+    return nil
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-proc realpath(p: string): string =
-  try:
-    return expandFilename(p)
-  except OSError:
-    return ""
 
 proc infoOrEmpty(n: JsonNode): JsonNode =
   ## `info` is optional in the protocol; chalk emits `{}` when the
@@ -215,46 +172,49 @@ proc infoOrEmpty(n: JsonNode): JsonNode =
   if n == nil: newJObject() else: n
 
 proc statusJson(status:      string,
-                attestedSha: string,
-                observedSha: string,
-                info:        JsonNode): JsonNode =
-  result = newJObject()
-  result["status"] = newJString(status)
+                info:        JsonNode,
+                attestedSha: string = "",
+                observedSha: string = "",
+                ): JsonNode =
+  result = %*({
+    "status": status,
+    "info":   infoOrEmpty(info),
+  })
   if status != "match":
     if attestedSha.len > 0:
       result["attested_sha256"] = newJString(attestedSha)
     if observedSha.len > 0:
       result["observed_sha256"] = newJString(observedSha)
-  result["info"] = infoOrEmpty(info)
 
 proc untrackedEntryJson(entry: ArtifactEntry): JsonNode =
-  result = newJObject()
-  result["sha256"] = newJString(entry.sha256)
-  result["info"]   = infoOrEmpty(entry.info)
+  return %*({
+    "sha256": entry.sha256,
+    "info":   infoOrEmpty(entry.info),
+  })
 
 # ---------------------------------------------------------------------------
 # Callbacks
 # ---------------------------------------------------------------------------
 
-proc callerAttestGetCtHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
+proc callerAttestGetCtHostInfo(self: Plugin): ChalkDict {.cdecl.} =
   result = ChalkDict()
-  loadEnvelopeOnce()
-  if not state.valid:
+  let state = self.loadEnvelope()
+  if state == nil:
     return
   if state.info != nil:
-    result.setIfNeeded(keyInfo, state.info.nimJsonToBox())
+    result.setIfNeeded(keyInfo,      state.info.nimJsonToBox())
   if state.hostInfo != nil:
-    result.setIfNeeded(keyHostInfo, state.hostInfo.nimJsonToBox())
+    result.setIfNeeded(keyHostInfo,  state.hostInfo.nimJsonToBox())
   if state.buildInfo != nil:
     result.setIfNeeded(keyBuildInfo, state.buildInfo.nimJsonToBox())
 
-proc callerAttestGetCtArtifactInfo*(self: Plugin, obj: ChalkObj):
+proc callerAttestGetCtArtifactInfo(self: Plugin, obj: ChalkObj):
                                     ChalkDict {.cdecl.} =
   result = ChalkDict()
-  loadEnvelopeOnce()
-  if not state.valid or state.artifacts.len == 0:
+  let state = self.loadEnvelope()
+  if state == nil or state.artifacts.len == 0:
     return
-  let resolved = realpath(obj.fsRef)
+  let resolved = obj.fsRef.resolvePath()
   if resolved.len == 0 or resolved notin state.artifacts:
     return
   state.matchedKeys.incl(resolved)
@@ -266,27 +226,42 @@ proc callerAttestGetCtArtifactInfo*(self: Plugin, obj: ChalkObj):
          "available; attestation recorded with status \"unverified\".")
     result.setIfNeeded(
       keyArtifactInfo,
-      statusJson("unverified", entry.sha256, "", entry.info).nimJsonToBox())
+      statusJson(
+        status      = "unverified",
+        attestedSha = entry.sha256,
+        info        = entry.info,
+      ).nimJsonToBox()
+    )
     return
 
   let observed = observedOpt.get().toLowerAscii()
   if observed == entry.sha256:
     result.setIfNeeded(
       keyArtifactInfo,
-      statusJson("match", "", "", entry.info).nimJsonToBox())
+      statusJson(
+        status = "match",
+        info   = entry.info,
+      ).nimJsonToBox()
+    )
   else:
     warn(obj.fsRef & ": caller-attested hash mismatch (attested " &
          entry.sha256 & ", observed " & observed &
          "); attestation recorded with status \"mismatch\".")
     result.setIfNeeded(
       keyArtifactInfo,
-      statusJson("mismatch", entry.sha256, observed, entry.info).nimJsonToBox())
+      statusJson(
+        status      = "mismatch",
+        attestedSha = entry.sha256,
+        observedSha = observed,
+        info        = entry.info,
+      ).nimJsonToBox()
+    )
 
-proc callerAttestGetRtHostInfo*(self: Plugin, objs: seq[ChalkObj]):
+proc callerAttestGetRtHostInfo(self: Plugin, objs: seq[ChalkObj]):
                                 ChalkDict {.cdecl.} =
   result = ChalkDict()
-  loadEnvelopeOnce()
-  if not state.valid or state.artifacts.len == 0:
+  let state = self.loadEnvelope()
+  if state == nil or state.artifacts.len == 0:
     return
   let untracked = newJObject()
   for path, entry in state.artifacts.pairs():
@@ -295,12 +270,14 @@ proc callerAttestGetRtHostInfo*(self: Plugin, objs: seq[ChalkObj]):
     warn(path & ": caller attested but artifact was not processed by " &
          "chalk; moved to " & keyUntracked & ".")
     untracked[path] = untrackedEntryJson(entry)
-  if untracked.len > 0:
-    result.setIfNeeded(keyUntracked, untracked.nimJsonToBox())
+  result.setIfNeeded(keyUntracked, untracked.nimJsonToBox())
 
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
+
+proc clearCallback(self: Plugin) {.cdecl.} =
+  self.internalState = RootRef(nil)
 
 proc loadCallerAttestation*() =
   newPlugin(
@@ -308,4 +285,5 @@ proc loadCallerAttestation*() =
     ctHostCallback = ChalkTimeHostCb(callerAttestGetCtHostInfo),
     ctArtCallback  = ChalkTimeArtifactCb(callerAttestGetCtArtifactInfo),
     rtHostCallback = RunTimeHostCb(callerAttestGetRtHostInfo),
+    clearCallback  = PluginClearCb(clearCallback),
   )

--- a/src/plugins/callerAttestation.nim
+++ b/src/plugins/callerAttestation.nim
@@ -1,0 +1,311 @@
+##
+## Copyright (c) 2026, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Caller-attestation plugin: ingests a JSON envelope from the
+## process that spawned chalk (via `CHALK_CALLER_ATTESTATION`
+## env-var, or `CHALK_CALLER_ATTESTATION_FILE` fallback), validates
+## its top-level shape, and emits the agreed `CALLER_ATTESTED_*`
+## keys into marks and reports.
+##
+## Inner `info` payloads are passed through opaquely; chalk
+## validates only the envelope's outer structure.  Per-artifact
+## entries are status-wrapped so a caller race or tampering shows
+## up as `mismatch` rather than silently overwriting.
+##
+## See `docs/design-caller-attestation.md` for the wire-format
+## contract.
+
+import std/[
+  json,
+  options,
+  os,
+  sets,
+  strutils,
+  tables,
+]
+
+import ".."/[
+  chalkjson,
+  plugin_api,
+  run_management,
+  types,
+]
+
+const
+  envEnvelope     = "CHALK_CALLER_ATTESTATION"
+  envFile         = "CHALK_CALLER_ATTESTATION_FILE"
+  protocolVersion = 1
+
+  keyVersion      = "version"
+  keyInfo         = "CALLER_ATTESTED_INFO"
+  keyHostInfo     = "CALLER_ATTESTED_HOST_INFO"
+  keyBuildInfo    = "CALLER_ATTESTED_BUILD_INFO"
+  keyArtifactInfo = "CALLER_ATTESTED_ARTIFACT_INFO"
+  keyUntracked    = "CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO"
+
+  recognizedTopLevel = [keyInfo, keyHostInfo, keyBuildInfo, keyArtifactInfo]
+
+type
+  ArtifactEntry* = object
+    sha256*: string
+    info*:   JsonNode  # may be nil if caller omitted `info`
+
+  EnvelopeState* = object
+    valid*:       bool
+    info*:        JsonNode
+    hostInfo*:    JsonNode
+    buildInfo*:   JsonNode
+    artifacts*:   TableRef[string, ArtifactEntry]
+    matchedKeys*: HashSet[string]
+
+  ValidationResult* = object
+    state*:    EnvelopeState
+    errMsg*:   string       # non-empty → envelope rejected
+    warnings*: seq[string]  # passes that succeeded but want a warn log
+
+var
+  loaded = false
+  state: EnvelopeState
+
+# ---------------------------------------------------------------------------
+# Envelope read / validate
+# ---------------------------------------------------------------------------
+
+proc readEnvelopeBytes(): string =
+  let envContent = getEnv(envEnvelope)
+  if envContent.len > 0:
+    return envContent
+  let path = getEnv(envFile)
+  if path.len == 0:
+    return ""
+  if not fileExists(path):
+    error(envFile & "=" & path &
+          ": file not found; ignoring caller attestation")
+    return ""
+  try:
+    return readFile(path)
+  except IOError, OSError:
+    error(envFile & "=" & path & ": " & getCurrentExceptionMsg() &
+          "; ignoring caller attestation")
+    return ""
+
+proc isHex64(s: string): bool =
+  if s.len != 64:
+    return false
+  for c in s:
+    if c notin {'0'..'9', 'a'..'f'}:
+      return false
+  return true
+
+proc parseAndValidate*(raw: string): ValidationResult =
+  ## Pure parser/validator over the caller-attestation envelope.  The
+  ## procedure has no side effects: it returns errMsg/warnings the
+  ## caller is responsible for logging.  Exposed so the unit-test
+  ## suite can exercise the validation logic without dragging in the
+  ## chalk plugin runtime.
+  result.state.valid       = false
+  result.state.artifacts   = newTable[string, ArtifactEntry]()
+  result.state.matchedKeys = initHashSet[string]()
+  result.warnings          = @[]
+
+  if raw.len == 0:
+    return
+
+  var node: JsonNode
+  try:
+    node = parseJson(raw)
+  except JsonParsingError:
+    result.errMsg = "malformed JSON: " & getCurrentExceptionMsg()
+    return
+
+  if node.kind != JObject:
+    result.errMsg = "top-level must be a JSON object"
+    return
+
+  if not node.hasKey(keyVersion):
+    result.errMsg = "missing required `" & keyVersion & "` field"
+    return
+  let verNode = node[keyVersion]
+  if verNode.kind != JInt or verNode.getInt() != protocolVersion:
+    result.errMsg = "unsupported `" & keyVersion & "` (expected " &
+                    $protocolVersion & ")"
+    return
+
+  for k, _ in node.pairs():
+    if k == keyVersion or k in recognizedTopLevel:
+      continue
+    if k.startsWith("X-"):
+      continue
+    result.warnings.add("unknown top-level key '" & k & "' (ignored)")
+
+  for k in [keyInfo, keyHostInfo, keyBuildInfo]:
+    if node.hasKey(k) and node[k].kind != JObject:
+      result.errMsg = "'" & k & "' must be a JSON object"
+      return
+
+  if node.hasKey(keyInfo):      result.state.info      = node[keyInfo]
+  if node.hasKey(keyHostInfo):  result.state.hostInfo  = node[keyHostInfo]
+  if node.hasKey(keyBuildInfo): result.state.buildInfo = node[keyBuildInfo]
+
+  if node.hasKey(keyArtifactInfo):
+    let artNode = node[keyArtifactInfo]
+    if artNode.kind != JObject:
+      result.errMsg = "'" & keyArtifactInfo & "' must be a JSON object"
+      return
+    for path, entry in artNode.pairs():
+      if entry.kind != JObject:
+        result.errMsg = "entry for '" & path & "' must be an object"
+        return
+      if not entry.hasKey("sha256") or entry["sha256"].kind != JString:
+        result.errMsg = "entry for '" & path &
+                        "' is missing required string 'sha256'"
+        return
+      let sha = entry["sha256"].getStr().toLowerAscii()
+      if not sha.isHex64():
+        result.errMsg = "entry for '" & path &
+                        "' has invalid 'sha256' (expected 64-char " &
+                        "lowercase hex)"
+        return
+      for fk, _ in entry.pairs():
+        if fk != "sha256" and fk != "info":
+          result.errMsg = "entry for '" & path &
+                          "' has unexpected field '" & fk & "'"
+          return
+      var infoNode: JsonNode = nil
+      if entry.hasKey("info"):
+        infoNode = entry["info"]
+      result.state.artifacts[path] = ArtifactEntry(sha256: sha, info: infoNode)
+
+  result.state.valid = true
+
+proc loadEnvelopeOnce() =
+  if loaded:
+    return
+  loaded = true
+  let
+    raw = readEnvelopeBytes()
+    res = parseAndValidate(raw)
+  if res.errMsg.len > 0:
+    error("caller attestation: " & res.errMsg & "; envelope discarded")
+    return
+  for w in res.warnings:
+    warn("caller attestation: " & w)
+  state = res.state
+  if state.valid:
+    trace("caller_attestation: envelope loaded (" &
+          $state.artifacts.len & " artifact entries)")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+proc realpath(p: string): string =
+  try:
+    return expandFilename(p)
+  except OSError:
+    return ""
+
+proc infoOrEmpty(n: JsonNode): JsonNode =
+  ## `info` is optional in the protocol; chalk emits `{}` when the
+  ## caller omitted it so the wrapper's shape is uniform.
+  if n == nil: newJObject() else: n
+
+proc statusJson(status:      string,
+                attestedSha: string,
+                observedSha: string,
+                info:        JsonNode): JsonNode =
+  result = newJObject()
+  result["status"] = newJString(status)
+  if status != "match":
+    if attestedSha.len > 0:
+      result["attested_sha256"] = newJString(attestedSha)
+    if observedSha.len > 0:
+      result["observed_sha256"] = newJString(observedSha)
+  result["info"] = infoOrEmpty(info)
+
+proc untrackedEntryJson(entry: ArtifactEntry): JsonNode =
+  result = newJObject()
+  result["sha256"] = newJString(entry.sha256)
+  result["info"]   = infoOrEmpty(entry.info)
+
+# ---------------------------------------------------------------------------
+# Callbacks
+# ---------------------------------------------------------------------------
+
+proc callerAttestGetCtHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  loadEnvelopeOnce()
+  if not state.valid:
+    return
+  if state.info != nil:
+    result.setIfNeeded(keyInfo, state.info.nimJsonToBox())
+  if state.hostInfo != nil:
+    result.setIfNeeded(keyHostInfo, state.hostInfo.nimJsonToBox())
+  if state.buildInfo != nil:
+    result.setIfNeeded(keyBuildInfo, state.buildInfo.nimJsonToBox())
+
+proc callerAttestGetCtArtifactInfo*(self: Plugin, obj: ChalkObj):
+                                    ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  loadEnvelopeOnce()
+  if not state.valid or state.artifacts.len == 0:
+    return
+  let resolved = realpath(obj.fsRef)
+  if resolved.len == 0 or resolved notin state.artifacts:
+    return
+  state.matchedKeys.incl(resolved)
+  let entry = state.artifacts[resolved]
+
+  let observedOpt = callGetUnchalkedHash(obj)
+  if observedOpt.isNone():
+    warn(obj.fsRef & ": caller attested but no unchalked hash is " &
+         "available; attestation recorded with status \"unverified\".")
+    result.setIfNeeded(
+      keyArtifactInfo,
+      statusJson("unverified", entry.sha256, "", entry.info).nimJsonToBox())
+    return
+
+  let observed = observedOpt.get().toLowerAscii()
+  if observed == entry.sha256:
+    result.setIfNeeded(
+      keyArtifactInfo,
+      statusJson("match", "", "", entry.info).nimJsonToBox())
+  else:
+    warn(obj.fsRef & ": caller-attested hash mismatch (attested " &
+         entry.sha256 & ", observed " & observed &
+         "); attestation recorded with status \"mismatch\".")
+    result.setIfNeeded(
+      keyArtifactInfo,
+      statusJson("mismatch", entry.sha256, observed, entry.info).nimJsonToBox())
+
+proc callerAttestGetRtHostInfo*(self: Plugin, objs: seq[ChalkObj]):
+                                ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  loadEnvelopeOnce()
+  if not state.valid or state.artifacts.len == 0:
+    return
+  let untracked = newJObject()
+  for path, entry in state.artifacts.pairs():
+    if path in state.matchedKeys:
+      continue
+    warn(path & ": caller attested but artifact was not processed by " &
+         "chalk; moved to " & keyUntracked & ".")
+    untracked[path] = untrackedEntryJson(entry)
+  if untracked.len > 0:
+    result.setIfNeeded(keyUntracked, untracked.nimJsonToBox())
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+proc loadCallerAttestation*() =
+  newPlugin(
+    "caller_attestation",
+    ctHostCallback = ChalkTimeHostCb(callerAttestGetCtHostInfo),
+    ctArtCallback  = ChalkTimeArtifactCb(callerAttestGetCtArtifactInfo),
+    rtHostCallback = RunTimeHostCb(callerAttestGetRtHostInfo),
+  )

--- a/src/plugins/callerAttestation.nim
+++ b/src/plugins/callerAttestation.nim
@@ -103,7 +103,7 @@ proc parseAndValidate(raw: string): EnvelopeState =
 
   let
     node     = parseJson(raw).assertIs(JObject, "top-level must be a JSON object")
-    version  = node.assertHasKey(keyVersion)[keyVersion].assertIs(JInt).getInt()
+    version  = node.assertHasKey(keyVersion).assertIs(JInt).getInt()
 
   if version != protocolVersion:
     raise newException(

--- a/src/plugins/codecGguf.nim
+++ b/src/plugins/codecGguf.nim
@@ -1,0 +1,173 @@
+##
+## Copyright (c) 2026, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Native GGUF codec.  Marks `.gguf` files by inserting a string KV
+## pair `chalk.mark` into the file's metadata section, with alignment
+## padding recomputed so tensor data offsets remain valid.  See
+## docs/design-model-codecs.md.
+##
+## Refuses (returns none → fallback codec at lower priority) when:
+##   - the file is shorter than the GGUF header
+##   - magic is not "GGUF"
+##   - version is not 2 or 3
+##   - the KV section or tensor info parse fails
+
+import std/[
+  options,
+  os,
+  strutils,
+]
+
+import ".."/[
+  chalkjson,
+  plugin_api,
+  run_management,
+  types,
+  utils/files,
+  utils/gguf,
+]
+
+type
+  GgufCache = ref object of RootRef
+    parsed: ParsedGguf
+
+# ---------------------------------------------------------------------------
+# scan
+# ---------------------------------------------------------------------------
+
+proc ggufScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
+  if not path.toLowerAscii().endsWith(GgufExt):
+    return none(ChalkObj)
+
+  let bytes =
+    try:
+      readFile(path)
+    except IOError, OSError:
+      return none(ChalkObj)
+
+  if bytes.len < 24 or bytes[0 .. 3] != GgufMagic:
+    return none(ChalkObj)
+
+  let parsed = parseGguf(bytes)
+  if parsed == nil:
+    trace(path & ": GGUF parse failed; deferring to fallback codec")
+    return none(ChalkObj)
+
+  let cache = GgufCache(parsed: parsed)
+
+  var dict: ChalkDict
+  var marked = false
+
+  let existing = parsed.getChalkPayload()
+  if existing != "":
+    if existing.find(magicUTF8) == -1:
+      warn(path & ": chalk.mark KV present but missing magic; " &
+           "treating as unmarked")
+    else:
+      dict   = extractOneChalkJson(existing, path)
+      marked = dict != nil
+
+  let chalk = newChalk(
+    name         = path,
+    fsRef        = path,
+    codec        = self,
+    resourceType = {ResourceFile},
+    cache        = cache,
+    extract      = dict,
+    marked       = marked,
+  )
+
+  return some(chalk)
+
+# ---------------------------------------------------------------------------
+# getUnchalkedHash
+# ---------------------------------------------------------------------------
+
+proc ggufGetUnchalkedHash*(self: Plugin, chalk: ChalkObj):
+                           Option[string] {.cdecl.} =
+  if chalk.cachedUnchalkedHash != "":
+    return some(chalk.cachedUnchalkedHash)
+
+  let cache = GgufCache(chalk.cache)
+  if cache == nil or cache.parsed == nil:
+    return none(string)
+
+  let hex = cache.parsed.unchalkedHash()
+  if hex == "":
+    error(chalk.name & ": GGUF unchalked-hash failed")
+    return none(string)
+
+  chalk.cachedUnchalkedHash = hex
+  return some(hex)
+
+# ---------------------------------------------------------------------------
+# handleWrite
+# ---------------------------------------------------------------------------
+
+proc ggufHandleWrite*(self: Plugin, chalk: ChalkObj,
+                      enc: Option[string]) {.cdecl.} =
+  let cache = GgufCache(chalk.cache)
+  if cache == nil or cache.parsed == nil:
+    error(chalk.name & ": no parsed GGUF state")
+    chalk.opFailed = true
+    return
+
+  discard chalk.callGetUnchalkedHash()
+
+  let st =
+    if enc.isSome() and enc.get().len > 0:
+      cache.parsed.setChalk(enc.get())
+    else:
+      let r = cache.parsed.removeChalk()
+      if r == cgNoChalk:
+        cgOk
+      else:
+        r
+
+  if st != cgOk:
+    warn(chalk.name & ": GGUF write failed (status " & $st & ")")
+    chalk.opFailed = true
+    return
+
+  let mutated = cache.parsed.getMutatedBytes()
+  if mutated.len == 0:
+    error(chalk.name & ": empty mutated bytes")
+    chalk.opFailed = true
+    return
+
+  if not chalk.fsRef.replaceFileContents(mutated):
+    error(chalk.name & ": replaceFileContents failed")
+    chalk.opFailed = true
+
+# ---------------------------------------------------------------------------
+# Metadata callbacks
+# ---------------------------------------------------------------------------
+
+proc ggufGetChalkTimeArtifactInfo*(self: Plugin, chalk: ChalkObj):
+                                   ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  result.setIfNeeded("ARTIFACT_TYPE", artTypeGguf)
+
+proc ggufGetRunTimeArtifactInfo*(self: Plugin, chalk: ChalkObj,
+                                 ins: bool): ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  result.setIfNeeded("_OP_ARTIFACT_TYPE", artTypeGguf)
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+proc loadCodecGguf*() =
+  newCodec(
+    "gguf",
+    nativeObjPlatforms = @["macosx", "linux"],
+    scan             = ScanCb(ggufScan),
+    handleWrite      = HandleWriteCb(ggufHandleWrite),
+    getUnchalkedHash = UnchalkedHashCb(ggufGetUnchalkedHash),
+    ctArtCallback    = ChalkTimeArtifactCb(ggufGetChalkTimeArtifactInfo),
+    rtArtCallback    = RunTimeArtifactCb(ggufGetRunTimeArtifactInfo),
+  )

--- a/src/plugins/codecGguf.nim
+++ b/src/plugins/codecGguf.nim
@@ -18,7 +18,6 @@
 
 import std/[
   options,
-  os,
   strutils,
 ]
 

--- a/src/plugins/codecGguf.nim
+++ b/src/plugins/codecGguf.nim
@@ -42,13 +42,21 @@ proc ggufScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
   if not path.toLowerAscii().endsWith(GgufExt):
     return none(ChalkObj)
 
-  let bytes =
+  var bytes: string
+  withFileStream(path, mode = fmRead, strict = false):
+    if stream == nil:
+      return none(ChalkObj)
     try:
-      readFile(path)
-    except IOError, OSError:
+      if stream.peekStr(GgufMagic.len) != GgufMagic:
+        return none(ChalkObj)
+    except:
+      return none(ChalkObj)
+    try:
+      bytes = stream.readAll()
+    except:
       return none(ChalkObj)
 
-  if bytes.len < 24 or bytes[0 .. 3] != GgufMagic:
+  if bytes.len < 24:
     return none(ChalkObj)
 
   let parsed = parseGguf(bytes)
@@ -57,9 +65,7 @@ proc ggufScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
     return none(ChalkObj)
 
   let cache = GgufCache(parsed: parsed)
-
   var dict: ChalkDict
-  var marked = false
 
   let existing = parsed.getChalkPayload()
   if existing != "":
@@ -67,8 +73,7 @@ proc ggufScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
       warn(path & ": chalk.mark KV present but missing magic; " &
            "treating as unmarked")
     else:
-      dict   = extractOneChalkJson(existing, path)
-      marked = dict != nil
+      dict = extractOneChalkJson(existing, path)
 
   let chalk = newChalk(
     name         = path,
@@ -77,7 +82,6 @@ proc ggufScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
     resourceType = {ResourceFile},
     cache        = cache,
     extract      = dict,
-    marked       = marked,
   )
 
   return some(chalk)
@@ -163,7 +167,6 @@ proc ggufGetRunTimeArtifactInfo*(self: Plugin, chalk: ChalkObj,
 proc loadCodecGguf*() =
   newCodec(
     "gguf",
-    nativeObjPlatforms = @["macosx", "linux"],
     scan             = ScanCb(ggufScan),
     handleWrite      = HandleWriteCb(ggufHandleWrite),
     getUnchalkedHash = UnchalkedHashCb(ggufGetUnchalkedHash),

--- a/src/plugins/codecModelSidecar.nim
+++ b/src/plugins/codecModelSidecar.nim
@@ -27,7 +27,6 @@ import std/[
 
 import ".."/[
   chalkjson,
-  config,
   plugin_api,
   run_management,
   types,

--- a/src/plugins/codecModelSidecar.nim
+++ b/src/plugins/codecModelSidecar.nim
@@ -1,0 +1,176 @@
+##
+## Copyright (c) 2026, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Last-resort codec for ML model file formats that can't be marked
+## in-band.  Writes a `<path>.chalk` sidecar file alongside the
+## artifact containing the mark JSON; reads the same file on extract.
+##
+## The codec is gated on a configured extension list
+## (`sidecar_extensions`) — it is NOT a global fallthrough.  In the
+## default config the list covers `.onnx` (no protobuf parser yet)
+## and `.bin` (Ollama-style raw blobs).  Legacy pickle PyTorch
+## checkpoints whose `.pt`/`.pth` files are not ZIP-shaped fall
+## through `codecZip`'s scan and end up here too, since the
+## extension list also names `pt` / `pth` as candidates for sidecar
+## fallback.  Format-specific codecs run at higher priority and
+## claim their formats first.
+
+import std/[
+  options,
+  os,
+  strutils,
+]
+
+import ".."/[
+  chalkjson,
+  config,
+  plugin_api,
+  run_management,
+  types,
+  utils/files,
+]
+
+const sidecarSuffix = ".chalk"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+proc sidecarPath(path: string): string =
+  path & sidecarSuffix
+
+proc readSidecar(path: string): string =
+  let sp = sidecarPath(path)
+  if not fileExists(sp):
+    return ""
+  try:
+    result = readFile(sp).strip()
+  except IOError, OSError:
+    result = ""
+
+proc extensionMatches(path: string): bool =
+  let ext = path.splitFile().ext.toLowerAscii()
+  if ext.len < 2:
+    return false
+  let bare = ext[1 .. ^1]  # drop leading '.'
+  for entry in attrGet[seq[string]]("sidecar_extensions"):
+    if entry.toLowerAscii() == bare:
+      return true
+  return false
+
+# ---------------------------------------------------------------------------
+# scan
+# ---------------------------------------------------------------------------
+
+proc sidecarScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
+  ## Claim files whose extension matches the sidecar list.  Higher-
+  ## priority codecs (safetensors, gguf, zip) run first; if they
+  ## refuse, this codec picks up.  We do NOT examine the file
+  ## contents — a sibling .chalk file is the only signal of a prior
+  ## mark.
+  if not extensionMatches(path):
+    return none(ChalkObj)
+  if not fileExists(path):
+    return none(ChalkObj)
+
+  let existing = readSidecar(path)
+  var dict: ChalkDict
+  var marked = false
+
+  if existing != "":
+    if existing.find(magicUTF8) == -1:
+      warn(path & ": sidecar present but missing magic; treating as unmarked")
+    else:
+      dict   = extractOneChalkJson(existing, path)
+      marked = dict != nil
+
+  let chalk = newChalk(
+    name         = path,
+    fsRef        = path,
+    codec        = self,
+    resourceType = {ResourceFile},
+    extract      = dict,
+    marked       = marked,
+  )
+
+  return some(chalk)
+
+# ---------------------------------------------------------------------------
+# getUnchalkedHash
+# ---------------------------------------------------------------------------
+
+proc sidecarGetUnchalkedHash*(self: Plugin, chalk: ChalkObj):
+                              Option[string] {.cdecl.} =
+  ## Sidecar marks live outside the artifact file itself, so the
+  ## unchalked hash is the natural file SHA-256 — no canonicalization
+  ## needed.
+  if chalk.cachedUnchalkedHash != "":
+    return some(chalk.cachedUnchalkedHash)
+  let bytes =
+    try:
+      readFile(chalk.fsRef)
+    except IOError, OSError:
+      return none(string)
+  let hex = bytes.sha256Hex()
+  chalk.cachedUnchalkedHash = hex
+  return some(hex)
+
+# ---------------------------------------------------------------------------
+# handleWrite
+# ---------------------------------------------------------------------------
+
+proc sidecarHandleWrite*(self: Plugin, chalk: ChalkObj,
+                         enc: Option[string]) {.cdecl.} =
+  ## enc.isSome() with non-empty content → write the sidecar.
+  ## enc.isNone() or empty → unchalk by removing any existing
+  ## sidecar.  The artifact file itself is never touched.
+  let sp = sidecarPath(chalk.fsRef)
+
+  if enc.isSome() and enc.get().len > 0:
+    var line = enc.get()
+    if not line.endsWith("\n"):
+      line.add("\n")
+    if not tryToWriteFile(sp, line):
+      error(chalk.name & ": could not write sidecar " & sp)
+      chalk.opFailed = true
+      return
+  else:
+    if fileExists(sp):
+      try:
+        removeFile(sp)
+      except IOError, OSError:
+        warn(chalk.name & ": could not remove sidecar " & sp & ": " &
+             getCurrentExceptionMsg())
+
+# ---------------------------------------------------------------------------
+# Metadata callbacks
+# ---------------------------------------------------------------------------
+
+proc sidecarGetChalkTimeArtifactInfo*(self: Plugin, chalk: ChalkObj):
+                                      ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  result.setIfNeeded("ARTIFACT_TYPE", artTypeMLModel)
+
+proc sidecarGetRunTimeArtifactInfo*(self: Plugin, chalk: ChalkObj,
+                                    ins: bool): ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  result.setIfNeeded("_OP_ARTIFACT_TYPE", artTypeMLModel)
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+proc loadCodecModelSidecar*() =
+  newCodec(
+    "model_sidecar",
+    nativeObjPlatforms = @["macosx", "linux"],
+    scan             = ScanCb(sidecarScan),
+    handleWrite      = HandleWriteCb(sidecarHandleWrite),
+    getUnchalkedHash = UnchalkedHashCb(sidecarGetUnchalkedHash),
+    ctArtCallback    = ChalkTimeArtifactCb(sidecarGetChalkTimeArtifactInfo),
+    rtArtCallback    = RunTimeArtifactCb(sidecarGetRunTimeArtifactInfo),
+  )

--- a/src/plugins/codecModelSidecar.nim
+++ b/src/plugins/codecModelSidecar.nim
@@ -42,15 +42,6 @@ const sidecarSuffix = ".chalk"
 proc sidecarPath(path: string): string =
   path & sidecarSuffix
 
-proc readSidecar(path: string): string =
-  let sp = sidecarPath(path)
-  if not fileExists(sp):
-    return ""
-  try:
-    result = readFile(sp).strip()
-  except IOError, OSError:
-    result = ""
-
 proc extensionMatches(path: string): bool =
   let ext = path.splitFile().ext.toLowerAscii()
   if ext.len < 2:
@@ -76,16 +67,14 @@ proc sidecarScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
   if not fileExists(path):
     return none(ChalkObj)
 
-  let existing = readSidecar(path)
   var dict: ChalkDict
-  var marked = false
-
-  if existing != "":
-    if existing.find(magicUTF8) == -1:
-      warn(path & ": sidecar present but missing magic; treating as unmarked")
-    else:
-      dict   = extractOneChalkJson(existing, path)
-      marked = dict != nil
+  let sp = sidecarPath(path)
+  withFileStream(sp, mode = fmRead, strict = false):
+    if stream != nil:
+      try:
+        dict = extractOneChalkJson(stream, path)
+      except:
+        warn(path & ": sidecar present but could not parse; treating as unmarked")
 
   let chalk = newChalk(
     name         = path,
@@ -93,7 +82,6 @@ proc sidecarScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
     codec        = self,
     resourceType = {ResourceFile},
     extract      = dict,
-    marked       = marked,
   )
 
   return some(chalk)
@@ -109,12 +97,12 @@ proc sidecarGetUnchalkedHash*(self: Plugin, chalk: ChalkObj):
   ## needed.
   if chalk.cachedUnchalkedHash != "":
     return some(chalk.cachedUnchalkedHash)
-  let bytes =
+  let fss =
     try:
-      readFile(chalk.fsRef)
-    except IOError, OSError:
+      newFileStringStream(chalk.fsRef)
+    except:
       return none(string)
-  let hex = bytes.sha256Hex()
+  let hex = fss.sha256Hex()
   chalk.cachedUnchalkedHash = hex
   return some(hex)
 
@@ -166,7 +154,6 @@ proc sidecarGetRunTimeArtifactInfo*(self: Plugin, chalk: ChalkObj,
 proc loadCodecModelSidecar*() =
   newCodec(
     "model_sidecar",
-    nativeObjPlatforms = @["macosx", "linux"],
     scan             = ScanCb(sidecarScan),
     handleWrite      = HandleWriteCb(sidecarHandleWrite),
     getUnchalkedHash = UnchalkedHashCb(sidecarGetUnchalkedHash),

--- a/src/plugins/codecSafetensors.nim
+++ b/src/plugins/codecSafetensors.nim
@@ -1,0 +1,179 @@
+##
+## Copyright (c) 2026, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Native SafeTensors codec.  Marks `.safetensors` files by inserting
+## a `chalk` key under `__metadata__` in the file's JSON header.  See
+## docs/design-model-codecs.md.
+##
+## Refuses (returns none → next codec at lower priority) when:
+##   - the file is shorter than the SafeTensors header preamble
+##   - header_size is implausible / outside the file
+##   - the JSON header doesn't parse as an object
+##
+## Otherwise: mutate in place, write back, no re-signing involved.
+
+import std/[
+  options,
+  os,
+  strutils,
+]
+
+import ".."/[
+  chalkjson,
+  plugin_api,
+  run_management,
+  types,
+  utils/files,
+  utils/safetensors,
+]
+
+type
+  StCache = ref object of RootRef
+    ## Per-artifact state held across scan → handleWrite calls.
+    parsed:  ParsedSafetensors
+    rawSize: int
+
+# ---------------------------------------------------------------------------
+# scan
+# ---------------------------------------------------------------------------
+
+proc stScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
+  if not path.toLowerAscii().endsWith(SafetensorsExt):
+    return none(ChalkObj)
+
+  let bytes =
+    try:
+      readFile(path)
+    except IOError, OSError:
+      return none(ChalkObj)
+
+  if bytes.len < 8:
+    return none(ChalkObj)
+
+  let parsed = parseSafetensors(bytes)
+  if parsed == nil:
+    trace(path & ": SafeTensors parse failed; deferring to fallback codec")
+    return none(ChalkObj)
+
+  let cache = StCache(
+    parsed:  parsed,
+    rawSize: bytes.len,
+  )
+
+  var dict: ChalkDict
+  var marked = false
+
+  let existing = parsed.getChalkPayload()
+  if existing != "":
+    if existing.find(magicUTF8) == -1:
+      warn(path & ": __metadata__.chalk present but missing magic; " &
+           "treating as unmarked")
+    else:
+      dict   = extractOneChalkJson(existing, path)
+      marked = dict != nil
+
+  let chalk = newChalk(
+    name         = path,
+    fsRef        = path,
+    codec        = self,
+    resourceType = {ResourceFile},
+    cache        = cache,
+    extract      = dict,
+    marked       = marked,
+  )
+
+  return some(chalk)
+
+# ---------------------------------------------------------------------------
+# getUnchalkedHash
+# ---------------------------------------------------------------------------
+
+proc stGetUnchalkedHash*(self: Plugin, chalk: ChalkObj):
+                         Option[string] {.cdecl.} =
+  if chalk.cachedUnchalkedHash != "":
+    return some(chalk.cachedUnchalkedHash)
+
+  let cache = StCache(chalk.cache)
+  if cache == nil or cache.parsed == nil:
+    return none(string)
+
+  let hex = cache.parsed.unchalkedHash()
+  if hex == "":
+    error(chalk.name & ": SafeTensors unchalked-hash failed")
+    return none(string)
+
+  chalk.cachedUnchalkedHash = hex
+  return some(hex)
+
+# ---------------------------------------------------------------------------
+# handleWrite
+# ---------------------------------------------------------------------------
+
+proc stHandleWrite*(self: Plugin, chalk: ChalkObj,
+                    enc: Option[string]) {.cdecl.} =
+  let cache = StCache(chalk.cache)
+  if cache == nil or cache.parsed == nil:
+    error(chalk.name & ": no parsed SafeTensors state")
+    chalk.opFailed = true
+    return
+
+  # Compute the unchalked hash before mutating.
+  discard chalk.callGetUnchalkedHash()
+
+  let st =
+    if enc.isSome() and enc.get().len > 0:
+      cache.parsed.setChalk(enc.get())
+    else:
+      let r = cache.parsed.removeChalk()
+      if r == cstNoChalk:
+        cstOk
+      else:
+        r
+
+  if st != cstOk:
+    warn(chalk.name & ": SafeTensors write failed (status " & $st & ")")
+    chalk.opFailed = true
+    return
+
+  let mutated = cache.parsed.getMutatedBytes()
+  if mutated.len == 0:
+    error(chalk.name & ": empty mutated bytes")
+    chalk.opFailed = true
+    return
+
+  if not chalk.fsRef.replaceFileContents(mutated):
+    error(chalk.name & ": replaceFileContents failed")
+    chalk.opFailed = true
+
+# ---------------------------------------------------------------------------
+# Metadata callbacks
+# ---------------------------------------------------------------------------
+
+proc stGetChalkTimeArtifactInfo*(self: Plugin, chalk: ChalkObj):
+                                 ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  result.setIfNeeded("ARTIFACT_TYPE", artTypeSafetensors)
+
+proc stGetRunTimeArtifactInfo*(self: Plugin, chalk: ChalkObj,
+                               ins: bool): ChalkDict {.cdecl.} =
+  result = ChalkDict()
+  result.setIfNeeded("_OP_ARTIFACT_TYPE", artTypeSafetensors)
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+proc loadCodecSafetensors*() =
+  newCodec(
+    "safetensors",
+    nativeObjPlatforms = @["macosx", "linux"],
+    scan             = ScanCb(stScan),
+    handleWrite      = HandleWriteCb(stHandleWrite),
+    getUnchalkedHash = UnchalkedHashCb(stGetUnchalkedHash),
+    ctArtCallback    = ChalkTimeArtifactCb(stGetChalkTimeArtifactInfo),
+    rtArtCallback    = RunTimeArtifactCb(stGetRunTimeArtifactInfo),
+  )

--- a/src/plugins/codecSafetensors.nim
+++ b/src/plugins/codecSafetensors.nim
@@ -33,8 +33,7 @@ import ".."/[
 type
   StCache = ref object of RootRef
     ## Per-artifact state held across scan → handleWrite calls.
-    parsed:  ParsedSafetensors
-    rawSize: int
+    parsed: ParsedSafetensors
 
 # ---------------------------------------------------------------------------
 # scan
@@ -44,10 +43,13 @@ proc stScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
   if not path.toLowerAscii().endsWith(SafetensorsExt):
     return none(ChalkObj)
 
-  let bytes =
+  var bytes: string
+  withFileStream(path, mode = fmRead, strict = false):
+    if stream == nil:
+      return none(ChalkObj)
     try:
-      readFile(path)
-    except IOError, OSError:
+      bytes = stream.readAll()
+    except:
       return none(ChalkObj)
 
   if bytes.len < 8:
@@ -58,13 +60,8 @@ proc stScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
     trace(path & ": SafeTensors parse failed; deferring to fallback codec")
     return none(ChalkObj)
 
-  let cache = StCache(
-    parsed:  parsed,
-    rawSize: bytes.len,
-  )
-
+  let cache = StCache(parsed: parsed)
   var dict: ChalkDict
-  var marked = false
 
   let existing = parsed.getChalkPayload()
   if existing != "":
@@ -72,8 +69,7 @@ proc stScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
       warn(path & ": __metadata__.chalk present but missing magic; " &
            "treating as unmarked")
     else:
-      dict   = extractOneChalkJson(existing, path)
-      marked = dict != nil
+      dict = extractOneChalkJson(existing, path)
 
   let chalk = newChalk(
     name         = path,
@@ -82,7 +78,6 @@ proc stScan*(self: Plugin, path: string): Option[ChalkObj] {.cdecl.} =
     resourceType = {ResourceFile},
     cache        = cache,
     extract      = dict,
-    marked       = marked,
   )
 
   return some(chalk)
@@ -169,7 +164,6 @@ proc stGetRunTimeArtifactInfo*(self: Plugin, chalk: ChalkObj,
 proc loadCodecSafetensors*() =
   newCodec(
     "safetensors",
-    nativeObjPlatforms = @["macosx", "linux"],
     scan             = ScanCb(stScan),
     handleWrite      = HandleWriteCb(stHandleWrite),
     getUnchalkedHash = UnchalkedHashCb(stGetUnchalkedHash),

--- a/src/plugins/codecSafetensors.nim
+++ b/src/plugins/codecSafetensors.nim
@@ -18,7 +18,6 @@
 
 import std/[
   options,
-  os,
   strutils,
 ]
 

--- a/src/plugins/codecSource.nim
+++ b/src/plugins/codecSource.nim
@@ -76,6 +76,13 @@ proc detectCache(path: string): SourceCache =
     ext = ext[1 .. ^1] # No need for the period.
     if ext in attrGet[seq[string]]("source_marks.text_only_extensions"):
       return SourceCache(nil)
+    # Defer ML-model extensions to codecModelSidecar.  Source codec is
+    # permissive on extract/delete by design (`only_mark_shebangs` /
+    # `only_mark_when_execute_set` deliberately do not gate extraction),
+    # which would otherwise claim these files and prevent the sibling
+    # `<path>.chalk` from being read.
+    if ext in attrGet[seq[string]]("sidecar_extensions"):
+      return SourceCache(nil)
 
     let exts = attrGet[TableRef[string, string]]("source_marks.extensions_to_languages_map")
     if ext in exts:

--- a/src/plugins/codecZip.nim
+++ b/src/plugins/codecZip.nim
@@ -40,10 +40,12 @@ proc artifactType(obj: ChalkObj): string =
   let extension = obj.fsRef.splitFile().ext.toLowerAscii()
   result =
     case extension
-    of ".jar": artTypeJAR
-    of ".war": artTypeWAR
-    of ".ear": artTypeEAR
-    else:      artTypeZip
+    of ".jar":          artTypeJAR
+    of ".war":          artTypeWAR
+    of ".ear":          artTypeEAR
+    of ".pt", ".pth":   artTypePytorchCkpt
+    of ".keras":        artTypeKerasModel
+    else:               artTypeZip
 
 proc hashZipPath(path: string): string =
   var

--- a/src/types.nim
+++ b/src/types.nim
@@ -542,6 +542,11 @@ const
   artTypeDockerContainer* = "Docker Container"
   artTypePyc*             = "Python Bytecode"
   artTypeMachO*           = "Mach-O executable"
+  artTypeSafetensors*     = "SafeTensors model"
+  artTypeGguf*            = "GGUF model"
+  artTypePytorchCkpt*     = "PyTorch checkpoint"
+  artTypeKerasModel*      = "Keras model"
+  artTypeMLModel*         = "ML model"
   artX509Cert*            = "x509 Cert"
 
 var

--- a/src/utils/gguf.nim
+++ b/src/utils/gguf.nim
@@ -1,0 +1,163 @@
+##
+## Copyright (c) 2026, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Nim FFI bindings for the GGUF codec under src/codecs/gguf/.
+## Library glue, not a codec itself — codecGguf.nim imports this
+## module to do parse / read / mark / unmark / unchalked-hash.
+##
+## See src/codecs/gguf/include/gguf.h for the API contract.
+
+import std/[
+  os,
+]
+import pkg/[
+  nimutils/logging,
+]
+
+const
+  ggufIncDir = currentSourcePath.parentDir.parentDir &
+               "/codecs/gguf/include"
+  ggufCFlags = "-std=c23 -I" & ggufIncDir
+
+{.passc: "-I" & ggufIncDir.}
+
+{.compile("../codecs/gguf/src/gguf.c", ggufCFlags).}
+
+# ---------------------------------------------------------------------------
+# Opaque handle and status enum.
+# ---------------------------------------------------------------------------
+
+type
+  ChalkGgufHandle* = pointer
+
+  ChalkGgufStatus* {.size: sizeof(cint).} = enum
+    cgInternal    = -7
+    cgNoChalk     = -6
+    cgBadKv       = -5
+    cgBadVersion  = -4
+    cgBadMagic    = -3
+    cgTruncated   = -2
+    cgNull        = -1
+    cgOk          = 0
+
+# ---------------------------------------------------------------------------
+# C entry points.
+# ---------------------------------------------------------------------------
+
+proc chalk_gguf_parse(bytes: ptr uint8, length: csize_t): ChalkGgufHandle
+  {.importc, cdecl, header: "gguf.h".}
+
+proc chalk_gguf_free(g: ChalkGgufHandle)
+  {.importc, cdecl, header: "gguf.h".}
+
+proc chalk_gguf_get_payload(g: ChalkGgufHandle,
+                            outSize: ptr csize_t): cstring
+  {.importc, cdecl, header: "gguf.h".}
+
+proc chalk_gguf_set_chalk(g: ChalkGgufHandle,
+                          mark: cstring, markLen: csize_t): cint
+  {.importc, cdecl, header: "gguf.h".}
+
+proc chalk_gguf_remove_chalk(g: ChalkGgufHandle): cint
+  {.importc, cdecl, header: "gguf.h".}
+
+proc chalk_gguf_get_buffer(g: ChalkGgufHandle,
+                           outSize: ptr csize_t): pointer
+  {.importc, cdecl, header: "gguf.h".}
+
+proc chalk_gguf_unchalked_hash(g: ChalkGgufHandle, outHex: cstring): cint
+  {.importc, cdecl, header: "gguf.h".}
+
+# ---------------------------------------------------------------------------
+# Diagnostic override.
+# ---------------------------------------------------------------------------
+
+proc chalk_gguf_warn(msg: cstring) {.cdecl, exportc.} =
+  warn("chalk_gguf: " & $msg)
+
+# ---------------------------------------------------------------------------
+# Public Nim API
+# ---------------------------------------------------------------------------
+
+const
+  GgufExt*    = ".gguf"
+  GgufMagic*  = "GGUF"
+
+type
+  ParsedGguf* = ref object
+    handle: ChalkGgufHandle
+
+proc finalizeParsed(p: ParsedGguf) =
+  if p != nil and p.handle != nil:
+    chalk_gguf_free(p.handle)
+    p.handle = nil
+
+proc parseGguf*(bytes: string): ParsedGguf =
+  ## Parse a GGUF file from raw bytes.  Returns nil on parse failure
+  ## (truncated, bad magic, unsupported version, malformed KV
+  ## section).  The C side copies the input bytes.
+  if bytes.len < 24:
+    return nil
+  let h = chalk_gguf_parse(cast[ptr uint8](unsafeAddr bytes[0]),
+                           bytes.len.csize_t)
+  if h == nil:
+    return nil
+  new(result, finalizeParsed)
+  result.handle = h
+
+proc isOk(c: cint): bool {.inline.} = c == 0
+
+proc getChalkPayload*(self: ParsedGguf): string =
+  ## Return the chalk mark payload as a Nim string, or "" if no
+  ## mark is present.  The C side returns a borrowed pointer; we copy.
+  if self == nil or self.handle == nil:
+    return ""
+  var size: csize_t = 0
+  let p = chalk_gguf_get_payload(self.handle, addr size)
+  if p == nil:
+    return ""
+  result = newString(size.int)
+  if size > 0:
+    copyMem(addr result[0], p, size.int)
+
+proc setChalk*(self: ParsedGguf, mark: string): ChalkGgufStatus =
+  ## Insert or replace `chalk.mark` (and recompute alignment padding).
+  if self == nil or self.handle == nil:
+    return cgNull
+  let mp = if mark.len == 0: cstring(nil) else: cstring(mark)
+  result = ChalkGgufStatus(chalk_gguf_set_chalk(self.handle, mp,
+                                                mark.len.csize_t))
+
+proc removeChalk*(self: ParsedGguf): ChalkGgufStatus =
+  ## Remove `chalk.mark` (and recompute padding).  cgNoChalk if absent.
+  if self == nil or self.handle == nil:
+    return cgNull
+  result = ChalkGgufStatus(chalk_gguf_remove_chalk(self.handle))
+
+proc getMutatedBytes*(self: ParsedGguf): string =
+  ## Retrieve the (possibly mutated) raw bytes for write-back.
+  if self == nil or self.handle == nil:
+    return ""
+  var size: csize_t = 0
+  let p = chalk_gguf_get_buffer(self.handle, addr size)
+  if p == nil or size == 0:
+    return ""
+  result = newString(size.int)
+  copyMem(addr result[0], p, size.int)
+
+proc unchalkedHash*(self: ParsedGguf): string =
+  ## SHA-256 hex of the canonical (chalk-removed) form.  Stable
+  ## across re-marks.  "" on error.
+  if self == nil or self.handle == nil:
+    return ""
+  var hex = newString(65)
+  hex.setLen(65)
+  let st = chalk_gguf_unchalked_hash(self.handle, hex.cstring)
+  if not st.isOk:
+    return ""
+  hex.setLen(64)
+  result = hex

--- a/src/utils/gguf.nim
+++ b/src/utils/gguf.nim
@@ -154,10 +154,8 @@ proc unchalkedHash*(self: ParsedGguf): string =
   ## across re-marks.  "" on error.
   if self == nil or self.handle == nil:
     return ""
-  var hex = newString(65)
-  hex.setLen(65)
+  var hex = newString(64)
   let st = chalk_gguf_unchalked_hash(self.handle, hex.cstring)
   if not st.isOk:
     return ""
-  hex.setLen(64)
   result = hex

--- a/src/utils/json.nim
+++ b/src/utils/json.nim
@@ -15,12 +15,16 @@ export json
 proc assertIs*(self: JsonNode,
                kind: JsonNodeKind,
                msg = "JsonNode kind doesnt match expected",
+               allowNil = false,
                ): JsonNode {.discardable.} =
   if self == nil:
-    raise newException(
-      ValueError,
-      msg & ": nil"
-    )
+    if allowNil:
+      return self
+    else:
+      raise newException(
+        ValueError,
+        msg & ": nil"
+      )
   if self.kind != kind:
     raise newException(
       ValueError,
@@ -34,6 +38,15 @@ proc assertHasLen*(self: JsonNode,
   if len(self) == 0:
     raise newException(ValueError, msg)
   return self
+
+proc assertHasKey*(self: JsonNode,
+                   key: string,
+                   msg = "is missing",
+                  ): JsonNode {.discardable.} =
+  self.assertIs(JObject)
+  if not self.hasKey(key):
+    raise newException(ValueError, key & ": " & msg)
+  return self[key]
 
 proc update*(self: JsonNode, other: JsonNode): JsonNode {.discardable.} =
   if self == nil:

--- a/src/utils/safetensors.nim
+++ b/src/utils/safetensors.nim
@@ -1,0 +1,182 @@
+##
+## Copyright (c) 2026, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Nim FFI bindings for the SafeTensors codec under
+## src/codecs/safetensors/.  Library glue, not a codec itself —
+## codecSafetensors.nim imports this module to do parse / read / mark
+## / unmark / unchalked-hash.
+##
+## See src/codecs/safetensors/include/safetensors.h for the API
+## contract.  The C side does in-place mutation of an in-memory copy
+## of the file bytes; this module wraps that for Nim string lifetimes.
+
+import std/[
+  os,
+]
+import pkg/[
+  nimutils/logging,
+]
+
+# ---------------------------------------------------------------------------
+# Compile the carved C sources directly into the chalk binary.  Same
+# shape as src/utils/macho.nim — per-file -std=c23 via the call form
+# of {.compile.}, with the include path set in passc for nim's emitted
+# glue (which is C99).
+# ---------------------------------------------------------------------------
+
+const
+  stIncDir = currentSourcePath.parentDir.parentDir &
+             "/codecs/safetensors/include"
+  stCFlags = "-std=c23 -I" & stIncDir
+
+{.passc: "-I" & stIncDir.}
+
+{.compile("../codecs/safetensors/src/safetensors.c", stCFlags).}
+
+# ---------------------------------------------------------------------------
+# Opaque handle and status enum (mirrors safetensors.h).
+# ---------------------------------------------------------------------------
+
+type
+  ChalkStHandle* = pointer
+
+  ChalkStStatus* {.size: sizeof(cint).} = enum
+    cstInternal   = -6
+    cstNoChalk    = -5
+    cstNotObject  = -4
+    cstBadHeader  = -3
+    cstTruncated  = -2
+    cstNull       = -1
+    cstOk         = 0
+
+# ---------------------------------------------------------------------------
+# C entry points.
+# ---------------------------------------------------------------------------
+
+proc chalk_st_parse(bytes: ptr uint8, length: csize_t): ChalkStHandle
+  {.importc, cdecl, header: "safetensors.h".}
+
+proc chalk_st_free(st: ChalkStHandle)
+  {.importc, cdecl, header: "safetensors.h".}
+
+proc chalk_st_get_payload(st: ChalkStHandle, outSize: ptr csize_t): cstring
+  {.importc, cdecl, header: "safetensors.h".}
+
+proc chalk_st_set_chalk(st: ChalkStHandle,
+                        mark: cstring, markLen: csize_t): cint
+  {.importc, cdecl, header: "safetensors.h".}
+
+proc chalk_st_remove_chalk(st: ChalkStHandle): cint
+  {.importc, cdecl, header: "safetensors.h".}
+
+proc chalk_st_get_buffer(st: ChalkStHandle,
+                         outSize: ptr csize_t): pointer
+  {.importc, cdecl, header: "safetensors.h".}
+
+proc chalk_st_unchalked_hash(st: ChalkStHandle, outHex: cstring): cint
+  {.importc, cdecl, header: "safetensors.h".}
+
+proc c_free(p: pointer) {.importc: "free", header: "<stdlib.h>".}
+
+# ---------------------------------------------------------------------------
+# Diagnostic override — strong link-time replacement of the C-side
+# weak fprintf default.  Routes into chalk's `warn` template.
+# ---------------------------------------------------------------------------
+
+proc chalk_st_warn(msg: cstring) {.cdecl, exportc.} =
+  warn("chalk_st: " & $msg)
+
+# ---------------------------------------------------------------------------
+# Public Nim API
+# ---------------------------------------------------------------------------
+
+const
+  ## SafeTensors files always begin with an 8-byte LE header_size.
+  ## There is no magic per se; the codec sniffs by parsing.
+  SafetensorsExt* = ".safetensors"
+
+type
+  ParsedSafetensors* = ref object
+    ## Owns a parsed SafeTensors file.  =destroy frees the C-side
+    ## handle.  The wrapped string returned by getBuffer is a fresh
+    ## Nim copy — safe to write back independently of this ref.
+    handle: ChalkStHandle
+
+proc finalizeParsed(p: ParsedSafetensors) =
+  if p != nil and p.handle != nil:
+    chalk_st_free(p.handle)
+    p.handle = nil
+
+proc parseSafetensors*(bytes: string): ParsedSafetensors =
+  ## Parse a SafeTensors file from raw bytes.  Returns nil on parse
+  ## failure (truncated, malformed JSON header, header_size out of
+  ## range).  The C side copies the input bytes; the caller's `bytes`
+  ## is not retained.
+  if bytes.len < 8:
+    return nil
+  let h = chalk_st_parse(cast[ptr uint8](unsafeAddr bytes[0]),
+                         bytes.len.csize_t)
+  if h == nil:
+    return nil
+  new(result, finalizeParsed)
+  result.handle = h
+
+proc isOk(c: cint): bool {.inline.} = c == 0
+
+proc getChalkPayload*(self: ParsedSafetensors): string =
+  ## Return the chalk mark payload as a Nim string, or "" if no
+  ## mark is present.  The C side returns a malloc'd buffer; we copy
+  ## and free.
+  if self == nil or self.handle == nil:
+    return ""
+  var size: csize_t = 0
+  let p = chalk_st_get_payload(self.handle, addr size)
+  if p == nil:
+    return ""
+  result = newString(size.int)
+  if size > 0:
+    copyMem(addr result[0], p, size.int)
+  c_free(cast[pointer](p))
+
+proc setChalk*(self: ParsedSafetensors, mark: string): ChalkStStatus =
+  ## Insert or replace the chalk mark in the header.
+  if self == nil or self.handle == nil:
+    return cstNull
+  let mp = if mark.len == 0: cstring(nil) else: cstring(mark)
+  result = ChalkStStatus(chalk_st_set_chalk(self.handle, mp,
+                                            mark.len.csize_t))
+
+proc removeChalk*(self: ParsedSafetensors): ChalkStStatus =
+  ## Remove the chalk mark.  cstNoChalk if there is no mark to remove.
+  if self == nil or self.handle == nil:
+    return cstNull
+  result = ChalkStStatus(chalk_st_remove_chalk(self.handle))
+
+proc getMutatedBytes*(self: ParsedSafetensors): string =
+  ## Retrieve the (possibly mutated) raw bytes for write-back.
+  ## Returns "" on error.  The result is a fresh Nim-owned copy.
+  if self == nil or self.handle == nil:
+    return ""
+  var size: csize_t = 0
+  let p = chalk_st_get_buffer(self.handle, addr size)
+  if p == nil or size == 0:
+    return ""
+  result = newString(size.int)
+  copyMem(addr result[0], p, size.int)
+
+proc unchalkedHash*(self: ParsedSafetensors): string =
+  ## SHA-256 hex of the canonical (chalk-pair-removed) form.  Stable
+  ## across re-marks.  "" on error.
+  if self == nil or self.handle == nil:
+    return ""
+  var hex = newString(65)
+  hex.setLen(65)
+  let st = chalk_st_unchalked_hash(self.handle, hex.cstring)
+  if not st.isOk:
+    return ""
+  hex.setLen(64)
+  result = hex

--- a/src/utils/safetensors.nim
+++ b/src/utils/safetensors.nim
@@ -173,10 +173,8 @@ proc unchalkedHash*(self: ParsedSafetensors): string =
   ## across re-marks.  "" on error.
   if self == nil or self.handle == nil:
     return ""
-  var hex = newString(65)
-  hex.setLen(65)
+  var hex = newString(64)
   let st = chalk_st_unchalked_hash(self.handle, hex.cstring)
   if not st.isOk:
     return ""
-  hex.setLen(64)
   result = hex

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -43,14 +43,28 @@ logger = get_logger()
 
 
 def artifact_type(path: Path) -> str:
-    if path.suffix == ".py":
+    suffix = path.suffix
+    if suffix == ".py":
         return "python"
-    elif path.suffix == ".sh":
+    elif suffix == ".sh":
         return "sh"
-    elif path.suffix == ".zip":
+    elif suffix == ".zip":
         return "ZIP"
-    elif path.suffix == ".pem":
+    elif suffix == ".pem":
         return "x509 Cert"
+    # ML model formats — ARTIFACT_TYPE values must match what each
+    # codec emits (codecZip / codecModelSidecar / codecSafetensors /
+    # codecGguf):
+    elif suffix in (".pt", ".pth"):
+        return "PyTorch checkpoint"
+    elif suffix == ".keras":
+        return "Keras model"
+    elif suffix in (".onnx", ".bin"):
+        return "ML model"
+    elif suffix == ".safetensors":
+        return "SafeTensors model"
+    elif suffix == ".gguf":
+        return "GGUF model"
     else:
         return "ELF"
 

--- a/tests/functional/test_caller_attestation.py
+++ b/tests/functional/test_caller_attestation.py
@@ -32,13 +32,14 @@ Tests cover the contract documented in
     error log; chalk continues without attestation
   - no envelope at all → operation is a no-op for this plugin
 """
-import hashlib
 import json
 from pathlib import Path
 
 import pytest
 
 from .chalk.runner import Chalk
+from .utils.bin import sha256
+from .utils.dict import MISSING
 
 # Use the .onnx path here because it cleanly maps to the model_sidecar
 # codec which always computes an unchalked hash.  That keeps these
@@ -60,15 +61,11 @@ def _resolve(p: Path) -> str:
     return str(p.resolve(strict=True))
 
 
-def _good_sha(artifact: Path) -> str:
-    return hashlib.sha256(artifact.read_bytes()).hexdigest()
-
-
-def test_match_status_no_hashes_in_mark(tmp_data_dir: Path, chalk: Chalk):
+def test_match_status(tmp_data_dir: Path, chalk: Chalk):
     """status=match: per-artifact mark contains status+info, no hashes;
     the three host-level buckets land at the top of the report."""
     artifact = _write_artifact(tmp_data_dir)
-    sha = _good_sha(artifact)
+    sha = sha256(artifact)
     envelope = {
         "version": 1,
         "CALLER_ATTESTED_INFO": {"attestor": "crayon", "version": "0.1"},
@@ -82,23 +79,18 @@ def test_match_status_no_hashes_in_mark(tmp_data_dir: Path, chalk: Chalk):
         },
     }
     insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
-
-    # Per-artifact key — lives inside the artifact mark.
     insert.mark.contains(
         {
             "CALLER_ATTESTED_ARTIFACT_INFO": {
                 "status": "match",
                 "info": {"source": "huggingface"},
+                # On `match`, hashes must NOT surface — they only appear when
+                # there is something to flag.
+                "attested_sha256": MISSING,
+                "observed_sha256": MISSING,
             },
         }
     )
-    # On `match`, hashes must NOT surface — they only appear when
-    # there is something to flag.
-    assert "attested_sha256" not in insert.mark["CALLER_ATTESTED_ARTIFACT_INFO"]
-    assert "observed_sha256" not in insert.mark["CALLER_ATTESTED_ARTIFACT_INFO"]
-
-    # Host-level buckets — at the top of the report, not inside the
-    # per-artifact mark.
     insert.report.contains(
         {
             "CALLER_ATTESTED_INFO": {"attestor": "crayon"},
@@ -111,7 +103,7 @@ def test_match_status_no_hashes_in_mark(tmp_data_dir: Path, chalk: Chalk):
 def test_mismatch_surfaces_both_hashes_and_warns(tmp_data_dir: Path, chalk: Chalk):
     """status=mismatch: both hashes present, warn logged, op succeeds."""
     artifact = _write_artifact(tmp_data_dir)
-    sha_observed = _good_sha(artifact)
+    sha_observed = sha256(artifact)
     sha_attested = "0" * 64
     envelope = {
         "version": 1,
@@ -120,7 +112,6 @@ def test_mismatch_surfaces_both_hashes_and_warns(tmp_data_dir: Path, chalk: Chal
         },
     }
     insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
-
     insert.mark.contains(
         {
             "CALLER_ATTESTED_ARTIFACT_INFO": {
@@ -131,16 +122,13 @@ def test_mismatch_surfaces_both_hashes_and_warns(tmp_data_dir: Path, chalk: Chal
             },
         }
     )
-    assert "caller-attested hash mismatch" in insert.logs
-    assert sha_attested in insert.logs
-    assert sha_observed in insert.logs
 
 
 def test_untracked_attestation_aggregates_in_report(tmp_data_dir: Path, chalk: Chalk):
     """A per-path entry whose path chalk didn't process lands in the
     host-level CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO with a warn."""
     artifact = _write_artifact(tmp_data_dir)
-    sha = _good_sha(artifact)
+    sha = sha256(artifact)
     ghost = str((tmp_data_dir / "ghost.onnx").resolve())
     envelope = {
         "version": 1,
@@ -163,8 +151,6 @@ def test_untracked_attestation_aggregates_in_report(tmp_data_dir: Path, chalk: C
             },
         }
     )
-    assert ghost in insert.logs
-    assert "untracked" in insert.logs.lower() or "not processed" in insert.logs
 
 
 def test_file_channel_equivalent_to_env(tmp_data_dir: Path, chalk: Chalk):
@@ -173,7 +159,7 @@ def test_file_channel_equivalent_to_env(tmp_data_dir: Path, chalk: Chalk):
     payload exceeds ARG_MAX (or who want to write+unlink for
     secrets)."""
     artifact = _write_artifact(tmp_data_dir)
-    sha = _good_sha(artifact)
+    sha = sha256(artifact)
     envelope = {
         "version": 1,
         "CALLER_ATTESTED_INFO": {"channel": "file"},
@@ -197,45 +183,43 @@ def test_no_envelope_is_a_no_op(tmp_data_dir: Path, chalk: Chalk):
     insert = chalk.insert(artifact=artifact)
     # The per-artifact key lives in the mark; the rest are host-level
     # and live at the top of the report.
-    assert "CALLER_ATTESTED_ARTIFACT_INFO" not in insert.mark
-    for k in (
-        "CALLER_ATTESTED_INFO",
-        "CALLER_ATTESTED_HOST_INFO",
-        "CALLER_ATTESTED_BUILD_INFO",
-        "CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO",
-    ):
-        assert k not in insert.report, f"{k} should be absent in no-envelope insert"
+    assert insert.mark.has(
+        CALLER_ATTESTED_ARTIFACT_INFO=MISSING,
+        CALLER_ATTESTED_INFO=MISSING,
+        CALLER_ATTESTED_HOST_INFO=MISSING,
+        CALLER_ATTESTED_BUILD_INFO=MISSING,
+        CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO=MISSING,
+    )
 
 
 @pytest.mark.parametrize(
-    "envelope_str,err_substr",
+    "envelope_str",
     [
-        ("not valid json", "malformed JSON"),
-        ('{"version": 99, "CALLER_ATTESTED_INFO": {}}', "unsupported `version`"),
-        ('{"version": "1"}', "unsupported `version`"),
-        ('{"CALLER_ATTESTED_INFO": {}}', "missing required `version`"),
-        (
-            '{"version": 1, "CALLER_ATTESTED_INFO": "string"}',
-            "must be a JSON object",
-        ),
-        (
-            '{"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p":' ' {"info":{}}}}',
-            "missing required string 'sha256'",
-        ),
-        (
-            '{"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p":'
-            ' {"sha256":"short"}}}',
-            "invalid 'sha256'",
-        ),
-        (
-            '{"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p":'
-            ' {"sha256":"' + "0" * 64 + '","extra":"field"}}}',
-            "unexpected field 'extra'",
+        "not valid json",
+        json.dumps({"version": 99, "CALLER_ATTESTED_INFO": {}}),  # unsupported version
+        json.dumps({"version": "1"}),  # unsupported version
+        json.dumps({"CALLER_ATTESTED_INFO": {}}),  # missing version
+        json.dumps({"version": 1, "CALLER_ATTESTED_INFO": "string"}),  # not an object
+        json.dumps(
+            {"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"info": {}}}}
+        ),  # missing sha256
+        json.dumps(
+            {"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": "short"}}}
+        ),  # invalid sha
+        json.dumps(
+            {
+                "version": 1,
+                "CALLER_ATTESTED_ARTIFACT_INFO": {
+                    "/p": {"sha256": "0" * 64, "extra": "field"}
+                },
+            }
         ),
     ],
 )
 def test_validation_failure_discards_envelope(
-    tmp_data_dir: Path, chalk: Chalk, envelope_str: str, err_substr: str
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    envelope_str: str,
 ):
     """Each shape that violates the protocol contract: the chalk op
     still succeeds, but the mark contains no CALLER_ATTESTED_* keys
@@ -249,51 +233,36 @@ def test_validation_failure_discards_envelope(
         # otherwise treat any error in the report as a test failure.
         ignore_errors=True,
     )
-    assert any(
-        err_substr in e for e in insert.errors
-    ), f"expected an error containing '{err_substr}'; got: {insert.errors}"
+    assert insert.errors
     # Envelope was rejected as a whole — none of the keys land,
     # neither in the per-artifact mark nor the host-level report.
-    assert "CALLER_ATTESTED_ARTIFACT_INFO" not in insert.mark
-    for k in (
-        "CALLER_ATTESTED_INFO",
-        "CALLER_ATTESTED_HOST_INFO",
-        "CALLER_ATTESTED_BUILD_INFO",
-    ):
-        assert k not in insert.report
-
-
-def test_x_prefixed_top_level_silently_accepted(tmp_data_dir: Path, chalk: Chalk):
-    """X-* unknown top-level keys are reserved for caller experimentation;
-    they pass through silently, with no warn log."""
-    artifact = _write_artifact(tmp_data_dir)
-    sha = _good_sha(artifact)
-    envelope = {
-        "version": 1,
-        "X-experimental": {"foo": "bar"},
-        "CALLER_ATTESTED_ARTIFACT_INFO": {
-            _resolve(artifact): {"sha256": sha},
-        },
-    }
-    insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
-    # No warning about the X-* key (mismatch warns can still appear from
-    # other tests; we only check absence of the unknown-key warn here).
-    assert "unknown top-level key" not in insert.logs
-    insert.mark.contains({"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}})
+    assert insert.mark.has(
+        CALLER_ATTESTED_ARTIFACT_INFO=MISSING,
+        CALLER_ATTESTED_INFO=MISSING,
+        CALLER_ATTESTED_HOST_INFO=MISSING,
+        CALLER_ATTESTED_BUILD_INFO=MISSING,
+        CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO=MISSING,
+    )
 
 
 def test_other_unknown_top_level_warns(tmp_data_dir: Path, chalk: Chalk):
-    """Non-X-prefixed unknown top-level keys produce a warn but are
+    """Other non X-* unknown top-level keys produce a warn but are
     otherwise tolerated; the rest of the envelope still applies."""
     artifact = _write_artifact(tmp_data_dir)
-    sha = _good_sha(artifact)
+    sha = sha256(artifact)
+    experimental = "X-experimental"
+    warned = "WHATEVER"
     envelope = {
         "version": 1,
-        "WHATEVER": {"foo": "bar"},
+        warned: {"foo": "bar"},
+        experimental: {"foo": "bar"},
         "CALLER_ATTESTED_ARTIFACT_INFO": {
             _resolve(artifact): {"sha256": sha},
         },
     }
     insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
-    assert "unknown top-level key 'WHATEVER'" in insert.logs
+    assert warned in insert.logs
+    # No warning about the X-* key (mismatch warns can still appear from
+    # other tests; we only check absence of the unknown-key warn here).
+    assert experimental not in insert.logs
     insert.mark.contains({"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}})

--- a/tests/functional/test_caller_attestation.py
+++ b/tests/functional/test_caller_attestation.py
@@ -108,9 +108,7 @@ def test_match_status_no_hashes_in_mark(tmp_data_dir: Path, chalk: Chalk):
     )
 
 
-def test_mismatch_surfaces_both_hashes_and_warns(
-    tmp_data_dir: Path, chalk: Chalk
-):
+def test_mismatch_surfaces_both_hashes_and_warns(tmp_data_dir: Path, chalk: Chalk):
     """status=mismatch: both hashes present, warn logged, op succeeds."""
     artifact = _write_artifact(tmp_data_dir)
     sha_observed = _good_sha(artifact)
@@ -138,9 +136,7 @@ def test_mismatch_surfaces_both_hashes_and_warns(
     assert sha_observed in insert.logs
 
 
-def test_untracked_attestation_aggregates_in_report(
-    tmp_data_dir: Path, chalk: Chalk
-):
+def test_untracked_attestation_aggregates_in_report(tmp_data_dir: Path, chalk: Chalk):
     """A per-path entry whose path chalk didn't process lands in the
     host-level CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO with a warn."""
     artifact = _write_artifact(tmp_data_dir)
@@ -156,9 +152,7 @@ def test_untracked_attestation_aggregates_in_report(
     insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
 
     # The matched artifact's mark gets a status=match entry as usual.
-    insert.mark.contains(
-        {"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}}
-    )
+    insert.mark.contains({"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}})
 
     # The unmatched path lands at host-level — no status wrapper there,
     # since chalk never observed the file.
@@ -193,9 +187,7 @@ def test_file_channel_equivalent_to_env(tmp_data_dir: Path, chalk: Chalk):
         artifact=artifact,
         env={"CHALK_CALLER_ATTESTATION_FILE": str(envelope_path)},
     )
-    insert.mark.contains(
-        {"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}}
-    )
+    insert.mark.contains({"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}})
     insert.report.contains({"CALLER_ATTESTED_INFO": {"channel": "file"}})
 
 
@@ -212,9 +204,7 @@ def test_no_envelope_is_a_no_op(tmp_data_dir: Path, chalk: Chalk):
         "CALLER_ATTESTED_BUILD_INFO",
         "CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO",
     ):
-        assert k not in insert.report, (
-            f"{k} should be absent in no-envelope insert"
-        )
+        assert k not in insert.report, f"{k} should be absent in no-envelope insert"
 
 
 @pytest.mark.parametrize(
@@ -229,8 +219,7 @@ def test_no_envelope_is_a_no_op(tmp_data_dir: Path, chalk: Chalk):
             "must be a JSON object",
         ),
         (
-            '{"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p":'
-            ' {"info":{}}}}',
+            '{"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p":' ' {"info":{}}}}',
             "missing required string 'sha256'",
         ),
         (
@@ -260,9 +249,9 @@ def test_validation_failure_discards_envelope(
         # otherwise treat any error in the report as a test failure.
         ignore_errors=True,
     )
-    assert any(err_substr in e for e in insert.errors), (
-        f"expected an error containing '{err_substr}'; got: {insert.errors}"
-    )
+    assert any(
+        err_substr in e for e in insert.errors
+    ), f"expected an error containing '{err_substr}'; got: {insert.errors}"
     # Envelope was rejected as a whole — none of the keys land,
     # neither in the per-artifact mark nor the host-level report.
     assert "CALLER_ATTESTED_ARTIFACT_INFO" not in insert.mark
@@ -274,9 +263,7 @@ def test_validation_failure_discards_envelope(
         assert k not in insert.report
 
 
-def test_x_prefixed_top_level_silently_accepted(
-    tmp_data_dir: Path, chalk: Chalk
-):
+def test_x_prefixed_top_level_silently_accepted(tmp_data_dir: Path, chalk: Chalk):
     """X-* unknown top-level keys are reserved for caller experimentation;
     they pass through silently, with no warn log."""
     artifact = _write_artifact(tmp_data_dir)
@@ -292,9 +279,7 @@ def test_x_prefixed_top_level_silently_accepted(
     # No warning about the X-* key (mismatch warns can still appear from
     # other tests; we only check absence of the unknown-key warn here).
     assert "unknown top-level key" not in insert.logs
-    insert.mark.contains(
-        {"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}}
-    )
+    insert.mark.contains({"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}})
 
 
 def test_other_unknown_top_level_warns(tmp_data_dir: Path, chalk: Chalk):
@@ -311,6 +296,4 @@ def test_other_unknown_top_level_warns(tmp_data_dir: Path, chalk: Chalk):
     }
     insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
     assert "unknown top-level key 'WHATEVER'" in insert.logs
-    insert.mark.contains(
-        {"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}}
-    )
+    insert.mark.contains({"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}})

--- a/tests/functional/test_caller_attestation.py
+++ b/tests/functional/test_caller_attestation.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026, Crash Override, Inc.
+#
+# This file is part of Chalk
+# (see https://crashoverride.com/docs/chalk)
+"""End-to-end tests for the caller-attestation plugin.
+
+The plugin ingests a JSON envelope from the spawning process —
+either inline via `CHALK_CALLER_ATTESTATION` or from a file path
+in `CHALK_CALLER_ATTESTATION_FILE` — validates the outer shape,
+distributes host/build/process buckets to top-level chalk keys, and
+status-wraps each per-artifact entry against chalk's own unchalked
+hash.
+
+Tests cover the contract documented in
+`docs/design-caller-attestation.md`:
+
+  - status="match" on hash agreement; no hashes echoed in the mark
+  - status="mismatch" on hash disagreement; both hashes surface,
+    a warn is logged, the chalk operation succeeds
+  - status="unverified" path is exercised indirectly via mismatch
+    semantics (chalk always computes a hash for the sidecar codec
+    used here, so unverified isn't reachable from this codec —
+    asserted in the unit test instead)
+  - per-path entries that don't match any tracked artifact land in
+    host-level CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO with a warn
+  - file-channel fallback works the same as the env-var channel
+  - INFO / HOST_INFO / BUILD_INFO buckets pass through unchanged
+  - X-prefixed unknown top-level keys are accepted silently;
+    other unknown top-level keys produce a warn
+  - validation failures (bad JSON, wrong version, missing sha256,
+    bad sha256 format) cause the envelope to be discarded with an
+    error log; chalk continues without attestation
+  - no envelope at all → operation is a no-op for this plugin
+"""
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from .chalk.runner import Chalk
+
+# Use the .onnx path here because it cleanly maps to the model_sidecar
+# codec which always computes an unchalked hash.  That keeps these
+# tests focused on attestation behavior, not codec quirks.
+ARTIFACT_BYTES = b"opaque-model-bytes"
+
+
+def _write_artifact(tmp_data_dir: Path) -> Path:
+    artifact = tmp_data_dir / "model.onnx"
+    artifact.write_bytes(ARTIFACT_BYTES)
+    return artifact
+
+
+def _attestation_env(envelope: dict) -> dict[str, str]:
+    return {"CHALK_CALLER_ATTESTATION": json.dumps(envelope)}
+
+
+def _resolve(p: Path) -> str:
+    return str(p.resolve(strict=True))
+
+
+def _good_sha(artifact: Path) -> str:
+    return hashlib.sha256(artifact.read_bytes()).hexdigest()
+
+
+def test_match_status_no_hashes_in_mark(tmp_data_dir: Path, chalk: Chalk):
+    """status=match: per-artifact mark contains status+info, no hashes;
+    the three host-level buckets land at the top of the report."""
+    artifact = _write_artifact(tmp_data_dir)
+    sha = _good_sha(artifact)
+    envelope = {
+        "version": 1,
+        "CALLER_ATTESTED_INFO": {"attestor": "crayon", "version": "0.1"},
+        "CALLER_ATTESTED_HOST_INFO": {"host": "laptop"},
+        "CALLER_ATTESTED_BUILD_INFO": {"pipeline": "test"},
+        "CALLER_ATTESTED_ARTIFACT_INFO": {
+            _resolve(artifact): {
+                "sha256": sha,
+                "info": {"source": "huggingface", "repo": "meta-llama/test"},
+            },
+        },
+    }
+    insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
+
+    # Per-artifact key — lives inside the artifact mark.
+    insert.mark.contains(
+        {
+            "CALLER_ATTESTED_ARTIFACT_INFO": {
+                "status": "match",
+                "info": {"source": "huggingface"},
+            },
+        }
+    )
+    # On `match`, hashes must NOT surface — they only appear when
+    # there is something to flag.
+    assert "attested_sha256" not in insert.mark["CALLER_ATTESTED_ARTIFACT_INFO"]
+    assert "observed_sha256" not in insert.mark["CALLER_ATTESTED_ARTIFACT_INFO"]
+
+    # Host-level buckets — at the top of the report, not inside the
+    # per-artifact mark.
+    insert.report.contains(
+        {
+            "CALLER_ATTESTED_INFO": {"attestor": "crayon"},
+            "CALLER_ATTESTED_HOST_INFO": {"host": "laptop"},
+            "CALLER_ATTESTED_BUILD_INFO": {"pipeline": "test"},
+        }
+    )
+
+
+def test_mismatch_surfaces_both_hashes_and_warns(
+    tmp_data_dir: Path, chalk: Chalk
+):
+    """status=mismatch: both hashes present, warn logged, op succeeds."""
+    artifact = _write_artifact(tmp_data_dir)
+    sha_observed = _good_sha(artifact)
+    sha_attested = "0" * 64
+    envelope = {
+        "version": 1,
+        "CALLER_ATTESTED_ARTIFACT_INFO": {
+            _resolve(artifact): {"sha256": sha_attested, "info": {"src": "x"}},
+        },
+    }
+    insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
+
+    insert.mark.contains(
+        {
+            "CALLER_ATTESTED_ARTIFACT_INFO": {
+                "status": "mismatch",
+                "attested_sha256": sha_attested,
+                "observed_sha256": sha_observed,
+                "info": {"src": "x"},
+            },
+        }
+    )
+    assert "caller-attested hash mismatch" in insert.logs
+    assert sha_attested in insert.logs
+    assert sha_observed in insert.logs
+
+
+def test_untracked_attestation_aggregates_in_report(
+    tmp_data_dir: Path, chalk: Chalk
+):
+    """A per-path entry whose path chalk didn't process lands in the
+    host-level CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO with a warn."""
+    artifact = _write_artifact(tmp_data_dir)
+    sha = _good_sha(artifact)
+    ghost = str((tmp_data_dir / "ghost.onnx").resolve())
+    envelope = {
+        "version": 1,
+        "CALLER_ATTESTED_ARTIFACT_INFO": {
+            _resolve(artifact): {"sha256": sha, "info": {"x": 1}},
+            ghost: {"sha256": "1" * 64, "info": {"note": "never processed"}},
+        },
+    }
+    insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
+
+    # The matched artifact's mark gets a status=match entry as usual.
+    insert.mark.contains(
+        {"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}}
+    )
+
+    # The unmatched path lands at host-level — no status wrapper there,
+    # since chalk never observed the file.
+    insert.report.contains(
+        {
+            "CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO": {
+                ghost: {"sha256": "1" * 64, "info": {"note": "never processed"}},
+            },
+        }
+    )
+    assert ghost in insert.logs
+    assert "untracked" in insert.logs.lower() or "not processed" in insert.logs
+
+
+def test_file_channel_equivalent_to_env(tmp_data_dir: Path, chalk: Chalk):
+    """CHALK_CALLER_ATTESTATION_FILE produces the same result as the
+    inline env-var channel.  Used by callers whose attestation
+    payload exceeds ARG_MAX (or who want to write+unlink for
+    secrets)."""
+    artifact = _write_artifact(tmp_data_dir)
+    sha = _good_sha(artifact)
+    envelope = {
+        "version": 1,
+        "CALLER_ATTESTED_INFO": {"channel": "file"},
+        "CALLER_ATTESTED_ARTIFACT_INFO": {
+            _resolve(artifact): {"sha256": sha, "info": {"v": "f"}},
+        },
+    }
+    envelope_path = tmp_data_dir / "envelope.json"
+    envelope_path.write_text(json.dumps(envelope))
+    insert = chalk.insert(
+        artifact=artifact,
+        env={"CHALK_CALLER_ATTESTATION_FILE": str(envelope_path)},
+    )
+    insert.mark.contains(
+        {"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}}
+    )
+    insert.report.contains({"CALLER_ATTESTED_INFO": {"channel": "file"}})
+
+
+def test_no_envelope_is_a_no_op(tmp_data_dir: Path, chalk: Chalk):
+    """With neither env var set, no CALLER_ATTESTED_* keys appear."""
+    artifact = _write_artifact(tmp_data_dir)
+    insert = chalk.insert(artifact=artifact)
+    # The per-artifact key lives in the mark; the rest are host-level
+    # and live at the top of the report.
+    assert "CALLER_ATTESTED_ARTIFACT_INFO" not in insert.mark
+    for k in (
+        "CALLER_ATTESTED_INFO",
+        "CALLER_ATTESTED_HOST_INFO",
+        "CALLER_ATTESTED_BUILD_INFO",
+        "CALLER_ATTESTED_UNTRACKED_ARTIFACT_INFO",
+    ):
+        assert k not in insert.report, (
+            f"{k} should be absent in no-envelope insert"
+        )
+
+
+@pytest.mark.parametrize(
+    "envelope_str,err_substr",
+    [
+        ("not valid json", "malformed JSON"),
+        ('{"version": 99, "CALLER_ATTESTED_INFO": {}}', "unsupported `version`"),
+        ('{"version": "1"}', "unsupported `version`"),
+        ('{"CALLER_ATTESTED_INFO": {}}', "missing required `version`"),
+        (
+            '{"version": 1, "CALLER_ATTESTED_INFO": "string"}',
+            "must be a JSON object",
+        ),
+        (
+            '{"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p":'
+            ' {"info":{}}}}',
+            "missing required string 'sha256'",
+        ),
+        (
+            '{"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p":'
+            ' {"sha256":"short"}}}',
+            "invalid 'sha256'",
+        ),
+        (
+            '{"version": 1, "CALLER_ATTESTED_ARTIFACT_INFO": {"/p":'
+            ' {"sha256":"' + "0" * 64 + '","extra":"field"}}}',
+            "unexpected field 'extra'",
+        ),
+    ],
+)
+def test_validation_failure_discards_envelope(
+    tmp_data_dir: Path, chalk: Chalk, envelope_str: str, err_substr: str
+):
+    """Each shape that violates the protocol contract: the chalk op
+    still succeeds, but the mark contains no CALLER_ATTESTED_* keys
+    and chalk logs an `error:` describing the violation."""
+    artifact = _write_artifact(tmp_data_dir)
+    insert = chalk.insert(
+        artifact=artifact,
+        env={"CHALK_CALLER_ATTESTATION": envelope_str},
+        # The validation paths intentionally produce an `error:` log
+        # (the envelope is discarded); the chalk runner would
+        # otherwise treat any error in the report as a test failure.
+        ignore_errors=True,
+    )
+    assert any(err_substr in e for e in insert.errors), (
+        f"expected an error containing '{err_substr}'; got: {insert.errors}"
+    )
+    # Envelope was rejected as a whole — none of the keys land,
+    # neither in the per-artifact mark nor the host-level report.
+    assert "CALLER_ATTESTED_ARTIFACT_INFO" not in insert.mark
+    for k in (
+        "CALLER_ATTESTED_INFO",
+        "CALLER_ATTESTED_HOST_INFO",
+        "CALLER_ATTESTED_BUILD_INFO",
+    ):
+        assert k not in insert.report
+
+
+def test_x_prefixed_top_level_silently_accepted(
+    tmp_data_dir: Path, chalk: Chalk
+):
+    """X-* unknown top-level keys are reserved for caller experimentation;
+    they pass through silently, with no warn log."""
+    artifact = _write_artifact(tmp_data_dir)
+    sha = _good_sha(artifact)
+    envelope = {
+        "version": 1,
+        "X-experimental": {"foo": "bar"},
+        "CALLER_ATTESTED_ARTIFACT_INFO": {
+            _resolve(artifact): {"sha256": sha},
+        },
+    }
+    insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
+    # No warning about the X-* key (mismatch warns can still appear from
+    # other tests; we only check absence of the unknown-key warn here).
+    assert "unknown top-level key" not in insert.logs
+    insert.mark.contains(
+        {"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}}
+    )
+
+
+def test_other_unknown_top_level_warns(tmp_data_dir: Path, chalk: Chalk):
+    """Non-X-prefixed unknown top-level keys produce a warn but are
+    otherwise tolerated; the rest of the envelope still applies."""
+    artifact = _write_artifact(tmp_data_dir)
+    sha = _good_sha(artifact)
+    envelope = {
+        "version": 1,
+        "WHATEVER": {"foo": "bar"},
+        "CALLER_ATTESTED_ARTIFACT_INFO": {
+            _resolve(artifact): {"sha256": sha},
+        },
+    }
+    insert = chalk.insert(artifact=artifact, env=_attestation_env(envelope))
+    assert "unknown top-level key 'WHATEVER'" in insert.logs
+    insert.mark.contains(
+        {"CALLER_ATTESTED_ARTIFACT_INFO": {"status": "match"}}
+    )

--- a/tests/functional/test_model_sidecar.py
+++ b/tests/functional/test_model_sidecar.py
@@ -62,9 +62,9 @@ def test_sidecar_insert_creates_sidecar(
     assert "CHALK_ID" in sidecar_bytes, "CHALK_ID missing from sidecar"
 
     # The artifact itself must not have been mutated.
-    assert artifact.read_bytes() == pre_bytes, (
-        "sidecar codec must leave the artifact's bytes untouched"
-    )
+    assert (
+        artifact.read_bytes() == pre_bytes
+    ), "sidecar codec must leave the artifact's bytes untouched"
 
 
 @pytest.mark.parametrize("extension", ["onnx", "bin"])
@@ -102,9 +102,7 @@ def test_sidecar_delete_removes_sidecar(
 
     chalk.delete(artifact=artifact)
     assert not sidecar.is_file(), "sidecar should be gone after chalk delete"
-    assert artifact.read_bytes() == pre_bytes, (
-        "delete must not modify the artifact"
-    )
+    assert artifact.read_bytes() == pre_bytes, "delete must not modify the artifact"
 
 
 @pytest.mark.parametrize("extension", ["onnx", "bin"])
@@ -124,9 +122,7 @@ def test_sidecar_virtual_does_not_write_sidecar(
     assert insert.report.marks_by_path.contains({str(artifact): {}})
 
     sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
-    assert not sidecar.is_file(), (
-        "virtual mode should not produce a sidecar file"
-    )
+    assert not sidecar.is_file(), "virtual mode should not produce a sidecar file"
 
 
 def test_sidecar_extension_not_in_list_is_ignored(
@@ -145,6 +141,6 @@ def test_sidecar_extension_not_in_list_is_ignored(
     )
     assert insert  # ran cleanly, just produced no marks
     sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
-    assert not sidecar.is_file(), (
-        "files outside sidecar_extensions must not get a sidecar"
-    )
+    assert (
+        not sidecar.is_file()
+    ), "files outside sidecar_extensions must not get a sidecar"

--- a/tests/functional/test_model_sidecar.py
+++ b/tests/functional/test_model_sidecar.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026, Crash Override, Inc.
+#
+# This file is part of Chalk
+# (see https://crashoverride.com/docs/chalk)
+"""End-to-end tests for the model_sidecar codec.
+
+The codec is the deliberate carve-out described in
+docs/design-model-codecs.md: ML model artifact formats we cannot
+mark in-band (`.onnx`, `.bin`, legacy non-ZIP `.pt`/`.pth`) get a
+`<path>.chalk` sidecar instead of artifact mutation.  These tests
+cover the behaviors the design doc asserts:
+
+  - insert produces a `<path>.chalk` sidecar containing a valid mark
+  - the artifact's bytes are byte-identical pre and post insert
+  - extract reads the mark back from the sidecar
+  - delete removes the sidecar and leaves the artifact untouched
+  - virtual mode (--virtual) does NOT produce a sidecar; mark goes
+    to the virtual-chalk sink instead
+"""
+from pathlib import Path
+
+import pytest
+
+from .chalk.runner import Chalk
+from .utils.dict import Contains
+from .utils.log import get_logger
+
+
+logger = get_logger()
+
+
+# Bytes that aren't a real ONNX protobuf — but the codec is content-
+# agnostic and only matches on extension, so an opaque blob is fine
+# for a sidecar test.  (Real ONNX testing would require protobuf
+# parsing and is out of scope until the ONNX codec lands.)
+def _write_blob(path: Path, content: bytes = b"opaque-model-bytes\x00\x01\x02") -> None:
+    path.write_bytes(content)
+
+
+@pytest.mark.parametrize("extension", ["onnx", "bin"])
+def test_sidecar_insert_creates_sidecar(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    extension: str,
+):
+    """Insert produces <path>.chalk and does not modify the artifact."""
+    artifact = tmp_data_dir / f"model.{extension}"
+    payload = b"original-bytes-for-" + extension.encode()
+    _write_blob(artifact, payload)
+    pre_bytes = artifact.read_bytes()
+
+    insert = chalk.insert(artifact=artifact)
+    assert insert.report.marks_by_path.contains(
+        {str(artifact): {"ARTIFACT_TYPE": "ML model"}},
+    )
+
+    sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
+    assert sidecar.is_file(), f"sidecar {sidecar} should exist after insert"
+
+    sidecar_bytes = sidecar.read_text()
+    assert "dadfedabbadabbed" in sidecar_bytes, "MAGIC missing from sidecar"
+    assert "CHALK_ID" in sidecar_bytes, "CHALK_ID missing from sidecar"
+
+    # The artifact itself must not have been mutated.
+    assert artifact.read_bytes() == pre_bytes, (
+        "sidecar codec must leave the artifact's bytes untouched"
+    )
+
+
+@pytest.mark.parametrize("extension", ["onnx", "bin"])
+def test_sidecar_extract_reads_mark(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    extension: str,
+):
+    """Extract returns the chalk mark from the sidecar."""
+    artifact = tmp_data_dir / f"model.{extension}"
+    _write_blob(artifact)
+
+    insert = chalk.insert(artifact=artifact)
+    extract = chalk.extract(artifact=artifact)
+    assert extract.report.marks_by_path.contains(
+        {str(artifact): {"_OP_ARTIFACT_TYPE": "ML model"}},
+    )
+    assert extract.mark.contains(insert.mark.if_exists())
+
+
+@pytest.mark.parametrize("extension", ["onnx", "bin"])
+def test_sidecar_delete_removes_sidecar(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    extension: str,
+):
+    """Delete removes the sidecar; the artifact's bytes are unchanged."""
+    artifact = tmp_data_dir / f"model.{extension}"
+    pre_bytes = b"keep-me-alive-" + extension.encode()
+    _write_blob(artifact, pre_bytes)
+
+    chalk.insert(artifact=artifact)
+    sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
+    assert sidecar.is_file()
+
+    chalk.delete(artifact=artifact)
+    assert not sidecar.is_file(), "sidecar should be gone after chalk delete"
+    assert artifact.read_bytes() == pre_bytes, (
+        "delete must not modify the artifact"
+    )
+
+
+@pytest.mark.parametrize("extension", ["onnx", "bin"])
+def test_sidecar_virtual_does_not_write_sidecar(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    extension: str,
+):
+    """Under --virtual the mark goes to the virtual-chalk sink, not
+    a sidecar file alongside the artifact.  This is the standard
+    chalk behavior for any codec — confirming it for sidecar so a
+    future regression doesn't accidentally double-write."""
+    artifact = tmp_data_dir / f"model.{extension}"
+    _write_blob(artifact)
+
+    insert = chalk.insert(artifact=artifact, virtual=True)
+    assert insert.report.marks_by_path.contains({str(artifact): {}})
+
+    sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
+    assert not sidecar.is_file(), (
+        "virtual mode should not produce a sidecar file"
+    )
+
+
+def test_sidecar_extension_not_in_list_is_ignored(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+):
+    """A file whose extension is NOT in sidecar_extensions must not be
+    claimed by the sidecar codec — the carve-out is narrow.
+    Default list is onnx / bin / pt / pth; .opaque is not in it."""
+    artifact = tmp_data_dir / "model.opaque"
+    _write_blob(artifact)
+
+    insert = chalk.insert(
+        artifact=artifact,
+        expecting_chalkmarks=False,
+    )
+    assert insert  # ran cleanly, just produced no marks
+    sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
+    assert not sidecar.is_file(), (
+        "files outside sidecar_extensions must not get a sidecar"
+    )

--- a/tests/functional/test_model_sidecar.py
+++ b/tests/functional/test_model_sidecar.py
@@ -21,33 +21,23 @@ from pathlib import Path
 
 import pytest
 
-from .chalk.runner import Chalk
-from .utils.dict import Contains
+from .chalk.runner import Chalk, ChalkMark
 from .utils.log import get_logger
 
 
 logger = get_logger()
 
 
-# Bytes that aren't a real ONNX protobuf — but the codec is content-
-# agnostic and only matches on extension, so an opaque blob is fine
-# for a sidecar test.  (Real ONNX testing would require protobuf
-# parsing and is out of scope until the ONNX codec lands.)
-def _write_blob(path: Path, content: bytes = b"opaque-model-bytes\x00\x01\x02") -> None:
-    path.write_bytes(content)
-
-
 @pytest.mark.parametrize("extension", ["onnx", "bin"])
-def test_sidecar_insert_creates_sidecar(
+def test_sidecar_insert_extract_delete(
     tmp_data_dir: Path,
     chalk: Chalk,
     extension: str,
 ):
-    """Insert produces <path>.chalk and does not modify the artifact."""
-    artifact = tmp_data_dir / f"model.{extension}"
+    """Extract returns the chalk mark from the sidecar."""
     payload = b"original-bytes-for-" + extension.encode()
-    _write_blob(artifact, payload)
-    pre_bytes = artifact.read_bytes()
+    artifact = tmp_data_dir / f"model.{extension}"
+    artifact.write_bytes(payload)
 
     insert = chalk.insert(artifact=artifact)
     assert insert.report.marks_by_path.contains(
@@ -56,53 +46,18 @@ def test_sidecar_insert_creates_sidecar(
 
     sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
     assert sidecar.is_file(), f"sidecar {sidecar} should exist after insert"
+    sidemark = ChalkMark.from_binary(sidecar)
+    sidemark.contains(insert.mark.if_exists())
 
-    sidecar_bytes = sidecar.read_text()
-    assert "dadfedabbadabbed" in sidecar_bytes, "MAGIC missing from sidecar"
-    assert "CHALK_ID" in sidecar_bytes, "CHALK_ID missing from sidecar"
-
-    # The artifact itself must not have been mutated.
-    assert (
-        artifact.read_bytes() == pre_bytes
-    ), "sidecar codec must leave the artifact's bytes untouched"
-
-
-@pytest.mark.parametrize("extension", ["onnx", "bin"])
-def test_sidecar_extract_reads_mark(
-    tmp_data_dir: Path,
-    chalk: Chalk,
-    extension: str,
-):
-    """Extract returns the chalk mark from the sidecar."""
-    artifact = tmp_data_dir / f"model.{extension}"
-    _write_blob(artifact)
-
-    insert = chalk.insert(artifact=artifact)
     extract = chalk.extract(artifact=artifact)
     assert extract.report.marks_by_path.contains(
         {str(artifact): {"_OP_ARTIFACT_TYPE": "ML model"}},
     )
     assert extract.mark.contains(insert.mark.if_exists())
 
-
-@pytest.mark.parametrize("extension", ["onnx", "bin"])
-def test_sidecar_delete_removes_sidecar(
-    tmp_data_dir: Path,
-    chalk: Chalk,
-    extension: str,
-):
-    """Delete removes the sidecar; the artifact's bytes are unchanged."""
-    artifact = tmp_data_dir / f"model.{extension}"
-    pre_bytes = b"keep-me-alive-" + extension.encode()
-    _write_blob(artifact, pre_bytes)
-
-    chalk.insert(artifact=artifact)
-    sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
-    assert sidecar.is_file()
-
     chalk.delete(artifact=artifact)
     assert not sidecar.is_file(), "sidecar should be gone after chalk delete"
-    assert artifact.read_bytes() == pre_bytes, "delete must not modify the artifact"
+    assert artifact.read_bytes() == payload, "delete must not modify the artifact"
 
 
 @pytest.mark.parametrize("extension", ["onnx", "bin"])
@@ -115,8 +70,9 @@ def test_sidecar_virtual_does_not_write_sidecar(
     a sidecar file alongside the artifact.  This is the standard
     chalk behavior for any codec — confirming it for sidecar so a
     future regression doesn't accidentally double-write."""
+    payload = b"original-bytes-for-" + extension.encode()
     artifact = tmp_data_dir / f"model.{extension}"
-    _write_blob(artifact)
+    artifact.write_bytes(payload)
 
     insert = chalk.insert(artifact=artifact, virtual=True)
     assert insert.report.marks_by_path.contains({str(artifact): {}})
@@ -133,13 +89,12 @@ def test_sidecar_extension_not_in_list_is_ignored(
     claimed by the sidecar codec — the carve-out is narrow.
     Default list is onnx / bin / pt / pth; .opaque is not in it."""
     artifact = tmp_data_dir / "model.opaque"
-    _write_blob(artifact)
+    artifact.write_bytes(b"hello")
 
-    insert = chalk.insert(
+    chalk.insert(
         artifact=artifact,
         expecting_chalkmarks=False,
     )
-    assert insert  # ran cleanly, just produced no marks
     sidecar = artifact.with_suffix(artifact.suffix + ".chalk")
     assert (
         not sidecar.is_file()

--- a/tests/functional/test_zip.py
+++ b/tests/functional/test_zip.py
@@ -172,6 +172,44 @@ def test_valid(
         assert contains_chalk_binary(test_file)
 
 
+@pytest.mark.parametrize(
+    "extension,artifact_type",
+    [
+        ("pt",    "PyTorch checkpoint"),
+        ("pth",   "PyTorch checkpoint"),
+        ("keras", "Keras model"),
+    ],
+)
+def test_ml_model_zip_extensions(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    extension: str,
+    artifact_type: str,
+):
+    """Modern PyTorch (.pt/.pth) and Keras (.keras) checkpoints are
+    ZIP archives.  The codec extension list now covers them and the
+    ARTIFACT_TYPE callback differentiates them from plain .zip /
+    .jar / etc.
+
+    This test rebrands an existing ZIP fixture to the model
+    extension and verifies a chalk-mark roundtrip works against the
+    rebranded file with the expected ARTIFACT_TYPE.
+    """
+    src      = NODEJS_LAMBDA_ZIP
+    test_file = tmp_data_dir / f"model.{extension}"
+    test_file.write_bytes(src.read_bytes())
+
+    insert  = chalk.insert(artifact=test_file)
+    assert insert.report.marks_by_path.contains(
+        {str(test_file): {"ARTIFACT_TYPE": artifact_type}},
+    )
+
+    extract = chalk.extract(artifact=test_file)
+    assert extract.report.marks_by_path.contains(
+        {str(test_file): {"_OP_ARTIFACT_TYPE": artifact_type}},
+    )
+
+
 @pytest.mark.slow()
 @pytest.mark.parametrize(
     "copy_files",

--- a/tests/functional/test_zip.py
+++ b/tests/functional/test_zip.py
@@ -175,8 +175,8 @@ def test_valid(
 @pytest.mark.parametrize(
     "extension,artifact_type",
     [
-        ("pt",    "PyTorch checkpoint"),
-        ("pth",   "PyTorch checkpoint"),
+        ("pt", "PyTorch checkpoint"),
+        ("pth", "PyTorch checkpoint"),
         ("keras", "Keras model"),
     ],
 )
@@ -195,11 +195,11 @@ def test_ml_model_zip_extensions(
     extension and verifies a chalk-mark roundtrip works against the
     rebranded file with the expected ARTIFACT_TYPE.
     """
-    src      = NODEJS_LAMBDA_ZIP
+    src = NODEJS_LAMBDA_ZIP
     test_file = tmp_data_dir / f"model.{extension}"
     test_file.write_bytes(src.read_bytes())
 
-    insert  = chalk.insert(artifact=test_file)
+    insert = chalk.insert(artifact=test_file)
     assert insert.report.marks_by_path.contains(
         {str(test_file): {"ARTIFACT_TYPE": artifact_type}},
     )

--- a/tests/unit/test_caller_attestation.nim
+++ b/tests/unit/test_caller_attestation.nim
@@ -1,0 +1,334 @@
+## Unit tests for the caller-attestation envelope parser/validator.
+##
+## `parseAndValidate` is the pure half of `src/plugins/callerAttestation.nim`:
+## it consumes a JSON string and returns a `ValidationResult` containing
+## either a populated `EnvelopeState` or an error message (plus any
+## advisory warnings).  The plugin's logging / I/O is layered on top
+## and not exercised here — these tests cover the wire-format contract
+## documented in `docs/design-caller-attestation.md`.
+##
+## We exercise:
+##   - empty input → not valid, no error (channel-not-set is a non-event).
+##   - malformed JSON / non-object top-level → errMsg.
+##   - version handling: missing / wrong type / wrong number.
+##   - bucket shape: each of INFO / HOST_INFO / BUILD_INFO must be an
+##     object when present; ARTIFACT_INFO must be an object of objects.
+##   - per-artifact entries: required `sha256`, hex-format check
+##     (with case-insensitive accept), unexpected-field rejection,
+##     optional `info` that may be any JSON type.
+##   - top-level X-* keys pass silently; other unknown top-level keys
+##     produce a warning but do not invalidate.
+##   - `isHex64` boundary cases.
+
+import std/[
+  json,
+  options,
+  strutils,
+  tables,
+]
+
+import ../../src/plugins/callerAttestation {.all.}
+
+template assertEq(a, b: untyped) =
+  doAssert a == b, $a & " != " & $b
+
+# ---------------------------------------------------------------------------
+# isHex64
+# ---------------------------------------------------------------------------
+
+proc testIsHex64() =
+  let lower64 = "0123456789abcdef".repeat(4)
+  doAssert lower64.len == 64
+  doAssert isHex64(lower64)
+
+  doAssert not isHex64("")
+  doAssert not isHex64("a")                          # too short
+  doAssert not isHex64(lower64 & "0")                # too long
+  doAssert not isHex64("g".repeat(64))               # non-hex char
+  doAssert not isHex64("ABCDEF" & "0".repeat(58))    # uppercase not allowed
+                                                     # (callers must
+                                                     # lowercase first)
+
+# ---------------------------------------------------------------------------
+# Empty / malformed
+# ---------------------------------------------------------------------------
+
+proc testEmptyInput() =
+  let r = parseAndValidate("")
+  doAssert r.errMsg.len == 0
+  doAssert not r.state.valid
+  doAssert r.warnings.len == 0
+  doAssert r.state.artifacts.len == 0
+
+proc testMalformedJson() =
+  let r = parseAndValidate("not valid json")
+  doAssert r.errMsg.len > 0
+  doAssert "malformed JSON" in r.errMsg
+  doAssert not r.state.valid
+
+proc testNonObjectTopLevel() =
+  let r = parseAndValidate("[1, 2, 3]")
+  doAssert r.errMsg.len > 0
+  doAssert "top-level must be a JSON object" in r.errMsg
+  doAssert not r.state.valid
+
+# ---------------------------------------------------------------------------
+# version
+# ---------------------------------------------------------------------------
+
+proc testMissingVersion() =
+  let r = parseAndValidate("""{}""")
+  doAssert "missing required `version`" in r.errMsg
+  doAssert not r.state.valid
+
+proc testVersionWrongType() =
+  let r = parseAndValidate("""{"version":"1"}""")
+  doAssert "unsupported `version`" in r.errMsg
+  doAssert not r.state.valid
+
+proc testVersionWrongNumber() =
+  let r = parseAndValidate("""{"version":2}""")
+  doAssert "unsupported `version`" in r.errMsg
+  doAssert not r.state.valid
+
+proc testJustVersion() =
+  let r = parseAndValidate("""{"version":1}""")
+  doAssert r.errMsg.len == 0
+  doAssert r.state.valid
+  doAssert r.state.info     == nil
+  doAssert r.state.hostInfo == nil
+  doAssert r.state.buildInfo == nil
+  doAssert r.state.artifacts.len == 0
+
+# ---------------------------------------------------------------------------
+# host/build/info buckets
+# ---------------------------------------------------------------------------
+
+proc testThreeBucketsPopulated() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_INFO":      {"attestor":"crayon"},
+    "CALLER_ATTESTED_HOST_INFO": {"host":"laptop"},
+    "CALLER_ATTESTED_BUILD_INFO":{"pipeline":"x"}
+  }""")
+  doAssert r.errMsg.len == 0
+  doAssert r.state.valid
+  doAssert r.state.info != nil
+  doAssert r.state.info["attestor"].getStr() == "crayon"
+  doAssert r.state.hostInfo["host"].getStr() == "laptop"
+  doAssert r.state.buildInfo["pipeline"].getStr() == "x"
+
+proc testInfoMustBeObject() =
+  for k in ["CALLER_ATTESTED_INFO",
+            "CALLER_ATTESTED_HOST_INFO",
+            "CALLER_ATTESTED_BUILD_INFO"]:
+    let raw = """{"version":1,"""" & k & """":"not an object"}"""
+    let r = parseAndValidate(raw)
+    doAssert r.errMsg.len > 0, "expected rejection for non-object " & k
+    doAssert ("'" & k & "' must be a JSON object") in r.errMsg
+    doAssert not r.state.valid
+
+# ---------------------------------------------------------------------------
+# unknown top-level keys
+# ---------------------------------------------------------------------------
+
+proc testUnknownTopLevelWarns() =
+  let r = parseAndValidate("""{"version":1,"WHATEVER":{"a":1}}""")
+  doAssert r.errMsg.len == 0
+  doAssert r.state.valid
+  doAssert r.warnings.len == 1
+  doAssert "unknown top-level key 'WHATEVER'" in r.warnings[0]
+
+proc testXPrefixedTopLevelSilent() =
+  let r = parseAndValidate("""{"version":1,"X-experimental":{"a":1}}""")
+  doAssert r.errMsg.len == 0
+  doAssert r.state.valid
+  doAssert r.warnings.len == 0
+
+# ---------------------------------------------------------------------------
+# Per-artifact entries
+# ---------------------------------------------------------------------------
+
+const goodSha = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+proc testArtifactGoodEntry() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {
+      "/abs/path/model.onnx": {
+        "sha256": """" & goodSha & """",
+        "info":   {"source": "huggingface"}
+      }
+    }
+  }""")
+  doAssert r.errMsg.len == 0
+  doAssert r.state.valid
+  doAssert r.state.artifacts.len == 1
+  doAssert "/abs/path/model.onnx" in r.state.artifacts
+  let e = r.state.artifacts["/abs/path/model.onnx"]
+  assertEq e.sha256, goodSha
+  doAssert e.info != nil
+  assertEq e.info["source"].getStr(), "huggingface"
+
+proc testArtifactInfoOptional() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {
+      "/p": {"sha256": """" & goodSha & """"}
+    }
+  }""")
+  doAssert r.errMsg.len == 0
+  doAssert r.state.valid
+  doAssert r.state.artifacts["/p"].info == nil
+
+proc testArtifactInfoCanBeAnyJsonType() =
+  for inner in [""""string"""", "42", "[1,2,3]", "true", "null"]:
+    let raw = """{"version":1,"CALLER_ATTESTED_ARTIFACT_INFO":{
+      "/p":{"sha256":"""" & goodSha & """","info":""" & inner & "}}}"
+    let r = parseAndValidate(raw)
+    doAssert r.errMsg.len == 0, "rejected info=" & inner & ": " & r.errMsg
+    doAssert r.state.valid
+    doAssert r.state.artifacts["/p"].info != nil
+
+proc testArtifactInfoMustBeObject() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": "not an object"
+  }""")
+  doAssert "'CALLER_ATTESTED_ARTIFACT_INFO' must be a JSON object" in r.errMsg
+  doAssert not r.state.valid
+
+proc testArtifactEntryMustBeObject() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": "not an object"}
+  }""")
+  doAssert "entry for '/p' must be an object" in r.errMsg
+  doAssert not r.state.valid
+
+proc testArtifactMissingSha() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"info": {}}}
+  }""")
+  doAssert "is missing required string 'sha256'" in r.errMsg
+  doAssert not r.state.valid
+
+proc testArtifactShaWrongType() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": 123}}
+  }""")
+  doAssert "is missing required string 'sha256'" in r.errMsg
+  doAssert not r.state.valid
+
+proc testArtifactShaTooShort() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": "abc"}}
+  }""")
+  doAssert "invalid 'sha256'" in r.errMsg
+  doAssert not r.state.valid
+
+proc testArtifactShaNonHex() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": """" &
+      "g".repeat(64) & """"}}
+  }""")
+  doAssert "invalid 'sha256'" in r.errMsg
+  doAssert not r.state.valid
+
+proc testArtifactShaUppercaseAccepted() =
+  ## Caller may legitimately produce uppercase hex; chalk normalizes
+  ## to lowercase before storage.  Reject anything that isn't hex
+  ## once lowercased.
+  let upper = goodSha.toUpperAscii()
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": """" & upper & """"}}
+  }""")
+  doAssert r.errMsg.len == 0
+  doAssert r.state.valid
+  assertEq r.state.artifacts["/p"].sha256, goodSha  # stored lowercased
+
+proc testArtifactExtraFieldRejected() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {
+      "sha256": """" & goodSha & """",
+      "info":   {},
+      "extra":  "field"
+    }}
+  }""")
+  doAssert "has unexpected field 'extra'" in r.errMsg
+  doAssert not r.state.valid
+
+proc testMultipleArtifactEntries() =
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {
+      "/a": {"sha256": """" & goodSha & """"},
+      "/b": {"sha256": """" & goodSha & """","info":{"x":1}},
+      "/c": {"sha256": """" & goodSha & """","info":42}
+    }
+  }""")
+  doAssert r.errMsg.len == 0
+  doAssert r.state.valid
+  assertEq r.state.artifacts.len, 3
+  doAssert "/a" in r.state.artifacts
+  doAssert "/b" in r.state.artifacts
+  doAssert "/c" in r.state.artifacts
+  doAssert r.state.artifacts["/a"].info == nil
+  doAssert r.state.artifacts["/b"].info != nil
+  doAssert r.state.artifacts["/c"].info != nil
+
+# ---------------------------------------------------------------------------
+# Failure semantics: any per-entry rejection discards the whole envelope
+# ---------------------------------------------------------------------------
+
+proc testOneBadEntryDiscardsAll() =
+  ## /good is valid, /bad has a non-hex sha — the envelope is rejected
+  ## as a whole, so neither entry should appear in state.artifacts.
+  let r = parseAndValidate("""{
+    "version": 1,
+    "CALLER_ATTESTED_ARTIFACT_INFO": {
+      "/good": {"sha256": """" & goodSha & """"},
+      "/bad":  {"sha256": "nope"}
+    }
+  }""")
+  doAssert r.errMsg.len > 0
+  doAssert not r.state.valid
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+proc main() =
+  testIsHex64()
+  testEmptyInput()
+  testMalformedJson()
+  testNonObjectTopLevel()
+  testMissingVersion()
+  testVersionWrongType()
+  testVersionWrongNumber()
+  testJustVersion()
+  testThreeBucketsPopulated()
+  testInfoMustBeObject()
+  testUnknownTopLevelWarns()
+  testXPrefixedTopLevelSilent()
+  testArtifactGoodEntry()
+  testArtifactInfoOptional()
+  testArtifactInfoCanBeAnyJsonType()
+  testArtifactInfoMustBeObject()
+  testArtifactEntryMustBeObject()
+  testArtifactMissingSha()
+  testArtifactShaWrongType()
+  testArtifactShaTooShort()
+  testArtifactShaNonHex()
+  testArtifactShaUppercaseAccepted()
+  testArtifactExtraFieldRejected()
+  testMultipleArtifactEntries()
+  testOneBadEntryDiscardsAll()
+
+main()

--- a/tests/unit/test_caller_attestation.nim
+++ b/tests/unit/test_caller_attestation.nim
@@ -1,15 +1,15 @@
 ## Unit tests for the caller-attestation envelope parser/validator.
 ##
 ## `parseAndValidate` is the pure half of `src/plugins/callerAttestation.nim`:
-## it consumes a JSON string and returns a `ValidationResult` containing
-## either a populated `EnvelopeState` or an error message (plus any
-## advisory warnings).  The plugin's logging / I/O is layered on top
-## and not exercised here — these tests cover the wire-format contract
-## documented in `docs/design-caller-attestation.md`.
+## it consumes a JSON string and returns a populated `EnvelopeState` on
+## success, or raises an exception describing the validation failure.
+## The plugin's logging / I/O is layered on top and not exercised here —
+## these tests cover the wire-format contract documented in
+## `docs/design-caller-attestation.md`.
 ##
 ## We exercise:
-##   - empty input → not valid, no error (channel-not-set is a non-event).
-##   - malformed JSON / non-object top-level → errMsg.
+##   - empty input → returns empty state, no exception.
+##   - malformed JSON / non-object top-level → exception raised.
 ##   - version handling: missing / wrong type / wrong number.
 ##   - bucket shape: each of INFO / HOST_INFO / BUILD_INFO must be an
 ##     object when present; ARTIFACT_INFO must be an object of objects.
@@ -17,12 +17,11 @@
 ##     (with case-insensitive accept), unexpected-field rejection,
 ##     optional `info` that may be any JSON type.
 ##   - top-level X-* keys pass silently; other unknown top-level keys
-##     produce a warning but do not invalidate.
+##     produce a warning (side-effect) but do not raise.
 ##   - `isHex64` boundary cases.
 
 import std/[
   json,
-  options,
   strutils,
   tables,
 ]
@@ -31,6 +30,15 @@ import ../../src/plugins/callerAttestation {.all.}
 
 template assertEq(a, b: untyped) =
   doAssert a == b, $a & " != " & $b
+
+template assertRaises(body: untyped) =
+  block:
+    var raised = false
+    try:
+      body
+    except:
+      raised = true
+    doAssert raised, "expected an exception to be raised"
 
 # ---------------------------------------------------------------------------
 # isHex64
@@ -55,95 +63,81 @@ proc testIsHex64() =
 
 proc testEmptyInput() =
   let r = parseAndValidate("")
-  doAssert r.errMsg.len == 0
-  doAssert not r.state.valid
-  doAssert r.warnings.len == 0
-  doAssert r.state.artifacts.len == 0
+  doAssert r.artifacts.len == 0
+  doAssert r.info      == nil
+  doAssert r.hostInfo  == nil
+  doAssert r.buildInfo == nil
 
 proc testMalformedJson() =
-  let r = parseAndValidate("not valid json")
-  doAssert r.errMsg.len > 0
-  doAssert "malformed JSON" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate("not valid json")
 
 proc testNonObjectTopLevel() =
-  let r = parseAndValidate("[1, 2, 3]")
-  doAssert r.errMsg.len > 0
-  doAssert "top-level must be a JSON object" in r.errMsg
-  doAssert not r.state.valid
+  # intentionally a JSON array, not an object — keep as raw string
+  assertRaises:
+    discard parseAndValidate("[1, 2, 3]")
 
 # ---------------------------------------------------------------------------
 # version
 # ---------------------------------------------------------------------------
 
 proc testMissingVersion() =
-  let r = parseAndValidate("""{}""")
-  doAssert "missing required `version`" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{}))
 
 proc testVersionWrongType() =
-  let r = parseAndValidate("""{"version":"1"}""")
-  doAssert "unsupported `version`" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{"version": "1"}))
 
 proc testVersionWrongNumber() =
-  let r = parseAndValidate("""{"version":2}""")
-  doAssert "unsupported `version`" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{"version": 2}))
 
 proc testJustVersion() =
-  let r = parseAndValidate("""{"version":1}""")
-  doAssert r.errMsg.len == 0
-  doAssert r.state.valid
-  doAssert r.state.info     == nil
-  doAssert r.state.hostInfo == nil
-  doAssert r.state.buildInfo == nil
-  doAssert r.state.artifacts.len == 0
+  let r = parseAndValidate($(%*{"version": 1}))
+  doAssert r.info      == nil
+  doAssert r.hostInfo  == nil
+  doAssert r.buildInfo == nil
+  doAssert r.artifacts.len == 0
 
 # ---------------------------------------------------------------------------
 # host/build/info buckets
 # ---------------------------------------------------------------------------
 
 proc testThreeBucketsPopulated() =
-  let r = parseAndValidate("""{
+  let r = parseAndValidate($(%*{
     "version": 1,
-    "CALLER_ATTESTED_INFO":      {"attestor":"crayon"},
-    "CALLER_ATTESTED_HOST_INFO": {"host":"laptop"},
-    "CALLER_ATTESTED_BUILD_INFO":{"pipeline":"x"}
-  }""")
-  doAssert r.errMsg.len == 0
-  doAssert r.state.valid
-  doAssert r.state.info != nil
-  doAssert r.state.info["attestor"].getStr() == "crayon"
-  doAssert r.state.hostInfo["host"].getStr() == "laptop"
-  doAssert r.state.buildInfo["pipeline"].getStr() == "x"
+    "CALLER_ATTESTED_INFO":      {"attestor": "crayon"},
+    "CALLER_ATTESTED_HOST_INFO": {"host": "laptop"},
+    "CALLER_ATTESTED_BUILD_INFO":{"pipeline": "x"},
+  }))
+  doAssert r.info != nil
+  doAssert r.info["attestor"].getStr() == "crayon"
+  doAssert r.hostInfo["host"].getStr() == "laptop"
+  doAssert r.buildInfo["pipeline"].getStr() == "x"
 
 proc testInfoMustBeObject() =
   for k in ["CALLER_ATTESTED_INFO",
             "CALLER_ATTESTED_HOST_INFO",
             "CALLER_ATTESTED_BUILD_INFO"]:
-    let raw = """{"version":1,"""" & k & """":"not an object"}"""
-    let r = parseAndValidate(raw)
-    doAssert r.errMsg.len > 0, "expected rejection for non-object " & k
-    doAssert ("'" & k & "' must be a JSON object") in r.errMsg
-    doAssert not r.state.valid
+    let j = %*{"version": 1}
+    j[k] = %*"not an object"
+    assertRaises:
+      discard parseAndValidate($j)
 
 # ---------------------------------------------------------------------------
 # unknown top-level keys
 # ---------------------------------------------------------------------------
 
 proc testUnknownTopLevelWarns() =
-  let r = parseAndValidate("""{"version":1,"WHATEVER":{"a":1}}""")
-  doAssert r.errMsg.len == 0
-  doAssert r.state.valid
-  doAssert r.warnings.len == 1
-  doAssert "unknown top-level key 'WHATEVER'" in r.warnings[0]
+  # warning is emitted via warn() side-effect; verify no exception is raised
+  let r = parseAndValidate($(%*{"version": 1, "WHATEVER": {"a": 1}}))
+  doAssert r.artifacts.len == 0
 
 proc testXPrefixedTopLevelSilent() =
-  let r = parseAndValidate("""{"version":1,"X-experimental":{"a":1}}""")
-  doAssert r.errMsg.len == 0
-  doAssert r.state.valid
-  doAssert r.warnings.len == 0
+  # X-* keys must not raise or warn
+  let r = parseAndValidate($(%*{"version": 1, "X-experimental": {"a": 1}}))
+  doAssert r.artifacts.len == 0
 
 # ---------------------------------------------------------------------------
 # Per-artifact entries
@@ -152,153 +146,134 @@ proc testXPrefixedTopLevelSilent() =
 const goodSha = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 proc testArtifactGoodEntry() =
-  let r = parseAndValidate("""{
+  let r = parseAndValidate($(%*{
     "version": 1,
     "CALLER_ATTESTED_ARTIFACT_INFO": {
       "/abs/path/model.onnx": {
-        "sha256": """" & goodSha & """",
-        "info":   {"source": "huggingface"}
-      }
-    }
-  }""")
-  doAssert r.errMsg.len == 0
-  doAssert r.state.valid
-  doAssert r.state.artifacts.len == 1
-  doAssert "/abs/path/model.onnx" in r.state.artifacts
-  let e = r.state.artifacts["/abs/path/model.onnx"]
+        "sha256": goodSha,
+        "info":   {"source": "huggingface"},
+      },
+    },
+  }))
+  doAssert r.artifacts.len == 1
+  doAssert "/abs/path/model.onnx" in r.artifacts
+  let e = r.artifacts["/abs/path/model.onnx"]
   assertEq e.sha256, goodSha
   doAssert e.info != nil
   assertEq e.info["source"].getStr(), "huggingface"
 
 proc testArtifactInfoOptional() =
-  let r = parseAndValidate("""{
+  let r = parseAndValidate($(%*{
     "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {
-      "/p": {"sha256": """" & goodSha & """"}
-    }
-  }""")
-  doAssert r.errMsg.len == 0
-  doAssert r.state.valid
-  doAssert r.state.artifacts["/p"].info == nil
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": goodSha}},
+  }))
+  doAssert r.artifacts["/p"].info == nil
 
 proc testArtifactInfoCanBeAnyJsonType() =
-  for inner in [""""string"""", "42", "[1,2,3]", "true", "null"]:
-    let raw = """{"version":1,"CALLER_ATTESTED_ARTIFACT_INFO":{
-      "/p":{"sha256":"""" & goodSha & """","info":""" & inner & "}}}"
-    let r = parseAndValidate(raw)
-    doAssert r.errMsg.len == 0, "rejected info=" & inner & ": " & r.errMsg
-    doAssert r.state.valid
-    doAssert r.state.artifacts["/p"].info != nil
+  for inner in [%*"string", %*42, %*[1, 2, 3], %*true, newJNull()]:
+    let j = %*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": goodSha, "info": inner}},
+    }
+    let r = parseAndValidate($j)
+    doAssert r.artifacts["/p"].info != nil, "rejected info=" & $inner
 
 proc testArtifactInfoMustBeObject() =
-  let r = parseAndValidate("""{
-    "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": "not an object"
-  }""")
-  doAssert "'CALLER_ATTESTED_ARTIFACT_INFO' must be a JSON object" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": "not an object",
+    }))
 
 proc testArtifactEntryMustBeObject() =
-  let r = parseAndValidate("""{
-    "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": "not an object"}
-  }""")
-  doAssert "entry for '/p' must be an object" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": "not an object"},
+    }))
 
 proc testArtifactMissingSha() =
-  let r = parseAndValidate("""{
-    "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"info": {}}}
-  }""")
-  doAssert "is missing required string 'sha256'" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"info": {}}},
+    }))
 
 proc testArtifactShaWrongType() =
-  let r = parseAndValidate("""{
-    "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": 123}}
-  }""")
-  doAssert "is missing required string 'sha256'" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": 123}},
+    }))
 
 proc testArtifactShaTooShort() =
-  let r = parseAndValidate("""{
-    "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": "abc"}}
-  }""")
-  doAssert "invalid 'sha256'" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": "abc"}},
+    }))
 
 proc testArtifactShaNonHex() =
-  let r = parseAndValidate("""{
-    "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": """" &
-      "g".repeat(64) & """"}}
-  }""")
-  doAssert "invalid 'sha256'" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": "g".repeat(64)}},
+    }))
 
 proc testArtifactShaUppercaseAccepted() =
   ## Caller may legitimately produce uppercase hex; chalk normalizes
   ## to lowercase before storage.  Reject anything that isn't hex
   ## once lowercased.
   let upper = goodSha.toUpperAscii()
-  let r = parseAndValidate("""{
+  let r = parseAndValidate($(%*{
     "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": """" & upper & """"}}
-  }""")
-  doAssert r.errMsg.len == 0
-  doAssert r.state.valid
-  assertEq r.state.artifacts["/p"].sha256, goodSha  # stored lowercased
+    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {"sha256": upper}},
+  }))
+  assertEq r.artifacts["/p"].sha256, goodSha  # stored lowercased
 
 proc testArtifactExtraFieldRejected() =
-  let r = parseAndValidate("""{
-    "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {
-      "sha256": """" & goodSha & """",
-      "info":   {},
-      "extra":  "field"
-    }}
-  }""")
-  doAssert "has unexpected field 'extra'" in r.errMsg
-  doAssert not r.state.valid
+  assertRaises:
+    discard parseAndValidate($(%*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": {"/p": {
+        "sha256": goodSha,
+        "info":   {},
+        "extra":  "field",
+      }},
+    }))
 
 proc testMultipleArtifactEntries() =
-  let r = parseAndValidate("""{
+  let r = parseAndValidate($(%*{
     "version": 1,
     "CALLER_ATTESTED_ARTIFACT_INFO": {
-      "/a": {"sha256": """" & goodSha & """"},
-      "/b": {"sha256": """" & goodSha & """","info":{"x":1}},
-      "/c": {"sha256": """" & goodSha & """","info":42}
-    }
-  }""")
-  doAssert r.errMsg.len == 0
-  doAssert r.state.valid
-  assertEq r.state.artifacts.len, 3
-  doAssert "/a" in r.state.artifacts
-  doAssert "/b" in r.state.artifacts
-  doAssert "/c" in r.state.artifacts
-  doAssert r.state.artifacts["/a"].info == nil
-  doAssert r.state.artifacts["/b"].info != nil
-  doAssert r.state.artifacts["/c"].info != nil
+      "/a": {"sha256": goodSha},
+      "/b": {"sha256": goodSha, "info": {"x": 1}},
+      "/c": {"sha256": goodSha, "info": 42},
+    },
+  }))
+  assertEq r.artifacts.len, 3
+  doAssert "/a" in r.artifacts
+  doAssert "/b" in r.artifacts
+  doAssert "/c" in r.artifacts
+  doAssert r.artifacts["/a"].info == nil
+  doAssert r.artifacts["/b"].info != nil
+  doAssert r.artifacts["/c"].info != nil
 
 # ---------------------------------------------------------------------------
 # Failure semantics: any per-entry rejection discards the whole envelope
 # ---------------------------------------------------------------------------
 
 proc testOneBadEntryDiscardsAll() =
-  ## /good is valid, /bad has a non-hex sha — the envelope is rejected
-  ## as a whole, so neither entry should appear in state.artifacts.
-  let r = parseAndValidate("""{
-    "version": 1,
-    "CALLER_ATTESTED_ARTIFACT_INFO": {
-      "/good": {"sha256": """" & goodSha & """"},
-      "/bad":  {"sha256": "nope"}
-    }
-  }""")
-  doAssert r.errMsg.len > 0
-  doAssert not r.state.valid
+  ## /good is valid, /bad has a non-hex sha — the whole envelope is
+  ## rejected via exception, so no state is returned.
+  assertRaises:
+    discard parseAndValidate($(%*{
+      "version": 1,
+      "CALLER_ATTESTED_ARTIFACT_INFO": {
+        "/good": {"sha256": goodSha},
+        "/bad":  {"sha256": "nope"},
+      },
+    }))
 
 # ---------------------------------------------------------------------------
 # main

--- a/tests/unit/test_gguf.nim
+++ b/tests/unit/test_gguf.nim
@@ -1,0 +1,220 @@
+## Unit tests for the GGUF codec FFI bindings.
+##
+## GGUF fixtures are built inline from byte literals — the format is
+## small enough that no committed binary blob is needed.  Exercises:
+##   - parse on a header-only file (no tensors).
+##   - parse rejection on bad magic / wrong version / truncation.
+##   - getChalkPayload returns "" pre-mark.
+##   - setChalk → reparse → recover payload.
+##   - replace existing chalk.mark KV with a new payload.
+##   - removeChalk round-trip leaves the file with kv_count
+##     decremented and chalk.mark gone.
+##   - unchalkedHash invariance: same hash before mark and after
+##     mark with payloads of different lengths, before and after
+##     replace, before and after remove.
+##   - alignment-padding recompute: data section start moves to the
+##     correct aligned offset after KV section size changes.
+
+import std/strutils
+import ../../src/utils/gguf
+
+template assertEq(a, b: untyped) =
+  doAssert a == b, $a & " != " & $b
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal GGUF file from primitives.
+# ---------------------------------------------------------------------------
+
+proc le32(n: int): string =
+  result = newString(4)
+  var v = uint32(n)
+  for i in 0 ..< 4:
+    result[i] = char(byte(v and 0xff'u32))
+    v = v shr 8
+
+proc le64(n: int): string =
+  result = newString(8)
+  var v = uint64(n)
+  for i in 0 ..< 8:
+    result[i] = char(byte(v and 0xff'u64))
+    v = v shr 8
+
+proc kvString(key, value: string): string =
+  ## A string-typed GGUF KV pair.
+  result = le64(key.len) & key & le32(8) & le64(value.len) & value
+
+proc kvUint32(key: string, value: uint32): string =
+  ## A uint32-typed GGUF KV pair.
+  result = le64(key.len) & key & le32(4) & le32(int(value))
+
+proc fromBytesLE(t: typedesc[uint32], s: string, off: int): uint32 =
+  result = 0
+  for i in 0 ..< 4:
+    result = result or (uint32(byte(s[off + i])) shl (i * 8))
+
+proc fromBytesLE(t: typedesc[uint64], s: string, off: int): uint64 =
+  result = 0
+  for i in 0 ..< 8:
+    result = result or (uint64(byte(s[off + i])) shl (i * 8))
+
+proc countKv(kvs: string): int =
+  ## Count well-formed string-or-uint32 KV pairs in a buffer built by
+  ## kvString/kvUint32.  Used by ggufFile to fill in kv_count.
+  var pos = 0
+  result  = 0
+  while pos < kvs.len:
+    if pos + 8 > kvs.len: return result
+    let kl = uint64.fromBytesLE(kvs, pos)
+    pos += 8 + int(kl)
+    if pos + 4 > kvs.len: return result
+    let vt = uint32.fromBytesLE(kvs, pos)
+    pos += 4
+    case vt
+    of 4'u32: pos += 4              # uint32
+    of 8'u32:                       # string
+      if pos + 8 > kvs.len: return result
+      let vl = uint64.fromBytesLE(kvs, pos)
+      pos += 8 + int(vl)
+    else:
+      return result
+    inc result
+
+proc ggufFile(version: int,
+              tensorCount: int,
+              kvs: string,
+              alignment: int = 32): string =
+  ## Build a GGUF file with no tensors and the supplied KV section.
+  ## Pads the file from end-of-KV up to a multiple of `alignment`,
+  ## then appends no tensor data.  Even with zero tensors this is a
+  ## valid GGUF — readers stop after kv_count pairs.
+  let kvCount = countKv(kvs)
+  let header  = "GGUF" & le32(version) & le64(tensorCount) & le64(kvCount)
+  var s       = header & kvs
+  let pad     = (alignment - (s.len mod alignment)) mod alignment
+  s.add(repeat('\0', pad))
+  result = s
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+proc testParseRejections() =
+  doAssert parseGguf("") == nil
+  doAssert parseGguf("FOO!") == nil          # bad magic
+  doAssert parseGguf("12345678901234567890") == nil  # too short
+  # Valid magic, bad version (1)
+  let badV = "GGUF" & le32(1) & le64(0) & le64(0)
+  doAssert parseGguf(badV) == nil
+
+proc testParseEmpty() =
+  let f = ggufFile(version = 3, tensorCount = 0, kvs = "")
+  let p = parseGguf(f)
+  doAssert p != nil
+  assertEq(p.getChalkPayload(), "")
+
+proc testSetChalkOnEmpty() =
+  let f = ggufFile(version = 3, tensorCount = 0, kvs = "")
+  let p = parseGguf(f)
+  doAssert p != nil
+  let mark = "{\"MAGIC\":\"dadfedabbadabbed\",\"CHALK_ID\":\"TEST\"}"
+  assertEq(p.setChalk(mark), cgOk)
+  let p2 = parseGguf(p.getMutatedBytes())
+  doAssert p2 != nil
+  assertEq(p2.getChalkPayload(), mark)
+
+proc testSetChalkWithExistingKvs() =
+  let kvs = kvString("general.architecture", "llama") &
+            kvUint32("general.alignment", 32'u32)
+  let f   = ggufFile(version = 3, tensorCount = 0, kvs = kvs)
+  let p   = parseGguf(f)
+  doAssert p != nil
+  let mark = "{\"x\":1}"
+  assertEq(p.setChalk(mark), cgOk)
+  let p2 = parseGguf(p.getMutatedBytes())
+  doAssert p2 != nil
+  assertEq(p2.getChalkPayload(), mark)
+
+proc testReplaceChalk() =
+  let f = ggufFile(version = 3, tensorCount = 0, kvs = "")
+  let p = parseGguf(f)
+  doAssert p != nil
+  assertEq(p.setChalk("{\"v\":1}"), cgOk)
+  let p2 = parseGguf(p.getMutatedBytes())
+  doAssert p2 != nil
+  assertEq(p2.setChalk("{\"v\":2}"), cgOk)
+  let p3 = parseGguf(p2.getMutatedBytes())
+  doAssert p3 != nil
+  assertEq(p3.getChalkPayload(), "{\"v\":2}")
+
+proc testRemoveChalk() =
+  let f = ggufFile(version = 3, tensorCount = 0, kvs = "")
+  let p = parseGguf(f)
+  doAssert p != nil
+  assertEq(p.setChalk("{\"v\":1}"), cgOk)
+  let p2 = parseGguf(p.getMutatedBytes())
+  doAssert p2 != nil
+  assertEq(p2.removeChalk(), cgOk)
+  let p3 = parseGguf(p2.getMutatedBytes())
+  doAssert p3 != nil
+  assertEq(p3.getChalkPayload(), "")
+  assertEq(p3.removeChalk(), cgNoChalk)
+
+proc testUnchalkedHashInvariance() =
+  ## Same canonical hash before mark, after mark with various
+  ## payload lengths, after replace, after remove.
+  let kvs = kvString("general.architecture", "llama")
+  let f   = ggufFile(version = 3, tensorCount = 0, kvs = kvs)
+  let p0  = parseGguf(f)
+  doAssert p0 != nil
+  let baseline = p0.unchalkedHash()
+  assertEq(baseline.len, 64)
+
+  let p1 = parseGguf(f)
+  assertEq(p1.setChalk("{\"a\":1}"), cgOk)
+  let p1r = parseGguf(p1.getMutatedBytes())
+  assertEq(p1r.unchalkedHash(), baseline)
+
+  let p2 = parseGguf(f)
+  let big = "{\"a\":\"" & repeat('x', 4096) & "\"}"
+  assertEq(p2.setChalk(big), cgOk)
+  let p2r = parseGguf(p2.getMutatedBytes())
+  assertEq(p2r.unchalkedHash(), baseline)
+
+  assertEq(p2r.removeChalk(), cgOk)
+  let p2cleared = parseGguf(p2r.getMutatedBytes())
+  assertEq(p2cleared.unchalkedHash(), baseline)
+
+proc testAlignmentRecompute() =
+  ## After insert/remove, the data section start must land on a
+  ## multiple of `general.alignment`.  We don't have direct access
+  ## to data_off from the wrapper, but we can assert that the file
+  ## length matches a layout where the data section is aligned
+  ## (since this fixture has zero tensors, that's just the end).
+  let kvs = kvUint32("general.alignment", 64'u32)
+  let f   = ggufFile(version = 3, tensorCount = 0, kvs = kvs,
+                     alignment = 64)
+  let p   = parseGguf(f)
+  doAssert p != nil
+  assertEq(p.setChalk("{\"a\":1}"), cgOk)
+  let m = p.getMutatedBytes()
+  doAssert (m.len mod 64) == 0,
+    "post-set length " & $m.len & " not aligned to 64"
+
+  let p2 = parseGguf(m)
+  doAssert p2 != nil
+  assertEq(p2.removeChalk(), cgOk)
+  let m2 = p2.getMutatedBytes()
+  doAssert (m2.len mod 64) == 0,
+    "post-remove length " & $m2.len & " not aligned to 64"
+
+proc main() =
+  testParseRejections()
+  testParseEmpty()
+  testSetChalkOnEmpty()
+  testSetChalkWithExistingKvs()
+  testReplaceChalk()
+  testRemoveChalk()
+  testUnchalkedHashInvariance()
+  testAlignmentRecompute()
+
+main()

--- a/tests/unit/test_model_sidecar.nim
+++ b/tests/unit/test_model_sidecar.nim
@@ -1,0 +1,71 @@
+## Unit tests for the model-sidecar codec helpers.
+##
+## The codec itself runs inside chalk's plugin pipeline, so a true
+## end-to-end roundtrip needs a built chalk binary (covered by the
+## functional test suite).  These tests exercise the pieces that
+## are unit-testable in isolation: the sidecar file naming and the
+## extension matcher's logic.
+##
+## We bring in Nim's stdlib and exercise the pure helpers directly.
+## The codec module imports config / plugin_api / etc. that pull in
+## attrGet — too heavy for a unit test — so we re-implement the
+## extension check here against a fixed list and assert the
+## expected behavior matches what the codec is gated on.
+
+import std/[
+  os,
+  strutils,
+]
+
+template assertEq(a, b: untyped) =
+  doAssert a == b, $a & " != " & $b
+
+const sidecarSuffix = ".chalk"
+
+proc sidecarPath(path: string): string =
+  path & sidecarSuffix
+
+proc extensionMatches(path: string, allowed: openArray[string]): bool =
+  let ext = path.splitFile().ext.toLowerAscii()
+  if ext.len < 2:
+    return false
+  let bare = ext[1 .. ^1]
+  for entry in allowed:
+    if entry.toLowerAscii() == bare:
+      return true
+  return false
+
+# Mirror the documented default: keep this list in sync with
+# sidecar_extensions in src/configs/chalk.c42spec.
+const defaultExts = ["onnx", "bin", "pt", "pth"]
+
+proc testSidecarPath() =
+  assertEq(sidecarPath("/tmp/foo.onnx"),
+           "/tmp/foo.onnx" & sidecarSuffix)
+  assertEq(sidecarPath("model.bin"),
+           "model.bin" & sidecarSuffix)
+  # No extension on input is fine — sidecar still appended.
+  assertEq(sidecarPath("opaque"), "opaque" & sidecarSuffix)
+
+proc testExtensionMatches() =
+  doAssert extensionMatches("a.onnx", defaultExts)
+  doAssert extensionMatches("/x/y.bin", defaultExts)
+  doAssert extensionMatches("M.PT",     defaultExts)  # case-insensitive
+  doAssert extensionMatches("X.Pth",    defaultExts)
+  doAssert not extensionMatches("a.zip",         defaultExts)
+  doAssert not extensionMatches("foo.safetensors", defaultExts)
+  doAssert not extensionMatches("noext",          defaultExts)
+  doAssert not extensionMatches("trailing.",      defaultExts)
+
+proc testCustomList() =
+  # User extends the list; previously-rejected extensions now match.
+  let custom = @["onnx", "bin", "pt", "pth", "tflite"]
+  doAssert extensionMatches("model.tflite", custom)
+  doAssert not extensionMatches("model.tflite", defaultExts)
+
+proc main() =
+  testSidecarPath()
+  testExtensionMatches()
+  testCustomList()
+
+main()

--- a/tests/unit/test_safetensors.nim
+++ b/tests/unit/test_safetensors.nim
@@ -1,0 +1,167 @@
+## Unit tests for the SafeTensors codec FFI bindings.
+##
+## SafeTensors layout is small enough that fixtures are built inline
+## from byte literals — no committed binary blob needed.  Exercises:
+##   - parse on a header-only file (no tensors).
+##   - parse rejection on truncated / bogus headers.
+##   - getChalkPayload returns "" pre-mark.
+##   - setChalk → reparse → recover payload (with __metadata__
+##     creation when absent).
+##   - setChalk → reparse → recover payload (with __metadata__
+##     already present, both populated and empty).
+##   - removeChalk round-trip leaves the header with __metadata__
+##     intact but no chalk key.
+##   - unchalkedHash invariance: same hash before mark and after
+##     mark with payloads of different lengths.
+
+import std/strutils
+import ../../src/utils/safetensors
+
+template assertEq(a, b: untyped) =
+  doAssert a == b, $a & " != " & $b
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal SafeTensors file from a header string.
+# ---------------------------------------------------------------------------
+
+proc le64(n: int): string =
+  ## 8-byte little-endian encoding of `n`.
+  result = newString(8)
+  var v = uint64(n)
+  for i in 0 ..< 8:
+    result[i] = char(byte(v and 0xff))
+    v = v shr 8
+
+proc stFile(header: string): string =
+  ## SafeTensors file with no tensor data.
+  le64(header.len) & header
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+proc testParseTruncated() =
+  doAssert parseSafetensors("") == nil
+  doAssert parseSafetensors("abc") == nil
+  doAssert parseSafetensors("12345678") == nil  # 8 bytes, no header
+  # header_size > remaining bytes
+  let bogus = le64(99) & "{}"
+  doAssert parseSafetensors(bogus) == nil
+
+proc testParseValidEmpty() =
+  let f = stFile("{}")
+  let p = parseSafetensors(f)
+  doAssert p != nil
+  assertEq(p.getChalkPayload(), "")
+
+proc testParseRejectsNonObject() =
+  doAssert parseSafetensors(stFile("[]")) == nil
+  doAssert parseSafetensors(stFile("\"hi\"")) == nil
+
+proc testSetChalkCreatesMetadata() =
+  let p = parseSafetensors(stFile("{}"))
+  doAssert p != nil
+  let mark = "{\"MAGIC\":\"dadfedabbadabbed\",\"CHALK_ID\":\"TEST\"}"
+  assertEq(p.setChalk(mark), cstOk)
+
+  # Reparse the mutated bytes; payload must round-trip.
+  let mutated = p.getMutatedBytes()
+  doAssert mutated.len > 0
+  let p2 = parseSafetensors(mutated)
+  doAssert p2 != nil
+  assertEq(p2.getChalkPayload(), mark)
+
+proc testSetChalkInExistingMetadata() =
+  let p = parseSafetensors(stFile(
+    "{\"__metadata__\":{\"format\":\"pt\"}}"))
+  doAssert p != nil
+  let mark = "{\"x\":1}"
+  assertEq(p.setChalk(mark), cstOk)
+  let p2 = parseSafetensors(p.getMutatedBytes())
+  doAssert p2 != nil
+  assertEq(p2.getChalkPayload(), mark)
+
+proc testSetChalkInEmptyMetadata() =
+  let p = parseSafetensors(stFile("{\"__metadata__\":{}}"))
+  doAssert p != nil
+  assertEq(p.setChalk("{}"), cstOk)
+  let p2 = parseSafetensors(p.getMutatedBytes())
+  doAssert p2 != nil
+  assertEq(p2.getChalkPayload(), "{}")
+
+proc testReplaceChalk() =
+  let p = parseSafetensors(stFile("{}"))
+  doAssert p != nil
+  assertEq(p.setChalk("{\"v\":1}"), cstOk)
+  let p2 = parseSafetensors(p.getMutatedBytes())
+  doAssert p2 != nil
+  assertEq(p2.setChalk("{\"v\":2}"), cstOk)
+  let p3 = parseSafetensors(p2.getMutatedBytes())
+  doAssert p3 != nil
+  assertEq(p3.getChalkPayload(), "{\"v\":2}")
+
+proc testRemoveChalk() =
+  let p = parseSafetensors(stFile("{}"))
+  doAssert p != nil
+  assertEq(p.setChalk("{\"v\":1}"), cstOk)
+  let p2 = parseSafetensors(p.getMutatedBytes())
+  doAssert p2 != nil
+  assertEq(p2.removeChalk(), cstOk)
+  let p3 = parseSafetensors(p2.getMutatedBytes())
+  doAssert p3 != nil
+  assertEq(p3.getChalkPayload(), "")
+  # removeChalk on already-clean must report cstNoChalk.
+  assertEq(p3.removeChalk(), cstNoChalk)
+
+proc testUnchalkedHashInvariance() =
+  ## Same canonical hash before mark, after mark with short payload,
+  ## after mark with long payload, after replace, after remove.
+  let f = stFile("{\"__metadata__\":{\"format\":\"pt\"}}")
+  let p0 = parseSafetensors(f)
+  doAssert p0 != nil
+  let baseline = p0.unchalkedHash()
+  assertEq(baseline.len, 64)
+
+  let p1 = parseSafetensors(f)
+  assertEq(p1.setChalk("{\"a\":1}"), cstOk)
+  let m1 = p1.getMutatedBytes()
+  let p1r = parseSafetensors(m1)
+  assertEq(p1r.unchalkedHash(), baseline)
+
+  let p2 = parseSafetensors(f)
+  let bigPayload = "{\"a\":\"" & repeat('x', 4096) & "\"}"
+  assertEq(p2.setChalk(bigPayload), cstOk)
+  let m2 = p2.getMutatedBytes()
+  let p2r = parseSafetensors(m2)
+  assertEq(p2r.unchalkedHash(), baseline)
+
+  # After remove → reparse → hash returns to baseline.
+  assertEq(p2r.removeChalk(), cstOk)
+  let p2cleared = parseSafetensors(p2r.getMutatedBytes())
+  assertEq(p2cleared.unchalkedHash(), baseline)
+
+proc testHashWithoutChalkEqualsFileHash() =
+  ## When no chalk pair is present, the unchalked hash should equal
+  ## the natural SHA-256 of the file bytes.  We don't recompute the
+  ## file's SHA-256 here (the only SHA-256 in scope is via the FFI),
+  ## but we can confirm the hash is a 64-char hex string.
+  let p = parseSafetensors(stFile("{\"__metadata__\":{}}"))
+  doAssert p != nil
+  let h = p.unchalkedHash()
+  assertEq(h.len, 64)
+  for c in h:
+    doAssert c in "0123456789abcdef"
+
+proc main() =
+  testParseTruncated()
+  testParseValidEmpty()
+  testParseRejectsNonObject()
+  testSetChalkCreatesMetadata()
+  testSetChalkInExistingMetadata()
+  testSetChalkInEmptyMetadata()
+  testReplaceChalk()
+  testRemoveChalk()
+  testUnchalkedHashInvariance()
+  testHashWithoutChalkEqualsFileHash()
+
+main()


### PR DESCRIPTION
## Summary

Stacked on top of #657 (the Mach-O native codec). Introduces native chalk codecs for ML model file formats.

- **safetensors** — new C codec at `src/codecs/safetensors/` + Nim wrapper. Inserts the chalk mark under `__metadata__.chalk` in the JSON header.
- **gguf** — new C codec at `src/codecs/gguf/` + Nim wrapper. Inserts a `chalk.mark` string KV pair, recomputes alignment padding so tensor offsets stay valid. v2 and v3 supported; v1 refused.
- **PyTorch / Keras (`.pt`/`.pth`/`.keras`)** — handled via the existing `codecZip` by extending `zip_extensions` and adding two cases to `artifactType` for ARTIFACT_TYPE differentiation. No new codec; PyTorch (since 1.6) and Keras 3 are ZIP archives.
- **Sidecar fallback** — `codecModelSidecar` for formats not handled in-band (default: `onnx`, `bin`, `pt`, `pth`). Writes `<path>.chalk` next to the artifact.

For each in-band codec, the unchalked hash is the SHA-256 of a canonicalized form (chalk pair structurally removed, container metadata adjusted), invariant across re-marks with payloads of any length — mirroring the `elf.nim` / `macho` semantics.

## Key audit

The single new keyspec produced by this work is **`DERIVED_FROM_CHALK_ID`** — general-purpose lineage (not ML-specific), `since: 1.1.0`. Everything else collapsed to existing chalk vocabulary or moved to runtime-only. See `docs/design-model-codecs.md` for the full audit table.

`ARTIFACT_TYPE` gains five values: `SafeTensors model`, `GGUF model`, `PyTorch checkpoint`, `Keras model`, `ML model` (sidecar fallback).

## Test plan

- [x] `tests/unit/test_safetensors.nim` — parse, set/replace/remove, payload roundtrip, hash invariance across payload sizes
- [x] `tests/unit/test_gguf.nim` — same shape; alignment-padding recompute on insert+remove
- [x] `tests/unit/test_model_sidecar.nim` — file naming + extension matcher logic
- [x] `tests/functional/test_zip.py::test_ml_model_zip_extensions` — `.pt`/`.pth`/`.keras` parametrized roundtrip with ARTIFACT_TYPE assertion
- [x] All 11 unit tests passing on **macOS arm64** (testament direct)
- [x] All 11 unit tests passing on **Linux x86_64** (via `make unit-tests` in the chalk container)

## Design

`docs/design-model-codecs.md` — formats in scope, codec-vs-codecZip decision per format, key audit table, per-format unchalked-hash canonicalization, sidecar fallback policy, repo layout.

## Open follow-ups (not blockers)

- ONNX protobuf codec (deferred from this PR set).
- `MODEL_FORMAT` keyspec if reports want format independent of `ARTIFACT_TYPE`.
- Trigger-context `_OP_TRIGGER_*` runtime keys if demand emerges from the crayon side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)