### PR TITLE
feat: set chalk/version as default HTTP User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@
 
   ([#674](https://github.com/crashappsec/chalk/pull/674))
 
+- All outgoing HTTP requests now include a `User-Agent` header identifying
+  the chalk version, e.g. `chalk/1.1.1 Nim-httpclient/2.2.6`.
+
+  ([#678](https://github.com/crashappsec/chalk/pull/678))
+
 ### Bug Fixes
 
 - File sinks and the report cache no longer emit continuous errors when chalk

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -15,7 +15,7 @@ bin           = @["chalk"]
 
 # Dependencies
 requires "nim >= 2.0.8"
-requires "https://github.com/crashappsec/con4m#59075614b2452386f230b73bad523f9b7020b7be"
+requires "https://github.com/crashappsec/con4m#a3134275b4940855583bc8f28b8ae306fe8adcae"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT
 

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -455,6 +455,7 @@ proc setupDefaultLogConfigs*() =
 
 proc ioSetup*(bgColor = "darkslategray") =
   once:
+    setDefaultUserAgent("chalk/" & getChalkExeVersion() & " " & getDefaultUserAgent())
     useCrashTheme()
     addDefaultSinks()
     addDefaultAuths()


### PR DESCRIPTION


<!-- Please ensure you have done the following steps: -->

- [x] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [x] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [x] Filled out the template to a useful degree
- [x] Updated `CHANGELOG.md` if necessary

## Description

Sets the User-Agent for all outgoing HTTP requests to "chalk/<version> Nim-httpclient/<nim-version>" via the new get/setDefaultUserAgent API in nimutils.

## Testing

check http requests chalk emits
