### PR TITLE
fix: silence repeated errors for file sinks and report cache on read-only filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,17 @@
 
   ([#674](https://github.com/crashappsec/chalk/pull/674))
 
+### Bug Fixes
+
+- File sinks and the report cache no longer emit continuous errors when chalk
+  runs in a container with a read-only root filesystem. A file sink whose
+  destination directory is not writable is now disabled at startup with a
+  single warning. Similarly, if the report cache location is on a read-only
+  filesystem, the cache is disabled with a single warning rather than
+  repeatedly failing on every publish attempt.
+
+  ([#676](https://github.com/crashappsec/chalk/pull/676))
+
 ## 1.1.0
 
 **June 8, 2026**

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -15,7 +15,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#d6fd3f0d077ed494d6ba27e364b7a31f9671d5f4"
+requires "https://github.com/crashappsec/con4m#59075614b2452386f230b73bad523f9b7020b7be"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 

--- a/src/reportcache.nim
+++ b/src/reportcache.nim
@@ -169,10 +169,8 @@ proc loadReportCache(fname: string) =
               cacheObj[topic].add(msg)
             else:
               cacheObj[topic] = @[msg]
-    # nimutils obtainLockFile raises ValueError (not OSError) for any open()
-    # failure, so we use osLastError() to check errno rather than e.errorCode.
-    except ValueError:
-      if osLastError() == OSErrorCode(EROFS):
+    except OSError as e:
+      if e.errorCode == cint(EROFS):
         if not cacheReadOnly:
           cacheReadOnly = true
           warn(
@@ -180,7 +178,9 @@ proc loadReportCache(fname: string) =
             "filesystem (" & fname & ")"
           )
       else:
-        trace(fname & ": file lock obtained, but no report cache to read.")
+        trace(fname & ": could not load report cache: " & getCurrentExceptionMsg())
+    except ValueError:
+      trace(fname & ": file lock obtained, but no report cache to read.")
     except:
       error("When opening chalk report cache for read: " &
             getCurrentExceptionMsg())
@@ -401,8 +401,8 @@ proc writeReportCache*() =
     try:
       (tmpfile, tmpname) = createTempFile("chalk-report-cache", ".jsonl")
       tmpfile.write(newCacheContents)
-    except:
-      if osLastError() == OSErrorCode(EROFS):
+    except OSError as e:
+      if e.errorCode == cint(EROFS):
         if not cacheReadOnly:
           cacheReadOnly = true
           warn(

--- a/src/reportcache.nim
+++ b/src/reportcache.nim
@@ -420,6 +420,10 @@ proc writeReportCache*() =
       except:
         discard
 
+    # tmpname (system temp dir) and fname (configured cache location) may be
+    # on different filesystems.  createTempFile above succeeded so the temp
+    # dir is writable; EROFS here means fname's filesystem is read-only.
+    # tryRemoveFile(tmpname) works because tmpname is on the writable temp fs.
     try:
       removeFile(fname)
       moveFile(tmpname, fname)
@@ -427,17 +431,13 @@ proc writeReportCache*() =
       warn("Will attempt to report on cache contents next invocation.")
     except OSError as e:
       if e.errorCode == cint(EROFS):
-        if not cacheReadOnly:
-          cacheReadOnly = true
-          warn(
-            "report cache disabled: cache location is on a read-only " &
-            "filesystem (" & fname & ")"
-          )
-        discard tryRemoveFile(tmpname)
-        dumpExOnDebug()
-      else:
-        panicPublish(newCacheContents, tmpname, fname, getCurrentExceptionMsg())
-        dumpExOnDebug()
+        cacheReadOnly = true
+        warn(
+          "report cache disabled: cache location is on a read-only " &
+          "filesystem (" & fname & ")"
+        )
+      panicPublish(newCacheContents, tmpname, fname, getCurrentExceptionMsg())
+      dumpExOnDebug()
 
   else:
     try:

--- a/src/reportcache.nim
+++ b/src/reportcache.nim
@@ -22,6 +22,7 @@
 ## 'current' sinks need to catch up.  If so, we UNSUBSCRIBE them from
 ## the current topic, and re-subscribe them to a topic just for them.
 
+import std/posix
 import "."/[
   sinks,
   types,
@@ -62,9 +63,10 @@ find / -name "chalk-report-cache*.jsonl" 2>/dev/null
 type ReportCacheInfo = TableRef[string, seq[string]]
 
 var
-  reportCache: Table[string, ReportCacheInfo]
-  cacheOpenFailed = false
-  dirtyCache = false # Controls whether the cache will WRITE.
+  reportCache:     Table[string, ReportCacheInfo]
+  cacheOpenFailed  = false
+  cacheReadOnly    = false
+  dirtyCache       = false
 
 
 template doPanicWrite(s: string) =
@@ -167,8 +169,18 @@ proc loadReportCache(fname: string) =
               cacheObj[topic].add(msg)
             else:
               cacheObj[topic] = @[msg]
+    # nimutils obtainLockFile raises ValueError (not OSError) for any open()
+    # failure, so we use osLastError() to check errno rather than e.errorCode.
     except ValueError:
-      trace(fname & ": file lock obtained, but no report cache to read.")
+      if osLastError() == OSErrorCode(EROFS):
+        if not cacheReadOnly:
+          cacheReadOnly = true
+          warn(
+            "report cache disabled: cache location is on a read-only " &
+            "filesystem (" & fname & ")"
+          )
+      else:
+        trace(fname & ": file lock obtained, but no report cache to read.")
     except:
       error("When opening chalk report cache for read: " &
             getCurrentExceptionMsg())
@@ -350,9 +362,8 @@ proc safePublish*(topic, msg: string) =
   # the sink is still broken, then the sink config will still live in
   # the sinkErrors field at this point.
 
-  if len(sinkErrors) != 0:
-    if len(sinkErrors) != 0:
-      addSinkErrorsToCache(topic, msg)
+  if len(sinkErrors) != 0 and not cacheReadOnly:
+    addSinkErrorsToCache(topic, msg)
 
 proc writeReportCache*() =
   # This is called after all reporting is done, to handle stashing any
@@ -365,8 +376,9 @@ proc writeReportCache*() =
   if not attrGet[bool]("use_report_cache"):
     return
 
-  # If nothing published, the reporting cache may not have been loaded, in
-  # which case there's nothing do do.
+  if cacheReadOnly:
+    return
+
   if cacheOpenFailed and len(reportCache) != 0:
     error(msgPossibleLoss)
 
@@ -390,6 +402,15 @@ proc writeReportCache*() =
       (tmpfile, tmpname) = createTempFile("chalk-report-cache", ".jsonl")
       tmpfile.write(newCacheContents)
     except:
+      if osLastError() == OSErrorCode(EROFS):
+        if not cacheReadOnly:
+          cacheReadOnly = true
+          warn(
+            "report cache disabled: cache location is on a read-only " &
+            "filesystem (" & fname & ")"
+          )
+        dumpExOnDebug()
+        return
       panicPublish(newCacheContents, "", fname, getCurrentExceptionMsg())
       dumpExOnDebug()
       return
@@ -404,8 +425,19 @@ proc writeReportCache*() =
       moveFile(tmpname, fname)
       warn("Some reports failed to publish, and are cached in: " & fname)
       warn("Will attempt to report on cache contents next invocation.")
-    except:
-      panicPublish(newCacheContents, tmpname, fname, getCurrentExceptionMsg())
+    except OSError as e:
+      if e.errorCode == cint(EROFS):
+        if not cacheReadOnly:
+          cacheReadOnly = true
+          warn(
+            "report cache disabled: cache location is on a read-only " &
+            "filesystem (" & fname & ")"
+          )
+        discard tryRemoveFile(tmpname)
+        dumpExOnDebug()
+      else:
+        panicPublish(newCacheContents, tmpname, fname, getCurrentExceptionMsg())
+        dumpExOnDebug()
 
   else:
     try:

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -184,7 +184,21 @@ template formatIo(cfg: SinkConfig, t: Topic, err: string, msg: string): string =
 
   line
 
+proc isSinkDestWritable(sinkPath: string): bool =
+  let dir = parentDir(sinkPath)
+  if dir == "" or not dirExists(dir):
+    return true
+  return posix.access(cstring(dir), W_OK) == 0
+
 proc ioErrorHandler(cfg: SinkConfig, t: Topic, msg, err, tb: string) =
+  if cfg.mySink.name in ["file", "rotating_log"]:
+    cfg.enabled = false
+    warn(
+      "sink '" & cfg.name & "' disabled after write failure " &
+      "(filesystem may be read-only or inaccessible): " & err
+    )
+    return
+
   let quiet = t.name in quietTopics
   if not quiet:
     sinkErrors.add(cfg)
@@ -320,6 +334,12 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
         opts[k] = resolvePath(opts[k])
       except:
         warn(opts[k] & ": could not resolve sink filename. disabling sink")
+        enabled = false
+      if enabled and not isSinkDestWritable(opts[k]):
+        warn(
+          "sink '" & name & "': destination '" & opts[k] &
+          "' is not writable (filesystem may be read-only), disabling sink"
+        )
         enabled = false
     else:
       opts[k] = attrGetOpt[string](section & "." & k).getOrElse("")

--- a/tests/functional/data/configs/validation/readonly_fs_cache.c4m
+++ b/tests/functional/data/configs/validation/readonly_fs_cache.c4m
@@ -1,0 +1,10 @@
+sink_config failing_post {
+  enabled: true
+  sink:    "post"
+  uri:     "http://127.0.0.1:1/chalk"
+}
+
+subscribe("report", "failing_post")
+
+use_report_cache          = true
+report_cache_location     = "/etc/chalk-cache.jsonl"

--- a/tests/functional/data/configs/validation/readonly_fs_sink.c4m
+++ b/tests/functional/data/configs/validation/readonly_fs_sink.c4m
@@ -1,0 +1,7 @@
+sink_config ro_file_sink {
+  sink: "file"
+  filename: "/etc/chalk.log"
+  enabled: true
+}
+
+subscribe("report", "ro_file_sink")

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -521,6 +521,67 @@ def test_profiles(
     validate_chalk_report_keys(delete.report, configs["delete"])
 
 
+def test_readonly_filesystem_sinks(chalk_default: Chalk):
+    """
+    chalk should not emit repeated errors when file sinks point to a read-only
+    filesystem.  The sink should be disabled with a single warning on startup.
+    """
+    _, result = Docker.run(
+        image="busybox",
+        entrypoint="/bin/sh",
+        params=["-c", "/chalk --no-color --log-level=warn env"],
+        tty=False,
+        read_only=True,
+        tmpfs=["/tmp"],
+        volumes={
+            chalk_default.binary: "/chalk",
+            CONFIGS / "validation/readonly_fs_sink.c4m": "/etc/chalk.c4m",
+        },
+    )
+
+    # The sink should be disabled exactly once with a warning, not spammed on
+    # every publish attempt.  Each JSON log line is one chalk warn() call.
+    disabled_warnings = [
+        line
+        for line in result.logs.splitlines()
+        if "ro_file_sink" in line and "not writable" in line
+    ]
+    assert len(disabled_warnings) == 1, (
+        f"expected exactly one sink-disabled warning for ro_file_sink, "
+        f"got {len(disabled_warnings)}\n{result.logs}"
+    )
+
+
+def test_readonly_filesystem_report_cache(chalk_default: Chalk):
+    """
+    chalk should not panic or emit repeated errors when the report cache
+    location is on a read-only filesystem.  A single warning should appear
+    and chalk should disable the cache for the rest of the run.
+    """
+    _, result = Docker.run(
+        image="busybox",
+        entrypoint="/bin/sh",
+        params=["-c", "/chalk --no-color --log-level=warn env"],
+        tty=False,
+        read_only=True,
+        tmpfs=["/tmp"],
+        volumes={
+            chalk_default.binary: "/chalk",
+            CONFIGS / "validation/readonly_fs_cache.c4m": "/etc/chalk.c4m",
+        },
+    )
+
+    cache_warnings = [
+        line
+        for line in result.logs.splitlines()
+        if "report cache disabled" in line and "read-only filesystem" in line
+    ]
+    assert len(cache_warnings) == 1, (
+        f"expected exactly one report-cache-disabled warning, "
+        f"got {len(cache_warnings)}\n{result.logs}"
+    )
+
+
 def test_no_certs(chalk_default: Chalk, server_chalkdust: str):
     """
     chalk should be able to connect to chalkdust even when system has no system certs

--- a/tests/functional/utils/docker.py
+++ b/tests/functional/utils/docker.py
@@ -354,6 +354,8 @@ class Docker:
         cwd: Optional[Path] = None,
         env: Optional[dict[str, str]] = None,
         networks: Optional[list[str]] = None,
+        read_only: bool = False,
+        tmpfs: Optional[list[str]] = None,
     ):
         cmd = ["docker", "create"]
         if name:
@@ -374,6 +376,10 @@ class Docker:
             cmd += ["-e", f"{k}={v}"]
         for i in networks or []:
             cmd += ["--network", i]
+        if read_only:
+            cmd += ["--read-only"]
+        for mount in tmpfs or []:
+            cmd += ["--tmpfs", mount]
         cmd += [image]
         cmd += params or []
         container_id = run(cmd).text


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Issue

read-only FS containers report many error logs for any report failures

## Description

File sinks whose destination directory is not writable are now disabled at startup with a single warning instead of logging an error on every publish attempt. The report cache likewise detects a read-only filesystem on first use and disables itself with a single warning for the rest of the run.

## Testing

```
make tests args="test_config.py::test_readonly_filesystem_sinks test_config.py::test_readonly_filesystem_report_cache"
```