### PR TITLE
feat: OCI referrers API support for attestations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,19 @@
 
   ([#669](https://github.com/crashappsec/chalk/pull/669))
 
+- OCI Referrers API support for attestations. When the target registry
+  supports `GET /v2/{name}/referrers/{digest}`, Chalk attaches attestations
+  as referrer manifests (using the `subject` field) instead of relying
+  solely on the legacy `sha256-<digest>` tag. The referrers path is detected
+  automatically via the `OCI-Subject` response header.
+
+  New configuration field on `docker`:
+  - `attestation_use_oci_tag` - when the referrers API is available, also
+    maintain the legacy attestation tag for clients that do not support the
+    referrers API (default: `true`)
+
+  ([#674](https://github.com/crashappsec/chalk/pull/674))
+
 ## 1.1.0
 
 **June 8, 2026**

--- a/src/attestation_api.nim
+++ b/src/attestation_api.nim
@@ -326,7 +326,7 @@ proc signBySigStore*(chalk: ChalkObj,
       "dsseEnvelope": dsse,
     })
   result.setIfNotEmpty("_SIGNATURES", %(@[dsse]))
-  subject.asImage().appendToAttestationManifestList(
+  subject.asImage().addAttestation(
     DockerManifest(
       kind:         DockerManifestType.image,
       mediaType:    "application/vnd.oci.image.manifest.v1+json",

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2044,6 +2044,22 @@ The cleanup runs at the start of each `chalk docker build` and `chalk docker pus
 """
   }
 
+  field attestation_use_oci_tag {
+    type:    bool
+    default: true
+    shortdoc: "Also push the OCI attestation tag when the referrers API is supported"
+    doc:     """
+When the target registry supports the OCI Referrers API
+(`GET /v2/{name}/referrers/{digest}`), Chalk attaches attestations as
+referrer manifests using the `subject` field.  When this option is `true`
+(the default), Chalk also maintains the legacy attestation tag
+(`sha256-<digest>`) so that clients that only understand the tag schema
+can still find the attestation.  The tag push is best-effort: errors are
+logged and never fail the operation.  Set to `false` to skip
+the tag push entirely when the referrers API is available.
+"""
+  }
+
 }
 
 docker_login_types := ["", "get"]

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -34,6 +34,7 @@ import "."/[
   image,
   inspect,
   login,
+  manifest,
   platform,
   registry,
   scan,
@@ -781,6 +782,7 @@ proc dockerBuild*(ctx: DockerInvocation): int =
         chalk.collectedData["_OP_ARTIFACT_CONTEXT"] = pack("build")
         chalk.collectRunTimeArtifactInfo()
   collectRunTimeHostInfo()
+  flushAttestationTags()
 
   if wrapVirtual and result == 0:
     for platform, chalk in chalksByPlatform:

--- a/src/docker/context_upload.nim
+++ b/src/docker/context_upload.nim
@@ -205,7 +205,7 @@ proc newContextManifest(
   ## Build an OCI image manifest wrapping a context tarball layer.
   DockerManifest(
     kind:         DockerManifestType.image,
-    name:         image.asOciAttestation(),
+    name:         image.withTag("").withDigest(""),
     mediaType:    "application/vnd.oci.image.manifest.v1+json",
     artifactType: CONTEXT_ARTIFACT_TYPE,
     subject:      subject,
@@ -429,7 +429,7 @@ proc completeBuildContextUpload(
         layer       = layer,
         contextName = contextName,
       )
-    discard image.appendToAttestationManifestList(ctxManifest)
+    image.addAttestation(ctxManifest)
     return (ctxManifest.digest.extractDockerHash(), blobSize, @[])
 
   of "local":
@@ -466,7 +466,7 @@ proc completeBuildContextUpload(
       layer       = layer,
       contextName = contextName,
     )
-    discard image.appendToAttestationManifestList(ctxManifest)
+    image.addAttestation(ctxManifest)
     return (ctxManifest.digest.extractDockerHash(), tarSize, @[])
 
   of "disk":
@@ -516,7 +516,7 @@ proc completeBuildContextUpload(
         layer       = layer,
         contextName = contextName,
       )
-      discard image.appendToAttestationManifestList(ctxManifest)
+      image.addAttestation(ctxManifest)
       return (ctxManifest.digest.extractDockerHash(), tarSize, skippedFiles)
     finally:
       removeFile(tarPath)

--- a/src/docker/context_upload.nim
+++ b/src/docker/context_upload.nim
@@ -205,7 +205,6 @@ proc newContextManifest(
   ## Build an OCI image manifest wrapping a context tarball layer.
   DockerManifest(
     kind:         DockerManifestType.image,
-    name:         image.withTag("").withDigest(""),
     mediaType:    "application/vnd.oci.image.manifest.v1+json",
     artifactType: CONTEXT_ARTIFACT_TYPE,
     subject:      subject,
@@ -215,7 +214,6 @@ proc newContextManifest(
     }),
     config: DockerManifest(
       kind:      DockerManifestType.config,
-      name:      image,
       mediaType: CONTEXT_CONFIG_TYPE,
       json:      newJObject(),
     ),
@@ -417,7 +415,6 @@ proc completeBuildContextUpload(
     let
       layer       = DockerManifest(
         kind:      DockerManifestType.layer,
-        name:      image,
         mediaType: CONTEXT_LAYER_TYPE,
         digest:    "sha256:" & blobDigest,
         size:      blobSize,
@@ -455,7 +452,7 @@ proc completeBuildContextUpload(
       tarSize = getFileSize(tarPath)
       layer   = DockerManifest(
         kind:       DockerManifestType.layer,
-        name:       image.withDigest(actualHash),
+        name:       image.withBare().withDigest(actualHash),
         mediaType:  CONTEXT_LAYER_TYPE,
         fileStream: newFileStringStream(tarPath),
       )
@@ -505,17 +502,15 @@ proc completeBuildContextUpload(
         tarSize = getFileSize(tarPath)
         layer   = DockerManifest(
           kind:       DockerManifestType.layer,
-          name:       image,
           mediaType:  CONTEXT_LAYER_TYPE,
           fileStream: newFileStringStream(tarPath),
         )
-      layer.put()
-      let ctxManifest = newContextManifest(
-        image       = image,
-        subject     = subject,
-        layer       = layer,
-        contextName = contextName,
-      )
+        ctxManifest = newContextManifest(
+          image       = image,
+          subject     = subject,
+          layer       = layer,
+          contextName = contextName,
+        )
       image.addAttestation(ctxManifest)
       return (ctxManifest.digest.extractDockerHash(), tarSize, skippedFiles)
     finally:

--- a/src/docker/ids.nim
+++ b/src/docker/ids.nim
@@ -494,9 +494,13 @@ proc exists*(self: DockerImage): bool =
   return self != ("", "", "")
 
 proc asOciAttestation*(self: DockerImage): DockerImage =
+  if self.digest == "":
+    raise newException(ValueError, "asOciAttestation requires a digest: " & $self)
   return self.withBare().withTag("sha256-" & self.digest)
 
 proc asCosignAttestation*(self: DockerImage): DockerImage =
+  if self.digest == "":
+    raise newException(ValueError, "asCosignAttestation requires a digest: " & $self)
   return self.withBare().withTag("sha256-" & self.digest & ".att")
 
 proc asRepoTag*(items: seq[DockerImage]): seq[string] =

--- a/src/docker/ids.nim
+++ b/src/docker/ids.nim
@@ -263,6 +263,9 @@ proc withTag*(self: DockerImage, tag: string): DockerImage =
 proc isPinned*(self: DockerImage): bool =
   return self.digest != "" or self.repo == "scratch"
 
+proc withBare*(self: DockerImage): DockerImage =
+  return (self.repo, "", "")
+
 proc withDigest*(self: DockerImage, digest: string): DockerImage =
   return (self.repo, self.tag, digest.extractDockerHash())
 
@@ -491,10 +494,10 @@ proc exists*(self: DockerImage): bool =
   return self != ("", "", "")
 
 proc asOciAttestation*(self: DockerImage): DockerImage =
-  return self.withTag("sha256-" & self.digest).withDigest("")
+  return self.withBare().withTag("sha256-" & self.digest)
 
 proc asCosignAttestation*(self: DockerImage): DockerImage =
-  return self.withTag("sha256-" & self.digest & ".att").withDigest("")
+  return self.withBare().withTag("sha256-" & self.digest & ".att")
 
 proc asRepoTag*(items: seq[DockerImage]): seq[string] =
   result = @[]

--- a/src/docker/json.nim
+++ b/src/docker/json.nim
@@ -38,7 +38,6 @@ proc parseAndDigestJson*(data: string, digest: string): DigestedJson =
 proc newDockerDigestedJson*(data:      string | JsonNode,
                             digest:    string,
                             mediaType: string,
-                            kind:      DockerManifestType,
                             size       = 0,
                             ): DockerDigestedJson =
   return DockerDigestedJson(
@@ -46,7 +45,6 @@ proc newDockerDigestedJson*(data:      string | JsonNode,
     digest:    "sha256:" & extractDockerHash(digest),
     size:      if size > 0 : size else: len($data),
     mediaType: mediaType,
-    kind:      kind,
   )
 
 type

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -33,8 +33,9 @@ type FilterManifests = ref object
 
 # cache is by repo ref as its normalized in buildx imagetools command
 var
-  jsonCache     = initTable[string, DigestedJson]()
-  manifestCache = initTable[string, DockerManifest]()
+  jsonCache              = initTable[string, DigestedJson]()
+  manifestCache          = initTable[string, DockerManifest]()
+  pendingAttestationTags = initOrderedTable[string, DockerManifest]()
 
 proc getCompressedSize(self: DockerManifest): int =
   if self.kind != DockerManifestType.image:
@@ -716,28 +717,64 @@ proc put*(self: DockerManifest) =
       ),
       check = false,
     )
+  self.isFetched = true
 
-proc appendToAttestationManifestList*(image: DockerImage,
-                                      item: DockerManifest,
-                                      ): DockerManifest {.discardable.} =
-  ## Fetch (or create) the OCI attestation manifest list for `image` and append
-  ## `item` to it, then push the updated list.  `image` must have a digest set.
-  ## Returns the manifest list that was pushed.
-  let attSpec = image.asOciAttestation()
-  try:
-    result = attSpec.fetchListManifest(fetchManifests = true)
-    trace("attestation: adding to existing manifest list at " & $attSpec)
-  except RegistryResponseError:
-    result = DockerManifest(
-      name:      attSpec,
-      kind:      DockerManifestType.list,
-      mediaType: "application/vnd.oci.image.index.v1+json",
-      manifests: @[],
+proc addAttestationToTag(subject: DockerImage, item: DockerManifest) =
+  ## Fetch (or create) the OCI attestation manifest list for `subject` and
+  ## append `item` to it.  `subject` must have a digest set.  The updated list
+  ## is not pushed immediately; call `flushAttestationTags` to push all pending
+  ## tags at once, avoiding duplicate writes to immutable-tag registries.
+  let
+    attSpec = subject.asOciAttestation()
+    key     = $attSpec
+  if key in pendingAttestationTags:
+    trace("attestation: appending to cached manifest list at " & $attSpec)
+    pendingAttestationTags[key].add(item)
+  else:
+    var manifest =
+      try:
+        let m = attSpec.fetchListManifest(fetchManifests = true)
+        trace("attestation: adding to existing manifest list at " & $attSpec)
+        m
+      except RegistryResponseError:
+        trace("attestation: creating new manifest list at " & $attSpec)
+        DockerManifest(
+          name:      attSpec,
+          kind:      DockerManifestType.list,
+          mediaType: "application/vnd.oci.image.index.v1+json",
+          manifests: @[],
+        )
+    manifest.add(item)
+    pendingAttestationTags[key] = manifest
+
+proc flushAttestationTags*() =
+  ## Push all deferred attestation manifest list tags accumulated via
+  ## `addAttestationToTag`.  All tags are attempted regardless of individual
+  ## failures; errors are logged and swallowed.
+  for key, manifest in pendingAttestationTags:
+    info("attestation: pushing attestation tag " & key)
+    try:
+      manifest.put()
+    except:
+      error("attestation: could not push attestation tag " & key & ": " & getCurrentExceptionMsg())
+      dumpExOnDebug()
+  pendingAttestationTags.clear()
+
+proc addAttestation*(subject: DockerImage, item: DockerManifest) =
+  let
+    useOciTag = attrGet[bool]("docker.attestation_use_oci_tag")
+    referrers = supportsReferrers(subject)
+
+  item.name = subject.withTag("").withDigest("")
+  item.link()
+  info("attestation: pushing attestation for " & $subject)
+  item.put()
+
+  if not referrers or useOciTag:
+    addAttestationToTag(
+      subject = subject,
+      item    = item,
     )
-    trace("attestation: creating new manifest list at " & $attSpec)
-  result.add(item)
-  info("attestation: pushing attestation for " & $image & " to " & $result.name)
-  result.put()
 
 proc findSibling(self: DockerManifest, reference = "attestation-manifest"): DockerManifest =
   return (
@@ -927,13 +964,28 @@ iterator fetchCosignDsseInTotoMark(image: DockerImage): (JsonNode, string) =
       trace("docker: could not get intoto statement from cosign sigstore attestation from " &
             $image & " due to " & getCurrentExceptionMsg())
 
-iterator fetchOCIDsseInTotoMark(image: DockerImage): (JsonNode, string) =
-  let spec = image.asOciAttestation()
-  trace("docker: getting intoto statement from cosign OCI attestation for " & $spec)
+proc fetchAttestationManifests(
+    subject:      DockerImage,
+    artifactType = "",
+): DockerManifest =
+  if supportsReferrers(subject):
+    let data = referrersGet(
+      image        = subject,
+      artifactType = artifactType,
+    )
+    if data != nil:
+      return newManifest(subject, data)
+  return fetchListOrImageManifest(
+    subject.asOciAttestation(),
+    fetchConfig = false,
+  )
+
+iterator fetchOCIDsseInTotoMark(subject: DockerImage): (JsonNode, string) =
+  trace("docker: getting intoto statement from OCI attestation for " & $subject)
   # in cosign v3 which uses OCI there could be multiple manifests
   # but each having only one attestation layer
   for manifest in (
-    fetchListOrImageManifest(spec, fetchConfig = false)
+    fetchAttestationManifests(subject)
     .allImages()
     .filterByAllAnnotations(
       {
@@ -960,10 +1012,10 @@ iterator fetchOCIDsseInTotoMark(image: DockerImage): (JsonNode, string) =
           envelope{"dsseEnvelope"}
           .assertIs(JObject, "Bad dsse in-toto envelope type")
         )
-      yield (dsse, dsse.getMarkFromDsseInToto(image))
+      yield (dsse, dsse.getMarkFromDsseInToto(subject))
     except:
       trace("docker: could not get intoto statement from OCI attestation from " &
-            $image & " due to " & getCurrentExceptionMsg())
+            $subject & " due to " & getCurrentExceptionMsg())
 
 iterator fetchDsseInTotoMark*(image:        DockerImage,
                               fetchOci    = true,

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -141,7 +141,10 @@ proc setImageConfig(self: DockerManifest, data: DigestedJson) =
   if self.kind != DockerManifestType.image:
     raise newException(AssertionDefect, "can only set image config on image manifests")
   let
-    configJson = data.json{"config"}
+    configJson = data.json{"config"}.assertIs(
+      JObject,
+      "malformed registry image manifest response: 'config' field",
+    )
     config     = DockerManifest(
       kind:       DockerManifestType.config,
       name:       self.name,
@@ -177,7 +180,10 @@ proc setImageLayers(self: DockerManifest, data: DigestedJson) =
   if self.kind != DockerManifestType.image:
     raise newException(AssertionDefect, "can only set image layers on image manifests")
   self.layers = @[]
-  for layer in data.json{"layers"}.items():
+  for layer in data.json{"layers"}.assertIs(
+    JArray,
+    "malformed registry image manifest response: 'layers' field",
+  ).items():
     self.layers.add(DockerManifest(
       kind:          DockerManifestType.layer,
       name:          self.name,
@@ -253,9 +259,10 @@ proc newManifest(name: DockerImage, data: DigestedJson): DockerManifest =
     )
     list.setJson(data)
     list.setAnnotations(json)
-    let manifests = json{"manifests"}
-    if manifests == nil or manifests.kind != JArray:
-      return list
+    let manifests = json{"manifests"}.assertIs(
+      JArray,
+      "malformed registry manifest list response: 'manifests' field",
+    )
     for item in manifests.items():
       let platform = item{"platform"}
       list.manifests.add(DockerManifest(
@@ -978,7 +985,9 @@ proc fetchAttestationManifests(
       artifactType = artifactType,
     )
     if data != nil:
-      return newManifest(subject, data)
+      let manifest = newManifest(subject, data)
+      if manifest.allImages().all().len > 0:
+        return manifest
   return fetchListOrImageManifest(
     subject.asOciAttestation(),
     fetchConfig = false,

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -784,7 +784,7 @@ proc addAttestation*(subject: DockerImage, item: DockerManifest) =
   # Check after put() so that the OCI-Subject response header from the
   # registry has a chance to warm the referrers cache before we decide
   # whether to also push the legacy sha256-<digest> tag.
-  if not supportsReferrers(subject) or useOciTag:
+  if useOciTag or not supportsReferrers(subject):
     addAttestationToTag(
       subject = subject,
       item    = item,

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -219,6 +219,8 @@ proc fetch(self:            DockerManifest,
       self.setAnnotations(data.json)
       self.setImageConfig(data)
       self.setImageLayers(data)
+      if self.artifactType == "":
+        self.artifactType = data.json{"artifactType"}.getStr()
     if fetchConfig:
       self.config.fetch()
       self.setImagePlatform(self.config.configPlatform, check = checkPlatform)
@@ -252,10 +254,11 @@ proc newManifest(name: DockerImage, data: DigestedJson): DockerManifest =
   if "manifests" in json:
     trace("docker: " & $name & " is a manifest list")
     let list = DockerManifest(
-      kind:       DockerManifestType.list,
-      name:       name,
-      mediaType:  json{"mediaType"}.getStr(),
-      manifests:  @[],
+      kind:         DockerManifestType.list,
+      name:         name,
+      mediaType:    json{"mediaType"}.getStr(),
+      artifactType: json{"artifactType"}.getStr(),
+      manifests:    @[],
     )
     list.setJson(data)
     list.setAnnotations(json)
@@ -270,7 +273,7 @@ proc newManifest(name: DockerImage, data: DigestedJson): DockerManifest =
         name:         name,
         list:         list,
         mediaType:    item{"mediaType"}.getStr(),
-        artifactType: json{"artifactType"}.getStr(),
+        artifactType: item{"artifactType"}.getStr(),
         digest:       item{"digest"}.getStr(),
         size:         item{"size"}.getInt(),
         platform:     DockerPlatform(

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -253,7 +253,10 @@ proc newManifest(name: DockerImage, data: DigestedJson): DockerManifest =
     )
     list.setJson(data)
     list.setAnnotations(json)
-    for item in json["manifests"].items():
+    let manifests = json{"manifests"}
+    if manifests == nil or manifests.kind != JArray:
+      return list
+    for item in manifests.items():
       let platform = item{"platform"}
       list.manifests.add(DockerManifest(
         kind:         DockerManifestType.image,
@@ -765,7 +768,7 @@ proc addAttestation*(subject: DockerImage, item: DockerManifest) =
     useOciTag = attrGet[bool]("docker.attestation_use_oci_tag")
     referrers = supportsReferrers(subject)
 
-  item.name = subject.withTag("").withDigest("")
+  item.name = subject.withBare()
   item.link()
   info("attestation: pushing attestation for " & $subject)
   item.put()

--- a/src/docker/manifest.nim
+++ b/src/docker/manifest.nim
@@ -764,16 +764,17 @@ proc flushAttestationTags*() =
   pendingAttestationTags.clear()
 
 proc addAttestation*(subject: DockerImage, item: DockerManifest) =
-  let
-    useOciTag = attrGet[bool]("docker.attestation_use_oci_tag")
-    referrers = supportsReferrers(subject)
+  let useOciTag = attrGet[bool]("docker.attestation_use_oci_tag")
 
   item.name = subject.withBare()
   item.link()
   info("attestation: pushing attestation for " & $subject)
   item.put()
 
-  if not referrers or useOciTag:
+  # Check after put() so that the OCI-Subject response header from the
+  # registry has a chance to warm the referrers cache before we decide
+  # whether to also push the legacy sha256-<digest> tag.
+  if not supportsReferrers(subject) or useOciTag:
     addAttestationToTag(
       subject = subject,
       item    = item,

--- a/src/docker/push.nim
+++ b/src/docker/push.nim
@@ -18,6 +18,7 @@ import "."/[
   context_upload,
   exe,
   login,
+  manifest,
   scan,
   util,
 ]
@@ -86,6 +87,7 @@ proc dockerPush*(ctx: DockerInvocation): int =
           error("docker: build context attestation failed: " & getCurrentExceptionMsg())
           dumpExOnDebug()
       collectRunTimeHostInfo()
+      flushAttestationTags()
     finally:
       for i in imagesToPrune:
         try:

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -633,7 +633,7 @@ proc manifestHead*(image:    DockerImage,
                    useCase = RegistryUseCase.ReadOnly,
                    ): DockerDigestedJson =
   let
-    (msg, response) = image.request(
+    (_, response) = image.request(
       useCase    = useCase,
       httpMethod = HttpHead,
       path       = "/manifests/" & image.imageRef,
@@ -645,28 +645,18 @@ proc manifestHead*(image:    DockerImage,
         "*/*"
       ),
     )
-    contentType = response.headers["Content-Type"]
-    digest      = validateDigest(response.headers["Docker-Content-Digest"])
+    contentType = response.headers.mustGet("Content-Type", "registry HEAD response missing Content-Type header")
+    digest      = validateDigest(response.headers.mustGet("Docker-Content-Digest", "registry HEAD response missing Docker-Content-Digest header"))
+  # HEAD normally doesnt return referrers header but checking just in-case
   checkReferrersSupport(image, response)
-  if contentType notin CONTENT_TYPE_MAPPING:
-    # TODO do heuristics on response payload as there are bound to be new mime types
-    raise newException(
-      ValueError,
-      msg & " returned unsupported registry content type: " & contentType
-    )
-  let size =
-    try:
-      parseInt(response.headers["Content-Length"])
-    except:
-      raise newException(
-        ValueError,
-        "invalid Content-Length from registry: " & response.headers["Content-Length"]
-      )
+  let size = response.headers.mustGetInt(
+    "Content-Length",
+    "registry HEAD response missing Content-Length header",
+  )
   return newDockerDigestedJson(
     data      = JsonNode(nil),
     digest    = digest,
     mediaType = contentType,
-    kind      = CONTENT_TYPE_MAPPING[contentType],
     size      = size,
   )
 
@@ -680,12 +670,12 @@ proc manifestGet*(image:    DockerImage,
     path       = "/manifests/" & image.imageRef,
     accept     = accept,
   )
+  # GET normally doesnt return referrers header but checking just in-case
   checkReferrersSupport(image, response)
   return newDockerDigestedJson(
     data      = response.body(),
-    digest    = image.imageRef,
+    digest    = response.body().sha256Hex(),
     mediaType = accept,
-    kind      = CONTENT_TYPE_MAPPING[accept],
   )
 
 proc layerGetString*(layer:    DockerImage,
@@ -811,20 +801,15 @@ proc layerPutFileStream*(
       accept      = contentType,
     )
     trace("docker: layer already exists. nothing to upload")
-    let existingSize =
-      try:
-        parseInt(response.headers["Content-Length"])
-      except:
-        raise newException(
-          ValueError,
-          "invalid Content-Length from registry: " & response.headers["Content-Length"]
-        )
+    let existingSize = response.headers.mustGetInt(
+      "Content-Length",
+      "registry HEAD response missing Content-Length header",
+    )
     return newDockerDigestedJson(
       data      = JsonNode(nil),
       digest    = layer.digest,
-      mediaType = response.headers["Content-Type"],
+      mediaType = response.headers.mustGet("Content-Type", "registry HEAD response missing Content-Type header"),
       size      = existingSize,
-      kind      = DockerManifestType.layer,
     )
   except RegistryResponseError:
     trace("docker: layer doesnt exist. uploading " & $layer)
@@ -884,9 +869,8 @@ proc layerPutFileStream*(
     # > uploaded blob which may differ from the provided digest.
     return newDockerDigestedJson(
       data      = JsonNode(nil),
-      digest    = validateDigest(response.headers["Docker-Content-Digest"]),
+      digest    = validateDigest(response.headers.mustGet("Docker-Content-Digest", "registry PUT response missing Docker-Content-Digest header")),
       mediaType = contentType,
-      kind      = DockerManifestType.layer,
       size      = len(fileStream),
     )
 
@@ -955,9 +939,8 @@ proc manifestPut*(image:       DockerImage,
     checkReferrersSupport(image, response)
     return newDockerDigestedJson(
       data      = data,
-      digest    = validateDigest(response.headers["Docker-Content-Digest"]),
+      digest    = validateDigest(response.headers.mustGet("Docker-Content-Digest", "registry PUT response missing Docker-Content-Digest header")),
       mediaType = contentType,
-      kind      = CONTENT_TYPE_MAPPING[contentType],
       size      = len(body),
     )
 
@@ -986,7 +969,6 @@ proc referrersGet*(image:        DockerImage,
       data      = response.body(),
       digest    = response.body().sha256Hex(),
       mediaType = "application/vnd.oci.image.index.v1+json",
-      kind      = DockerManifestType.list,
     )
   except:
     dumpExOnDebug()

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -496,6 +496,14 @@ var jsonCache = initTable[
   (DockerImage, HttpMethod, string, RegistryUseCase),
   (string, Response)
 ]()
+var referrersCache = initTable[string, bool]()
+
+proc checkReferrersSupport(image: DockerImage, response: Response) =
+  if not response.headers.hasKey("OCI-Subject"):
+    return
+  let key = image.withTag("").withDigest("").asRepoRef()
+  referrersCache[key] = true
+
 proc request(self:              DockerImage,
              httpMethod:        HttpMethod,
              path               = "",
@@ -638,7 +646,8 @@ proc manifestHead*(image:    DockerImage,
       ),
     )
     contentType = response.headers["Content-Type"]
-    digest      = validateDigest(response.headers["Docker-Content-Digest"])
+    digest      = response.headers["Docker-Content-Digest"]
+  checkReferrersSupport(image, response)
   if contentType notin CONTENT_TYPE_MAPPING:
     # TODO do heuristics on response payload as there are bound to be new mime types
     raise newException(
@@ -671,6 +680,7 @@ proc manifestGet*(image:    DockerImage,
     path       = "/manifests/" & image.imageRef,
     accept     = accept,
   )
+  checkReferrersSupport(image, response)
   return newDockerDigestedJson(
     data      = response.body(),
     digest    = image.imageRef,
@@ -942,6 +952,7 @@ proc manifestPut*(image:       DockerImage,
           image.imageRef
       ),
     )
+    checkReferrersSupport(image, response)
     return newDockerDigestedJson(
       data      = data,
       digest    = validateDigest(response.headers["Docker-Content-Digest"]),
@@ -949,6 +960,48 @@ proc manifestPut*(image:       DockerImage,
       kind      = CONTENT_TYPE_MAPPING[contentType],
       size      = len(body),
     )
+
+proc referrersGet*(image:        DockerImage,
+                   artifactType = "",
+                  ): DockerDigestedJson =
+  ## Returns the OCI referrers index for image, or nil if the registry
+  ## does not support the referrers API.  image.digest must be set.
+  ## artifactType filters the result to referrers with a matching artifactType.
+  let path =
+    if artifactType != "":
+      "/referrers/" & image.imageRef & "?artifactType=" & encodeUrl(artifactType, usePlus = false)
+    else:
+      "/referrers/" & image.imageRef
+  try:
+    let (_, response) = image.request(
+      useCase           = RegistryUseCase.ReadOnly,
+      httpMethod        = HttpGet,
+      path              = path,
+      accept            = "application/vnd.oci.image.index.v1+json",
+      acceptStatusCodes = @[200..299, 404..404],
+    )
+    if not response.code().is2xx():
+      return nil
+    return newDockerDigestedJson(
+      data      = response.body(),
+      digest    = response.body().sha256Hex(),
+      mediaType = "application/vnd.oci.image.index.v1+json",
+      kind      = DockerManifestType.list,
+    )
+  except:
+    dumpExOnDebug()
+    return nil
+
+proc supportsReferrers*(image: DockerImage): bool =
+  let key = image.withTag("").withDigest("").asRepoRef()
+  if key in referrersCache:
+    return referrersCache[key]
+  result = referrersGet(image) != nil
+  referrersCache[key] = result
+  if result:
+    trace("attestation: registry supports OCI referrers API for " & $image)
+  else:
+    trace("attestation: registry does not support OCI referrers API for " & $image)
 
 proc toChalkDict(self: RegistryConfig): ChalkDict =
   result = ChalkDict()

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -501,7 +501,7 @@ var referrersCache = initTable[string, bool]()
 proc checkReferrersSupport(image: DockerImage, response: Response) =
   if not response.headers.hasKey("OCI-Subject"):
     return
-  let key = image.withTag("").withDigest("").asRepoRef()
+  let key = image.withBare().asRepoRef()
   referrersCache[key] = true
 
 proc request(self:              DockerImage,
@@ -993,7 +993,7 @@ proc referrersGet*(image:        DockerImage,
     return nil
 
 proc supportsReferrers*(image: DockerImage): bool =
-  let key = image.withTag("").withDigest("").asRepoRef()
+  let key = image.withBare().asRepoRef()
   if key in referrersCache:
     return referrersCache[key]
   result = referrersGet(image) != nil

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -646,7 +646,7 @@ proc manifestHead*(image:    DockerImage,
       ),
     )
     contentType = response.headers["Content-Type"]
-    digest      = response.headers["Docker-Content-Digest"]
+    digest      = validateDigest(response.headers["Docker-Content-Digest"])
   checkReferrersSupport(image, response)
   if contentType notin CONTENT_TYPE_MAPPING:
     # TODO do heuristics on response payload as there are bound to be new mime types

--- a/src/types.nim
+++ b/src/types.nim
@@ -368,7 +368,6 @@ type
 
   DockerDigestedJson* = ref object of DigestedJson
     mediaType*: string
-    kind*:      DockerManifestType
 
   DockerManifestType* = enum
     list, image, config, layer

--- a/src/utils/http.nim
+++ b/src/utils/http.nim
@@ -8,6 +8,7 @@
 import std/[
   httpclient,
   httpcore,
+  strutils,
 ]
 
 export httpclient
@@ -17,3 +18,15 @@ proc update*(self: HttpHeaders, with: HttpHeaders): HttpHeaders =
   for k, v in with.pairs():
     self[k] = v
   return self
+
+proc mustGet*(headers: HttpHeaders, header: string, msg: string): string =
+  if not headers.hasKey(header):
+    raise newException(ValueError, msg)
+  return headers[header]
+
+proc mustGetInt*(headers: HttpHeaders, header: string, msg: string): int =
+  let value = headers.mustGet(header, msg)
+  try:
+    return parseInt(value)
+  except:
+    raise newException(ValueError, msg & ": invalid integer: " & value)


### PR DESCRIPTION
- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

Immutable tags registry fails when both context upload and attestations are enabled

## Description

When a registry supports the OCI Referrers API (`GET /v2/{name}/referrers/{digest}`),
attestations are now pushed as referrer manifests using the `subject` field rather than
relying solely on the legacy `sha256-<digest>` tag schema. Support is detected
automatically via the `OCI-Subject` response header on manifest operations.

Changes:

- **`registry.nim`**: detect referrers support via `OCI-Subject` response header and
  cache per repo; add `referrersGet` (fetch referrers index) and `supportsReferrers`
  (cached probe) procs
- **`manifest.nim`**: replace `appendToAttestationManifestList` with `addAttestation`
  which pushes the referrer manifest and optionally also maintains the legacy tag;
  `addAttestationToTag` now defers the tag push into `pendingAttestationTags`;
  `flushAttestationTags` pushes all pending tags at the end of build/push to avoid
  duplicate writes to immutable-tag registries (e.g. when both context upload and
  sigstore attestation run in the same operation)
- **`build.nim`**, **`push.nim`**: call `flushAttestationTags` after all attestations
  have been added
- **`context_upload.nim`**, **`attestation_api.nim`**: updated to use `addAttestation`
- **`chalk.c42spec`**: new `docker.attestation_use_oci_tag` field — when the referrers
  API is available, also maintain the legacy tag for clients that only understand the
  tag schema (default: `true`); set to `false` to skip the tag push entirely

## Testing

```
maketests test_docker.py
```