### PR TITLE
feat: wrap syft/semgrep/trufflehog with configurable timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,13 @@
 
   ([#665](https://github.com/crashappsec/chalk/pull/665))
 
+- External tools (syft, semgrep, trufflehog) now support a configurable
+  execution timeout. When the system `timeout` command is present, the tool
+  invocation is automatically wrapped with `timeout <value>`. The timeout is
+  configured via `tool.<name>.<name>_timeout` (e.g.
+  `tool.semgrep.semgrep_timeout`) and defaults to `"300"` (5 minutes). Set
+  to `""` to disable.
+
 ### Fixes
 
 - Docker probe always failed due to a typo introduced in chalk `1.0.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,10 +127,14 @@
 
 - External tools (syft, semgrep, trufflehog) now support a configurable
   execution timeout. When the system `timeout` command is present, the tool
-  invocation is automatically wrapped with `timeout <value>`. The timeout is
-  configured via `tool.<name>.<name>_timeout` (e.g.
+  invocation is automatically wrapped with `timeout -s KILL <value>`. The
+  timeout is configured via `tool.<name>.<name>_timeout` (e.g.
   `tool.semgrep.semgrep_timeout`) and defaults to `"300"` (5 minutes). Set
-  to `""` to disable.
+  to `""` to disable. This guard primarily targets Linux CI environments
+  (where the `timeout` command from GNU coreutils is typically available)
+  and is intended to prevent runaway scans from inflating CI build times.
+  On macOS the `timeout` command is not available by default, so the guard
+  is silently skipped.
   ([#670](https://github.com/crashappsec/chalk/pull/670))
 
 - Trufflehog now checks the size of the `.git` directory before running in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,13 @@
   `tool.semgrep.semgrep_timeout`) and defaults to `"300"` (5 minutes). Set
   to `""` to disable.
 
+- Trufflehog now checks the size of the `.git` directory before running in
+  git mode. If the directory exceeds the threshold (default `<<250mb>>`),
+  trufflehog falls back to filesystem mode to avoid excessively long scan
+  times on large repositories. Controlled via
+  `tool.trufflehog.trufflehog_git_size_check` (bool, default `true`) and
+  `tool.trufflehog.trufflehog_git_size_limit` (size, default `<<250mb>>`).
+
 ### Fixes
 
 - Docker probe always failed due to a typo introduced in chalk `1.0.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,8 +127,10 @@
 
 - External tools (syft, semgrep, trufflehog) now support a configurable
   execution timeout. When the system `timeout` command is present, the tool
-  invocation is automatically wrapped with `timeout -s KILL <value>`. The
-  timeout is configured via `tool.<name>.<name>_timeout` (e.g.
+  invocation is automatically wrapped with `timeout -s KILL <value>` for
+  system-installed binaries, or `timeout -s TERM <value>` when running via
+  Docker (so the daemon can stop the container cleanly). The timeout is
+  configured via `tool.<name>.<name>_timeout` (e.g.
   `tool.semgrep.semgrep_timeout`) and defaults to `"300"` (5 minutes). Set
   to `""` to disable. This guard primarily targets Linux CI environments
   (where the `timeout` command from GNU coreutils is typically available)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@
   configured via `tool.<name>.<name>_timeout` (e.g.
   `tool.semgrep.semgrep_timeout`) and defaults to `"300"` (5 minutes). Set
   to `""` to disable.
+  ([#670](https://github.com/crashappsec/chalk/pull/670))
 
 - Trufflehog now checks the size of the `.git` directory before running in
   git mode. If the directory exceeds the threshold (default `<<250mb>>`),
@@ -138,6 +139,7 @@
   times on large repositories. Controlled via
   `tool.trufflehog.trufflehog_git_size_check` (bool, default `true`) and
   `tool.trufflehog.trufflehog_git_size_limit` (size, default `<<250mb>>`).
+  ([#670](https://github.com/crashappsec/chalk/pull/670))
 
 ### Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ endif
 # to get back to original compiled binary
 $(BINARY).bck: $(SOURCES)
 ifneq "$(TMUX)" ""
-	reset
-	tmux clear-history
+	@test -t 0 && reset || true
+	@test -t 0 && tmux clear-history || true
 endif
-	$(DOCKER) nimble -y $(CHALK_BUILD)
+	$(DOCKER) nimble -y $(CHALK_BUILD); touch $(WATCH_DONE)
 	mv $(BINARY) $@
 	cp $@ $(BINARY)
 	ls -la $(BINARY) $@
@@ -76,8 +76,11 @@ version:
 clean:
 	-$(DOCKER) rm -rf $(BINARY) $(BINARY).bck dist nimutils con4m nimble.develop nimble.paths
 
+WATCH_LOG  ?= /tmp/chalk-watch.log
+WATCH_DONE ?= /tmp/chalk-watch-done
+
 watch: $(SOURCES)
-	echo $^ | tr ' ' '\n' | entr $(MAKE)
+	echo $^ | tr ' ' '\n' | entr $(MAKE) 2>&1 | tee $(WATCH_LOG)
 
 # devmode for local deps
 # this allows to dev againt local versions of nimutils/con4m

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,10 @@ ifneq "$(TMUX)" ""
 	@test -t 0 && reset || true
 	@test -t 0 && tmux clear-history || true
 endif
-	$(DOCKER) nimble -y $(CHALK_BUILD); touch $(WATCH_DONE)
+	$(DOCKER) nimble -y $(CHALK_BUILD); \
+		_rc=$$?; \
+		touch $(WATCH_DONE); \
+		exit $$_rc
 	mv $(BINARY) $@
 	cp $@ $(BINARY)
 	ls -la $(BINARY) $@
@@ -76,6 +79,18 @@ version:
 clean:
 	-$(DOCKER) rm -rf $(BINARY) $(BINARY).bck dist nimutils con4m nimble.develop nimble.paths
 
+# WATCH_LOG  - build output is tee'd here on every rebuild cycle.
+#              Truncated once when "make watch" starts (tee opens for write);
+#              subsequent rebuilds append to the same file until watch restarts.
+#              A successful build ends with the "mv chalk chalk.bck" line.
+#              Any compile error appears before that line.
+#
+# WATCH_DONE - touched after every nimble invocation (success or failure) so
+#              that watch automation can wait on a single file event rather than
+#              polling. Use "echo $(WATCH_DONE) | entr -npz tail -5 $(WATCH_LOG)"
+#              to block until a cycle completes, then inspect the log.
+#              NOTE: the touch runs unconditionally (exit code saved and
+#              restored) so Make correctly fails the target on build errors.
 WATCH_LOG  ?= /tmp/chalk-watch.log
 WATCH_DONE ?= /tmp/chalk-watch-done
 

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -178,6 +178,24 @@ proc c4mDirSize(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   except:
     return some(pack(Con4mSize(0)))
 
+proc c4mDirSizeUnder(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
+  try:
+    let
+      path  = resolvePath(unpack[string](args[0]))
+      limit = unpack[Con4mSize](args[1])
+    var total: Con4mSize = 0
+    for f in walkDirRec(path, yieldFilter = {pcFile}):
+      try:
+        total += Con4mSize(getFileSize(f))
+      except:
+        dumpExOnDebug()
+      if total >= limit:
+        return some(pack(false))
+    return some(pack(true))
+  except:
+    dumpExOnDebug()
+    return some(pack(true))
+
 proc dockerExe(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   return some(pack(getDockerExeLocation()))
 
@@ -332,6 +350,16 @@ Returns normalized binary hash of the data.
       """
 Returns the total size in bytes of all files under the given directory,
 recursing into subdirectories. Returns 0 if the path cannot be read.
+""",
+      @["filesystem"]),
+     ("dir_size_under(string, Size) -> bool",
+      BuiltInFn(c4mDirSizeUnder),
+      """
+Returns true if the total size of all files under the given directory is
+strictly less than the given limit, false otherwise. Stops walking as soon
+as the limit is reached, making it more efficient than dir_size for threshold
+checks. Returns true (conservatively allowing the operation) if the path
+cannot be read.
 """,
       @["filesystem"]),
      ("docker_exe() -> string",

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -12,6 +12,7 @@
 ## Though, it might be a decent thing to push the logging stuff into
 ## con4m at some point, as long as it's all optional.
 
+import std/os
 import pkg/[
   con4m/st,
   nimutils/jwt,
@@ -164,6 +165,19 @@ proc c4mBinarySha256(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   let data = args[0]
   return some(pack(data.binEncodeItem().sha256Hex()))
 
+proc c4mDirSize(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
+  try:
+    let path = resolvePath(unpack[string](args[0]))
+    var total: Con4mSize = 0
+    for f in walkDirRec(path, yieldFilter = {pcFile}):
+      try:
+        total += Con4mSize(getFileSize(f))
+      except:
+        discard
+    return some(pack(total))
+  except:
+    return some(pack(Con4mSize(0)))
+
 proc dockerExe(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   return some(pack(getDockerExeLocation()))
 
@@ -313,6 +327,13 @@ Convert to JSON string.
 Returns normalized binary hash of the data.
 """,
      @["chalk"]),
+     ("dir_size(string) -> Size",
+      BuiltInFn(c4mDirSize),
+      """
+Returns the total size in bytes of all files under the given directory,
+recursing into subdirectories. Returns 0 if the path cannot be read.
+""",
+      @["filesystem"]),
      ("docker_exe() -> string",
       BuiltInFn(dockerExe),
       """

--- a/src/configs/base_callbacks.c4m
+++ b/src/configs/base_callbacks.c4m
@@ -9,7 +9,9 @@
 
 # Wrap a command with `timeout -s <signal> <secs>` if the `timeout` executable
 # is available and timeout_secs is non-empty. Returns cmd unchanged otherwise.
-# Exit code 124 is returned by timeout when the limit is exceeded.
+# Exit codes when the limit is exceeded:
+#   124 - SIGTERM (default): timeout sends TERM and exits 124.
+#   137 - SIGKILL: the killed process exits 128+9; callers must handle both.
 #
 # signal: "KILL" for system binaries (cannot be caught or ignored).
 #         "TERM" for docker commands: SIGKILL would kill only the docker CLI
@@ -21,7 +23,7 @@ func with_timeout(cmd, timeout_secs, signal) {
   }
   timeout_exe := find_exe("timeout", [])
   if timeout_exe == "" {
-    trace("with_timeout: timeout command not found; running without timeout")
+    warn("with_timeout: timeout command not found; " + cmd + " will run without a timeout")
     return cmd
   }
   return timeout_exe + " -s " + signal + " " + timeout_secs + " " + cmd

--- a/src/configs/base_callbacks.c4m
+++ b/src/configs/base_callbacks.c4m
@@ -7,8 +7,10 @@
 
 # base non-builtin callbacks to get used in keyspecs
 
-# Wrap a command with `timeout <secs>` if the `timeout` executable is available
-# and timeout_secs is non-empty. Returns cmd unchanged otherwise.
+# Wrap a command with `timeout -s KILL <secs>` if the `timeout` executable is
+# available and timeout_secs is non-empty. Returns cmd unchanged otherwise.
+# Uses SIGKILL so the process cannot catch or ignore the signal.
+# Exit code 124 is returned by timeout when the limit is exceeded.
 func with_timeout(cmd, timeout_secs) {
   if cmd == "" or timeout_secs == "" {
     return cmd
@@ -18,7 +20,7 @@ func with_timeout(cmd, timeout_secs) {
     trace("with_timeout: timeout command not found; running without timeout")
     return cmd
   }
-  return timeout_exe + " " + timeout_secs + " " + cmd
+  return timeout_exe + " -s KILL " + timeout_secs + " " + cmd
 }
 
 func canonicalize_tools(data: dict[string, `x]) {

--- a/src/configs/base_callbacks.c4m
+++ b/src/configs/base_callbacks.c4m
@@ -9,11 +9,13 @@
 
 # Wrap a command with `timeout -s <signal> <secs>` if the `timeout` executable
 # is available and timeout_secs is non-empty. Returns cmd unchanged otherwise.
-# Uses SIGKILL for non-docker commands so the tool cannot catch or ignore the
-# signal. Uses SIGTERM for docker commands so the daemon stops the container
-# cleanly; SIGKILL would kill only the docker CLI and orphan the container.
 # Exit code 124 is returned by timeout when the limit is exceeded.
-func with_timeout(cmd, timeout_secs) {
+#
+# signal: "KILL" for system binaries (cannot be caught or ignored).
+#         "TERM" for docker commands: SIGKILL would kill only the docker CLI
+#         and orphan the running container; SIGTERM lets the daemon stop the
+#         container cleanly before the CLI exits.
+func with_timeout(cmd, timeout_secs, signal) {
   if cmd == "" or timeout_secs == "" {
     return cmd
   }
@@ -21,11 +23,6 @@ func with_timeout(cmd, timeout_secs) {
   if timeout_exe == "" {
     trace("with_timeout: timeout command not found; running without timeout")
     return cmd
-  }
-  signal := "KILL"
-  docker := docker_exe()
-  if docker != "" and starts_with(cmd, docker) {
-    signal := "TERM"
   }
   return timeout_exe + " -s " + signal + " " + timeout_secs + " " + cmd
 }

--- a/src/configs/base_callbacks.c4m
+++ b/src/configs/base_callbacks.c4m
@@ -7,6 +7,20 @@
 
 # base non-builtin callbacks to get used in keyspecs
 
+# Wrap a command with `timeout <secs>` if the `timeout` executable is available
+# and timeout_secs is non-empty. Returns cmd unchanged otherwise.
+func with_timeout(cmd, timeout_secs) {
+  if cmd == "" or timeout_secs == "" {
+    return cmd
+  }
+  timeout_exe := find_exe("timeout", [])
+  if timeout_exe == "" {
+    trace("with_timeout: timeout command not found; running without timeout")
+    return cmd
+  }
+  return timeout_exe + " " + timeout_secs + " " + cmd
+}
+
 func canonicalize_tools(data: dict[string, `x]) {
   t := typeof(data)
   if not typecmp(t, dict[string, `x]) {

--- a/src/configs/base_callbacks.c4m
+++ b/src/configs/base_callbacks.c4m
@@ -7,9 +7,11 @@
 
 # base non-builtin callbacks to get used in keyspecs
 
-# Wrap a command with `timeout -s KILL <secs>` if the `timeout` executable is
-# available and timeout_secs is non-empty. Returns cmd unchanged otherwise.
-# Uses SIGKILL so the process cannot catch or ignore the signal.
+# Wrap a command with `timeout -s <signal> <secs>` if the `timeout` executable
+# is available and timeout_secs is non-empty. Returns cmd unchanged otherwise.
+# Uses SIGKILL for non-docker commands so the tool cannot catch or ignore the
+# signal. Uses SIGTERM for docker commands so the daemon stops the container
+# cleanly; SIGKILL would kill only the docker CLI and orphan the container.
 # Exit code 124 is returned by timeout when the limit is exceeded.
 func with_timeout(cmd, timeout_secs) {
   if cmd == "" or timeout_secs == "" {
@@ -20,7 +22,12 @@ func with_timeout(cmd, timeout_secs) {
     trace("with_timeout: timeout command not found; running without timeout")
     return cmd
   }
-  return timeout_exe + " -s KILL " + timeout_secs + " " + cmd
+  signal := "KILL"
+  docker := docker_exe()
+  if docker != "" and starts_with(cmd, docker) {
+    signal := "TERM"
+  }
+  return timeout_exe + " -s " + signal + " " + timeout_secs + " " + cmd
 }
 
 func canonicalize_tools(data: dict[string, `x]) {

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -161,6 +161,10 @@ func get_semgrep_args(path) {
 func load_semgrep_results(out: string, code) {
   result := {}
 
+  if code == 124 {
+    error("semgrep timed out after " + tool.semgrep.semgrep_timeout + "s; results will be empty. Consider increasing semgrep_timeout.")
+    return {}
+  }
   if code != 0 {
     error("semgrep failed to run properly; ignoring")
     echo(out)

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -23,6 +23,7 @@ tool semgrep {
   semgrep_container:      "semgrep/semgrep"
   semgrep_entrypoint:     "semgrep"
   semgrep_prefer_docker:  false
+  semgrep_timeout:        "300"
   doc: """
 This runs the semgrep static analyizer.  If it doesn't exist in the
 path, chalk will:
@@ -47,6 +48,10 @@ semgrep_format:         The output format flag to pass.
                         Defaults to  'sarif'.
 semgrep_metrics:        Whether to ping semgrep. 'on' or 'off'.
                         Defaults to 'on' to be compatible with config=auto
+semgrep_timeout:        Maximum time to allow semgrep to run, in seconds.
+                        When non-empty and the `timeout` executable is present,
+                        the invocation is wrapped with `timeout <value>`.
+                        Defaults to "300" (5 minutes). Set to "" to disable.
 """
 }
 
@@ -97,22 +102,25 @@ func semgrep_system() {
     # ensure semgrep is on PATH
     # https://github.com/semgrep/semgrep/issues/10652
     head, tail := path_split(result)
-    result := "PATH=" + head + ":$PATH " + result
+    # timeout goes between the PATH= prefix and the binary so the shell
+    # can interpret the assignment while timeout wraps just the executable
+    result := "PATH=" + head + ":$PATH " + with_timeout(result, tool.semgrep.semgrep_timeout)
   }
 }
 
 func find_semgrep(path) {
   if tool.semgrep.semgrep_prefer_docker {
-    result := semgrep_docker(path)
-    if result != "" {
+    found := semgrep_docker(path)
+    if found != "" {
+      result := with_timeout(found, tool.semgrep.semgrep_timeout)
       return
     }
   }
   result := semgrep_system()
   if result != "" {
-    return result
+    return
   }
-  result := semgrep_docker(path)
+  result := with_timeout(semgrep_docker(path), tool.semgrep.semgrep_timeout)
 }
 
 func install_semgrep(path) {

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -161,7 +161,7 @@ func get_semgrep_args(path) {
 func load_semgrep_results(out: string, code) {
   result := {}
 
-  if code == 124 {
+  if code == 124 or code == 137 {
     error("semgrep timed out after " + tool.semgrep.semgrep_timeout + "s; results will be empty. Consider increasing semgrep_timeout.")
     return {}
   }

--- a/src/configs/sastconfig.c4m
+++ b/src/configs/sastconfig.c4m
@@ -104,7 +104,7 @@ func semgrep_system() {
     head, tail := path_split(result)
     # timeout goes between the PATH= prefix and the binary so the shell
     # can interpret the assignment while timeout wraps just the executable
-    result := "PATH=" + head + ":$PATH " + with_timeout(result, tool.semgrep.semgrep_timeout)
+    result := "PATH=" + head + ":$PATH " + with_timeout(result, tool.semgrep.semgrep_timeout, "KILL")
   }
 }
 
@@ -112,7 +112,7 @@ func find_semgrep(path) {
   if tool.semgrep.semgrep_prefer_docker {
     found := semgrep_docker(path)
     if found != "" {
-      result := with_timeout(found, tool.semgrep.semgrep_timeout)
+      result := with_timeout(found, tool.semgrep.semgrep_timeout, "TERM")
       return
     }
   }
@@ -120,7 +120,7 @@ func find_semgrep(path) {
   if result != "" {
     return
   }
-  result := with_timeout(semgrep_docker(path), tool.semgrep.semgrep_timeout)
+  result := with_timeout(semgrep_docker(path), tool.semgrep.semgrep_timeout, "TERM")
 }
 
 func install_semgrep(path) {

--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -136,6 +136,10 @@ func get_syft_args(path) {
 func extract_syft_sbom(out: string, code) {
   result := {}
 
+  if code == 124 {
+    error("syft timed out after " + tool.syft.syft_timeout + "s; results will be empty. Consider increasing syft_timeout.")
+    return {}
+  }
   if code != 0 {
     error("syft failed to run properly; ignoring")
     echo(out)

--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -84,19 +84,19 @@ func syft_system() {
 }
 
 func find_syft(path) {
-  found := ""
   if tool.syft.syft_prefer_docker {
     found := syft_docker(path)
     if found != "" {
-      result := with_timeout(found, tool.syft.syft_timeout)
+      result := with_timeout(found, tool.syft.syft_timeout, "TERM")
       return
     }
   }
   found := syft_system()
-  if found == "" {
-    found := syft_docker(path)
+  if found != "" {
+    result := with_timeout(found, tool.syft.syft_timeout, "KILL")
+    return
   }
-  result := with_timeout(found, tool.syft.syft_timeout)
+  result := with_timeout(syft_docker(path), tool.syft.syft_timeout, "TERM")
 }
 
 func install_syft(path) {

--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -136,7 +136,7 @@ func get_syft_args(path) {
 func extract_syft_sbom(out: string, code) {
   result := {}
 
-  if code == 124 {
+  if code == 124 or code == 137 {
     error("syft timed out after " + tool.syft.syft_timeout + "s; results will be empty. Consider increasing syft_timeout.")
     return {}
   }

--- a/src/configs/sbomconfig.c4m
+++ b/src/configs/sbomconfig.c4m
@@ -21,6 +21,7 @@ tool syft {
   syft_entrypoint:    "/syft"
   syft_prefer_docker: false
   syft_argv:          " -o cyclonedx-json"  # CycloneDX by default.
+  syft_timeout:       "300"
   ~doc:               """
 This runs the syft SBOM tool.  If it can't be found in the current path,
 chalk will:
@@ -43,6 +44,10 @@ syft_installer:     URL of the official syft installer script.
                     Defaults to 'https://raw.githubusercontent.com/anchore/syft/main/install.sh'.
 syft_argv:          Command-line flags to pass to syft.
                     Defaults to '-o cyclone-json'
+syft_timeout:       Maximum time to allow syft to run, in seconds.
+                    When non-empty and the `timeout` executable is present,
+                    the invocation is wrapped with `timeout <value>`.
+                    Defaults to "300" (5 minutes). Set to "" to disable.
 """
 }
 
@@ -79,17 +84,19 @@ func syft_system() {
 }
 
 func find_syft(path) {
+  found := ""
   if tool.syft.syft_prefer_docker {
-    result := syft_docker(path)
-    if result != "" {
+    found := syft_docker(path)
+    if found != "" {
+      result := with_timeout(found, tool.syft.syft_timeout)
       return
     }
   }
-  result := syft_system()
-  if result != "" {
-    return result
+  found := syft_system()
+  if found == "" {
+    found := syft_docker(path)
   }
-  result := syft_docker(path)
+  result := with_timeout(found, tool.syft.syft_timeout)
 }
 
 func install_syft(path) {

--- a/src/configs/secretscannerconfig.c4m
+++ b/src/configs/secretscannerconfig.c4m
@@ -180,6 +180,10 @@ func get_trufflehog_args(path) {
 func load_trufflehog_results(out: string, code) {
   result := {}
 
+  if code == 124 {
+    error("trufflehog timed out after " + tool.trufflehog.trufflehog_timeout + "s; results will be empty. Consider increasing trufflehog_timeout.")
+    return {}
+  }
   if code != 0 {
     error("trufflehog failed to run properly; ignoring")
     echo(out)

--- a/src/configs/secretscannerconfig.c4m
+++ b/src/configs/secretscannerconfig.c4m
@@ -24,6 +24,8 @@ tool trufflehog {
   trufflehog_prefer_docker:  false
   trufflehog_installer:      "https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh"
   trufflehog_timeout:        "300"
+  trufflehog_git_size_check: true
+  trufflehog_git_size_limit: <<250mb>>
   doc: """
 This runs the trufflehog secret scanner.  If it doesn't exist in the
 path, chalk will:
@@ -49,6 +51,15 @@ trufflehog_timeout:        Maximum time to allow trufflehog to run, in seconds.
                            When non-empty and the `timeout` executable is present,
                            the invocation is wrapped with `timeout <value>`.
                            Defaults to "300" (5 minutes). Set to "" to disable.
+trufflehog_git_size_check: When true, the size of the .git directory is checked
+                           before running trufflehog in git mode. If the directory
+                           exceeds trufflehog_git_size_limit, trufflehog falls back
+                           to filesystem mode to avoid very long scan times on large
+                           repositories. Defaults to true.
+trufflehog_git_size_limit: Size threshold for the .git directory above which
+                           trufflehog switches from git mode to filesystem mode.
+                           Uses size literal notation e.g. <<250mb>>, <<1gb>>.
+                           Defaults to <<250mb>>.
 """
 }
 
@@ -144,8 +155,18 @@ func get_trufflehog_args(path) {
   mode   := "filesystem"
   prefix := ""
   if is_dir(path) and is_dir(join_path(path, ".git")) {
-    mode   := "git"
-    prefix := "file://"
+    use_git := true
+    if tool.trufflehog.trufflehog_git_size_check {
+      git_size := dir_size(join_path(path, ".git"))
+      if git_size > tool.trufflehog.trufflehog_git_size_limit {
+        warn("trufflehog: " + join_path(path, ".git") + " size " + $(git_size) + " exceeds limit " + $(tool.trufflehog.trufflehog_git_size_limit) + "; falling back to filesystem mode")
+        use_git := false
+      }
+    }
+    if use_git {
+      mode   := "git"
+      prefix := "file://"
+    }
   }
   result := mode + " "
   if tool.trufflehog.trufflehog_config != "" {

--- a/src/configs/secretscannerconfig.c4m
+++ b/src/configs/secretscannerconfig.c4m
@@ -88,6 +88,10 @@ func trufflehog_docker(path) {
   if config != "" and is_file(config) {
     config_volume := "-v " + config + ":" + config + " "
   }
+  # Mount the system temp directory so that host-side temp files created by
+  # get_trufflehog_args (e.g. the -x exclude-paths file) are accessible inside
+  # the container at the same path when Docker executes the command.
+  tmp_volume := "-v " + tmp_dir() + ":" + tmp_dir() + " "
   return (
     docker_path + " run " +
     "--rm " +
@@ -96,6 +100,7 @@ func trufflehog_docker(path) {
     "-v " + dir + ":" + dir + " " +
     cwd_volume +
     config_volume +
+    tmp_volume +
     tool.trufflehog.trufflehog_container
   )
 }

--- a/src/configs/secretscannerconfig.c4m
+++ b/src/configs/secretscannerconfig.c4m
@@ -174,13 +174,17 @@ func get_trufflehog_args(path) {
   }
   result := result + tool.trufflehog.trufflehog_format_flags + " "
   result := result + tool.trufflehog.trufflehog_other_flags + " "
+  if mode == "filesystem" and is_dir(join_path(path, ".git")) {
+    exclude_file := to_tmp_file("[.]git(/|$)", ".txt")
+    result := result + "-x " + exclude_file + " "
+  }
   result := result + prefix + path + " 2>/dev/null"
 }
 
 func load_trufflehog_results(out: string, code) {
   result := {}
 
-  if code == 124 {
+  if code == 124 or code == 137 {
     error("trufflehog timed out after " + tool.trufflehog.trufflehog_timeout + "s; results will be empty. Consider increasing trufflehog_timeout.")
     return {}
   }

--- a/src/configs/secretscannerconfig.c4m
+++ b/src/configs/secretscannerconfig.c4m
@@ -110,19 +110,19 @@ func trufflehog_system() {
 }
 
 func find_trufflehog(path) {
-  found := ""
   if tool.trufflehog.trufflehog_prefer_docker {
     found := trufflehog_docker(path)
     if found != "" {
-      result := with_timeout(found, tool.trufflehog.trufflehog_timeout)
+      result := with_timeout(found, tool.trufflehog.trufflehog_timeout, "TERM")
       return
     }
   }
   found := trufflehog_system()
-  if found == "" {
-    found := trufflehog_docker(path)
+  if found != "" {
+    result := with_timeout(found, tool.trufflehog.trufflehog_timeout, "KILL")
+    return
   }
-  result := with_timeout(found, tool.trufflehog.trufflehog_timeout)
+  result := with_timeout(trufflehog_docker(path), tool.trufflehog.trufflehog_timeout, "TERM")
 }
 
 func install_trufflehog(path) {
@@ -157,9 +157,9 @@ func get_trufflehog_args(path) {
   if is_dir(path) and is_dir(join_path(path, ".git")) {
     use_git := true
     if tool.trufflehog.trufflehog_git_size_check {
-      git_size := dir_size(join_path(path, ".git"))
-      if git_size > tool.trufflehog.trufflehog_git_size_limit {
-        warn("trufflehog: " + join_path(path, ".git") + " size " + $(git_size) + " exceeds limit " + $(tool.trufflehog.trufflehog_git_size_limit) + "; falling back to filesystem mode")
+      git_path := join_path(path, ".git")
+      if not dir_size_under(git_path, tool.trufflehog.trufflehog_git_size_limit) {
+        warn("trufflehog: " + git_path + " exceeds size limit " + $(tool.trufflehog.trufflehog_git_size_limit) + "; falling back to filesystem mode")
         use_git := false
       }
     }

--- a/src/configs/secretscannerconfig.c4m
+++ b/src/configs/secretscannerconfig.c4m
@@ -23,6 +23,7 @@ tool trufflehog {
   trufflehog_entrypoint:     "trufflehog"
   trufflehog_prefer_docker:  false
   trufflehog_installer:      "https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh"
+  trufflehog_timeout:        "300"
   doc: """
 This runs the trufflehog secret scanner.  If it doesn't exist in the
 path, chalk will:
@@ -44,6 +45,10 @@ trufflehog_config:         The trufflehog config to use.
                            By default no config is provided.
 trufflehog_format:         The output format flag to pass.
                            Defaults to  'sarif'.
+trufflehog_timeout:        Maximum time to allow trufflehog to run, in seconds.
+                           When non-empty and the `timeout` executable is present,
+                           the invocation is wrapped with `timeout <value>`.
+                           Defaults to "300" (5 minutes). Set to "" to disable.
 """
 }
 
@@ -94,17 +99,19 @@ func trufflehog_system() {
 }
 
 func find_trufflehog(path) {
+  found := ""
   if tool.trufflehog.trufflehog_prefer_docker {
-    result := trufflehog_docker(path)
-    if result != "" {
+    found := trufflehog_docker(path)
+    if found != "" {
+      result := with_timeout(found, tool.trufflehog.trufflehog_timeout)
       return
     }
   }
-  result := trufflehog_system()
-  if result != "" {
-    return result
+  found := trufflehog_system()
+  if found == "" {
+    found := trufflehog_docker(path)
   }
-  result := trufflehog_docker(path)
+  result := with_timeout(found, tool.trufflehog.trufflehog_timeout)
 }
 
 func install_trufflehog(path) {

--- a/tests/functional/data/configs/composable/valid/secret_scanner/tiny_git_size_limit.c4m
+++ b/tests/functional/data/configs/composable/valid/secret_scanner/tiny_git_size_limit.c4m
@@ -1,0 +1,12 @@
+run_secret_scanner_tools: true
+
+# `chalk insert` output secret to terminal
+report_template.terminal_insert.key.SECRET_SCANNER.use: true
+report_template.insertion_default.key.SECRET_SCANNER.use: true
+
+# Embed SECRET_SCANNER reports in chalk marks.
+mark_template.mark_default.key.SECRET_SCANNER.use: true
+
+# Set a tiny git size limit so any .git directory triggers the filesystem
+# fallback, regardless of actual repository size.
+tool.trufflehog.trufflehog_git_size_limit = <<1b>>

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -1323,6 +1323,50 @@ export AWS_SESSION_TOKEN={AWS_SESSION_TOKEN}
     )
 
 
+@pytest.mark.skipif(not aws_secrets_configured(), reason="AWS secrets not configured")
+def test_trufflehog_large_git_fallback(chalk: Chalk, tmp_data_dir: Path):
+    """
+    When .git exceeds trufflehog_git_size_limit, trufflehog falls back to
+    filesystem mode and should not report secrets that exist only in git history.
+    """
+    repo_dir = tmp_data_dir / "repo"
+    repo_dir.mkdir()
+    git = Git(repo_dir).init()
+
+    # Commit real AWS credentials into history, then remove them from the
+    # working tree. They should be invisible to a filesystem-mode scan.
+    secret_file = repo_dir / "aws.sh"
+    secret_file.write_text(
+        f"""#!/bin/sh
+export AWS_ACCESS_KEY_ID={AWS_ACCESS_KEY_ID}
+export AWS_SECRET_ACCESS_KEY={AWS_SECRET_ACCESS_KEY}
+export AWS_SESSION_TOKEN={AWS_SESSION_TOKEN}
+""".strip()
+    )
+    git.add().commit("add secrets")
+    secret_file.write_text("#!/bin/sh\n")
+    git.add().commit("remove secrets")
+
+    target = repo_dir / "hello.sh"
+    target.write_text("#!/bin/sh\necho hello\n")
+
+    insert = chalk.insert(
+        artifact=target,
+        config=(
+            CONFIGS
+            / "composable"
+            / "valid"
+            / "secret_scanner"
+            / "tiny_git_size_limit.c4m"
+        ),
+    )
+    # Confirm the size limit was actually triggered (not just no secrets found
+    # by coincidence).
+    assert "falling back to filesystem mode" in insert.logs
+    # Filesystem mode skips git history so no secrets should be reported.
+    assert insert.mark.has(SECRET_SCANNER=MISSING)
+
+
 @pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
 def test_jenkins(copy_files: list[Path], chalk: Chalk):
     bin_path = copy_files[0]


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Large repos cause significant slowdowns in chalk when running external tools (syft, semgrep, trufflehog). For example, trufflehog in git mode on a large repository can take 30+ minutes.

## Description

**External tool timeouts** (syft, semgrep, trufflehog): When the system `timeout` command is present, tool invocations are automatically wrapped with it. Configurable per tool via `tool.<name>.<name>_timeout` (default `"300"` — 5 minutes). Set to `""` to disable. The timeout value is plain seconds for cross-platform compatibility.

**Trufflehog git-mode size guard**: Adds a `dir_size(string) -> Size` con4m builtin that recursively sums file sizes under a directory. Uses it in `get_trufflehog_args` to check the `.git` directory size before running trufflehog in git mode — if the directory exceeds a configurable threshold (default `<<250mb>>`), trufflehog falls back to filesystem mode and logs a warning with the measured size and limit. Controlled via:
- `tool.trufflehog.trufflehog_git_size_check` (bool, default `true`) — enable/disable the check
- `tool.trufflehog.trufflehog_git_size_limit` (Size, default `<<250mb>>`) — threshold

## Testing

```
make tests args="test_plugins.py::test_syft_docker test_plugins.py::test_syft_binary test_plugins.py::test_semgrep test_plugins.py::test_trufflehog -v"
```