### PR TITLE
fix: incorrect heartbeats timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,12 @@
   loaded component parameters.
   ([#664](https://github.com/crashappsec/chalk/pull/664))
 
+- Reset reporting state before each heartbeat report
+  after the heartbeat interval sleep.
+  This fixes timestamp reported during the heartbeat.
+  Previously it would report timestamp from a previous heartbeat.
+  ([#668](https://github.com/crashappsec/chalk/issues/668))
+
 ## 1.0.2
 
 **April 29, 2026**

--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -203,6 +203,9 @@ proc doHeartbeat(chalkOpt: Option[ChalkObj], pid: Pid, fn: (pid: Pid) -> bool) =
 
   while true:
     sleep(sleepInterval)
+    # reset stats which includes the startTime
+    # so that each heartbeat has accurate timestamp
+    clearReportingState()
     chalkOpt.doHeartbeatReport()
     if fn(pid):
       break


### PR DESCRIPTION
<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

heartbeat report would report older timestamp than expected

## Testing

n/a
