### PR TITLE
Provide chalk support for SHT_NOBITS section offsets beyond EOF

### DIFF
--- a/src/plugins/elf.nim
+++ b/src/plugins/elf.nim
@@ -554,11 +554,11 @@ proc parseSectionTable(self: ElfFile): bool =
     var sectionHeader = self.parseSectionHeader(offset)
     var sectionOffset = sectionHeader.offset.value
     var sectionSize   = sectionHeader.size.value
-    if sectionOffset > dataLen:
-      self.errors.add(ERR_SECTION_OUT_OF_RANGE)
-      self.logInvalidSection(sectionHeader, len(sectionHeaders))
-      return false
     if sectionHeader.headerType.value != uint32(SHT_NOBITS):
+      if sectionOffset > dataLen:
+        self.errors.add(ERR_SECTION_OUT_OF_RANGE)
+        self.logInvalidSection(sectionHeader, len(sectionHeaders))
+        return false
       if sectionSize > dataLen:
         self.errors.add(ERR_SECTION_OUT_OF_RANGE)
         self.logInvalidSection(sectionHeader, len(sectionHeaders))


### PR DESCRIPTION
Apparently some producers of legit ELFs will place section offsets beyond file EOF for SHT_NOBITS segment types. This PR moves one of the section offset checks into the next if-block, so that it only applies to section types which are not SHT_NOBITS. 

Testing was only performed on the `rclone` binary first observed exhibiting sections of type SHT_NOBITS with offsets beyond EOF.
