### PR TITLE
Support s3-compatible sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New Features
 
+- Add `endpoint` option for sink configuration to support S3-compatible APIs.
+  ([663](https://github.com/crashappsec/chalk/pull/663))
+
 - Native support for chalking Macho binaries.
   As mac requires binaries to be signed therefore on Linux
   chalk can extract chalkmarks but only chalks macho binaries

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -15,7 +15,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#33743aada3a2db054804d92992d7df2536840012"
+requires "https://github.com/crashappsec/con4m#e8020aa2768041ee760739df96494d26d84ed8d2"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -90,6 +90,7 @@ sink s3 {
   ~uri:           true
   ~region:        true
   ~extra:         false
+  ~endpoint:      false
   ~on_write_msg:  false
   shortdoc:       "S3 object storage"
   doc:       """
@@ -100,8 +101,9 @@ sink s3 {
 | `secret` | `string` | true | A valid AWS auth token |
 | `token` | `string` | false | AWS session token |
 | `uri` | `string` | true | The URI for the bucket in `s3:` format; see below |
-| `region` | `string` | true | The region |
+| `region` | `string` | true | The AWS region (or any non-empty string for S3-compatible stores) |
 | `extra` | `string` | false | A prefix added to the object path within the bucket |
+| `endpoint` | `string` | false | Custom S3-compatible endpoint URL (e.g. `http://localhost:9000` for MinIO or `http://localhost:8080` for `rclone serve s3`). When omitted, the standard AWS endpoint is used. |
 
 To ensure uniqueness, each run of chalk constructs a unique object
 name. Here are the components:
@@ -121,6 +123,41 @@ this will not be checked; the operation will fail if they are not.
 
 Generally, you should not use dots in your bucket name, as this will
 thwart TLS protection of the connection.
+
+## Using with S3-compatible stores (MinIO, rclone, etc.)
+
+Set `endpoint` to the base URL of the service and keep `uri` in the
+normal `s3://bucket-name/object-path` form.  The `region` field is
+still required by the AWS SigV4 signing algorithm; for most
+S3-compatible stores any non-empty value (e.g. `"us-east-1"`) works.
+
+Example for a local MinIO instance:
+
+```
+sink_config my_minio_config {
+  enabled:  true
+  sink:     "s3"
+  endpoint: "http://localhost:9000"
+  uri:      "s3://my-bucket/chalk-reports"
+  uid:      env("MINIO_ROOT_USER")
+  secret:   env("MINIO_ROOT_PASSWORD")
+  region:   "us-east-1"
+}
+```
+
+Example for `rclone serve s3 --addr :8080`:
+
+```
+sink_config my_rclone_config {
+  enabled:  true
+  sink:     "s3"
+  endpoint: "http://localhost:8080"
+  uri:      "s3://my-bucket/chalk-reports"
+  uid:      env("RCLONE_S3_ACCESS_KEY_ID")
+  secret:   env("RCLONE_S3_SECRET_ACCESS_KEY")
+  region:   "us-east-1"
+}
+```
 """
 }
 

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -8,6 +8,7 @@
 ## Chalk-specific setup and APIs around nimtuils' IO sinks.
 
 import std/[
+  os,
   uri,
   posix,
 ]
@@ -146,10 +147,15 @@ template formatIo(cfg: SinkConfig, t: Topic, err: string, msg: string): string =
       line &= "\n\tpreferBundledCerts = " & cfg.params.getOrDefault("prefer_bundled_certs", "false") & "\n"
     of "s3":
       let state = S3SinkState(cfg.private)
-      line &= "\n\turi    = " & cfg.params["uri"]
-      line &= "\n\tuid    = " & state.uid
-      line &= "\n\tregion = " & state.region
-      line &= "\n\textra  = "
+      line &= "\n\turi     = " & cfg.params["uri"]
+      line &= "\n\tuid     = " & state.uid
+      line &= "\n\tregion  = " & state.region
+      line &= "\n\textra   = "
+      line &= "\n\tendpoint = "
+      if state.endpoint == "":
+        line &= "<aws default>"
+      else:
+        line &= state.endpoint
       if state.extra == "":
         line &= "<not provided>\n"
       else:
@@ -335,6 +341,17 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
         return none(SinkConfig)
     except:
         error("Sink config '" & name & "' has an invalid URI.")
+        dumpExOnDebug()
+        return none(SinkConfig)
+    if "endpoint" in opts and opts["endpoint"] != "":
+      try:
+        let epUri = parseUri(opts["endpoint"])
+        if epUri.scheme notin ["http", "https"]:
+          error("Sink config '" & name & "' endpoint must use http or https " &
+                "(got: '" & opts["endpoint"] & "')")
+          return none(SinkConfig)
+      except:
+        error("Sink config '" & name & "' has an invalid endpoint URI.")
         dumpExOnDebug()
         return none(SinkConfig)
   of "post", "presign":


### PR DESCRIPTION
Companion PR in nimutils https://github.com/crashappsec/nimutils/pull/98

```
sink_config chalk_s3_sink {
  enabled:  true
  sink:     "s3"
  endpoint: "http://localhost:8080"
  uri:      "s3://myorg/chalks3sink/report.json"
  uid:      "mykey"
  secret:   "mysecret"
  region:   "us-east-1"
}
subscribe("report", "my_rclone")
```

and to test

```
$ mkdir -p data/myorg
$ rclone serve s3 --auth-key "mykey,mysecret" data
$ ./chalk load s3sink.c4m
$ ./chalk insert ./chalk
$ ls data/myorg/chalks3sink
1777919291137-D00YFFGN2XG857EA5YG9Z1KJ5G-report.json
```