### PR TITLE
fix: remove dead keys, fix docker key mismatches, populate missing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,25 @@
 
   ([#678](https://github.com/crashappsec/chalk/pull/678))
 
+- `DOCKER_CHALK_ADDED_LABELS` is now populated with the labels chalk injects
+  during `docker build`, keyed by the original (pre-prefix) key name.
+
+  ([#679](https://github.com/crashappsec/chalk/pull/679))
+
 ### Bug Fixes
+
+- `_OP_PUBLIC_IPV4_ADDR` was defined but never set; it is now populated in
+  every chalk operation report.
+
+  ([#679](https://github.com/crashappsec/chalk/pull/679))
+
+- Three docker image keys were silently absent due to name mismatches between
+  the keyspec and the collector:
+  - `_IMAGE_HOSTNAME`
+  - `_IMAGE_EXPOSED_PORTS`
+  - `_INSTANCE_IP`
+
+  ([#679](https://github.com/crashappsec/chalk/pull/679))
 
 - File sinks and the report cache no longer emit continuous errors when chalk
   runs in a container with a read-only root filesystem. A file sink whose

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -45,7 +45,6 @@ or vice versa.
   key.INJECTOR_COMMIT_ID.use                  = true
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
   key.CHALK_ID.use                            = true
   key.TIMESTAMP_WHEN_CHALKED.use              = true
   key.CHALK_PTR.use                           = true
@@ -166,7 +165,6 @@ mark_template mark_large {
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
   key.INJECTOR_PUBLIC_KEY.use                 = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
   key.TIMESTAMP_WHEN_CHALKED.use              = true
   key.CHALK_PTR.use                           = true
   key.PATH_WHEN_CHALKED.use                   = true
@@ -259,7 +257,6 @@ mark_template mark_large {
   key.$CHALK_LOAD_COUNT.use                   = true
   key.$CHALK_PUBLIC_KEY.use                   = true
   key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = true
-  key.$CHALK_ATTESTATION_TOKEN.use            = true
   key.$CHALK_COMPONENT_CACHE.use              = true
   key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = true
   key.$CHALK_MEMOIZE.use                      = true
@@ -289,7 +286,6 @@ use the mark template named `reproducable`.
   key.PLATFORM_WHEN_CHALKED.use               = true
   key.INJECTOR_COMMIT_ID.use                  = true
   key.INJECTOR_PUBLIC_KEY.use                 = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
   key.ARTIFACT_TYPE.use                       = true
   key.HASH.use                                = true
   key.ORIGIN_URI.use                          = true
@@ -358,7 +354,6 @@ use the mark template named `reproducable`.
   key.$CHALK_LOAD_COUNT.use                   = true
   key.$CHALK_PUBLIC_KEY.use                   = true
   key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = true
-  key.$CHALK_ATTESTATION_TOKEN.use            = true
   key.$CHALK_COMPONENT_CACHE.use              = true
   key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = true
   key.$CHALK_MEMOIZE.use                      = true
@@ -380,7 +375,6 @@ the time and the nonce removed.
   key.PLATFORM_WHEN_CHALKED.use               = true
   key.INJECTOR_COMMIT_ID.use                  = true
   key.INJECTOR_PUBLIC_KEY.use                 = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
   key.ARTIFACT_TYPE.use                       = true
   key.HASH.use                                = true
   key.ORIGIN_URI.use                          = true
@@ -429,7 +423,6 @@ the time and the nonce removed.
   key.$CHALK_LOAD_COUNT.use                   = true
   key.$CHALK_PUBLIC_KEY.use                   = true
   key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = true
-  key.$CHALK_ATTESTATION_TOKEN.use            = true
   key.$CHALK_COMPONENT_CACHE.use              = true
   key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = true
   key.$CHALK_MEMOIZE.use                      = true
@@ -454,7 +447,6 @@ This is the default for `docker` chalk marks.
   key.$CHALK_LOAD_COUNT.use                   = true
   key.$CHALK_PUBLIC_KEY.use                   = true
   key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = true
-  key.$CHALK_ATTESTATION_TOKEN.use            = true
   key.$CHALK_COMPONENT_CACHE.use              = true
   key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = true
   key.$CHALK_MEMOIZE.use                      = true

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -496,23 +496,6 @@ See `docs/design-caller-attestation.md`.
 """
 }
 
-keyspec TENANT_ID_WHEN_CHALKED {
-    kind:     ChalkTimeHost
-    type:     string
-    standard: true
-    since:    "0.1.0"
-    shortdoc: "Tenant info added at mark time"
-    doc:      """
-A user-defined unique identifier, intended to represent a unique user
-in multi-tenant environments. This key is set only at the time in
-which a chalk operation occurs. Its value can be used at that time for
-various URL substitutions (for instance, in the `CHALK_PTR` key).
-
-The default OSS configuration never sets this value, but it can be
-configured manually, or in binaries created by tooling.
-"""
-}
-
 keyspec CHALK_ID {
     required_in_chalk_mark: true
     kind:                   ChalkTimeArtifact
@@ -607,8 +590,6 @@ at the time of chalking:
  of chalking.
  - **{hash}** is replaced with the software artifact's `HASH` field (the Chalk
  hash; see `chalk help hashing`).
- - **{tenant}** is replaced with the software artifact's
- `TENANT_ID_WHEN_CHALKED` field, as set at the time of chalking.
  - **{random}** is replaced with the value of `CHALK_RAND`, as set at the
  time of chalking.
 
@@ -656,6 +637,7 @@ For items chalked when they were in a embedded into a ZIP file, this is the
 """
 }
 
+# TODO: not yet set by any codec; requires ST->GGUF conversion detection
 keyspec DERIVED_FROM_CHALK_ID {
     kind:        ChalkTimeArtifact
     never_early: true
@@ -5263,20 +5245,6 @@ For example:
 """
 }
 
-keyspec _FOUND_BASE_MARK {
-    kind:     RunTimeArtifact
-    type:     tuple[string, string]
-    standard: true
-    since:    "0.1.0"
-    doc:      """
-When extracting from a docker image that is unmarked at the top layer,
-if lower layers are searched, this will be set to the found values of
-CHALK_ID and METADATA_ID, in the highest layer where a mark was found.
-
-These values will not have been validated.
-"""
-}
-
 keyspec _SIGNATURES {
     kind:     RunTimeArtifact
     type:     list[dict[string, string]]
@@ -5393,21 +5361,6 @@ Currently, this filtering is not handled per-report, meaning
 collect both at chalk time.
 """
 }
-
-keyspec _TENANT_ID {
-    kind:     RunTimeHost
-    type:     string
-    standard: true
-    since:    "0.1.0"
-    shortdoc: "Tenant info during the current chalk operation"
-    doc:      """
-Akin to `TENANT_ID_WHEN_CHALKED`, but will not be added to a chalk
-mark, and can be set for any given operation. The default OSS
-configuration never sets this value, but it can be configured
-manually, or in binaries created by tooling.
-"""
-}
-
 
 keyspec _OPERATION {
     kind:             RunTimeHost
@@ -7718,55 +7671,6 @@ keyspec $CHALK_ENCRYPTED_PRIVATE_KEY {
    since:                  "0.1.0"
    doc:                    """
 Also necessary for attestations.
-"""
-}
-
-keyspec $CHALK_DATA_API_KEY {
-   required_in_self_mark:  true
-   kind:                   ChalkTimeArtifact
-   type:                   string
-   standard:               true
-   system:                 true
-   since:                  "0.3.0"
-   doc:                    """
-API key used to optionally save/load attestation keys to cloud.
-"""
-}
-
-keyspec $CHALK_API_REFRESH_TOKEN {
-   required_in_self_mark:  true
-   kind:                   ChalkTimeArtifact
-   type:                   string
-   standard:               true
-   system:                 true
-   since:                  "0.1.4"
-   doc:                    """
-Key to hold the OIDC refresh token for non-user present API
-re-authentication.
-"""
-}
-
-keyspec $CHALK_ATTESTATION_TOKEN {
-   required_in_self_mark:  true
-   kind:                   ChalkTimeArtifact
-   type:                   string
-   standard:               true
-   system:                 true
-   since:                  "0.1.0"
-   doc:                    """
-...
-"""
-}
-
-keyspec $CHALK_SECRET_ENDPOINT_URI {
-   required_in_self_mark:  true
-   kind:                   ChalkTimeArtifact
-   type:                   string
-   standard:               true
-   system:                 true
-   since:                  "0.1.0"
-   doc:                    """
-...
 """
 }
 

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -648,8 +648,6 @@ Note on _EXEC_DEPLOYMENT_ID:
 # {now}     -> value of TIMESTAMP
 # {path}    -> value of PATH_WHEN_CHALKED
 # {hash}    -> value of HASH
-# {tenant}  -> value of TENANT_ID_WHEN_CHALKED
-#
 #
 # While we don't enforce that, if you want to ensure callbacks are called,
 # and that provided values clobber plugin values, you can leave the

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -46,7 +46,6 @@ report and subtract from it.
   key.INJECTOR_COMMIT_ID.use                  = true
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
   key.CHALK_ID.use                            = true
   key.TIMESTAMP_WHEN_CHALKED.use              = true
   key.CHALK_PTR.use                           = true
@@ -387,14 +386,12 @@ report and subtract from it.
   key._REPO_BUILD_CONTEXT_SKIPPED_FILES.use   = true
   key.DOCKER_BUILD_CONTEXT_SNAPSHOTS.use      = true
   key._REPO_LIST_DIGESTS.use                  = true
-  key._FOUND_BASE_MARK.use                    = true
   key._SIGNATURES.use                         = true
   key._INVALID_SIGNATURE.use                  = true
   key._ACTION_ID.use                          = true
   key._EXEC_ID.use                            = true
   key._ARGV.use                               = true
   key._ENV.use                                = true
-  key._TENANT_ID.use                          = true
   key._OPERATION.use                          = true
   key._OP_EXIT_CODE.use                       = true
   key._TIMESTAMP.use                          = true
@@ -543,10 +540,6 @@ report and subtract from it.
   key.$CHALK_LOAD_COUNT.use                   = true
   key.$CHALK_PUBLIC_KEY.use                   = true
   key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = true
-  key.$CHALK_DATA_API_KEY.use                 = true
-  key.$CHALK_API_REFRESH_TOKEN.use            = false
-  key.$CHALK_ATTESTATION_TOKEN.use            = true
-  key.$CHALK_SECRET_ENDPOINT_URI.use          = true
   key.$CHALK_COMPONENT_CACHE.use              = false
   key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = true
   key.$CHALK_MEMOIZE.use                      = true
@@ -579,7 +572,6 @@ doc: """
   key.INJECTOR_COMMIT_ID.use                  = true
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
   key.EXTERNAL_TOOL_DURATION.use              = true
   key.SECRET_SCANNER.use                      = true
   key.SBOM.use                                = true
@@ -588,7 +580,6 @@ doc: """
   key._EXEC_ID.use                            = true
   key._ARGV.use                               = true
   key._ENV.use                                = true
-  key._TENANT_ID.use                          = true
   key._OPERATION.use                          = true
   key._OP_EXIT_CODE.use                       = true
   key._TIMESTAMP.use                          = true
@@ -740,7 +731,6 @@ doc: """
   key.INJECTOR_COMMIT_ID.use                  = true
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
   key.CHALK_ID.use                            = true
   key.TIMESTAMP_WHEN_CHALKED.use              = true
   key.CHALK_PTR.use                           = true
@@ -1078,7 +1068,6 @@ doc: """
   key._REPO_BUILD_CONTEXT_SKIPPED_FILES.use   = true
   key.DOCKER_BUILD_CONTEXT_SNAPSHOTS.use      = true
   key._REPO_LIST_DIGESTS.use                  = true
-  key._FOUND_BASE_MARK.use                    = true
   key._SIGNATURES.use                         = true
   key._INVALID_SIGNATURE.use                  = true
   key._VALIDATED_SIGNATURE.use                = true
@@ -1106,7 +1095,6 @@ doc: """
   key.$CHALK_LOAD_COUNT.use                   = true
   key.$CHALK_PUBLIC_KEY.use                   = true
   key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = true
-  key.$CHALK_ATTESTATION_TOKEN.use            = true
   key.$CHALK_COMPONENT_CACHE.use              = false
   key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = true
   key.$CHALK_MEMOIZE.use                      = true
@@ -1160,7 +1148,6 @@ container.
   key.INJECTOR_COMMIT_ID.use                  = true
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
   key.EXTERNAL_TOOL_DURATION.use              = true
   key.SECRET_SCANNER.use                      = true
   key.SBOM.use                                = true
@@ -1171,7 +1158,6 @@ container.
   key._EXEC_ID.use                            = true
   key._ARGV.use                               = true
   key._ENV.use                                = true
-  key._TENANT_ID.use                          = true
   key._OPERATION.use                          = true
   key._TIMESTAMP.use                          = true
   key._DATE.use                               = false # Go with _DATETIME
@@ -1632,7 +1618,6 @@ container.
   key._REPO_BUILD_CONTEXT_SKIPPED_FILES.use   = true
   key.DOCKER_BUILD_CONTEXT_SNAPSHOTS.use      = true
   key._REPO_LIST_DIGESTS.use                  = true
-  key._FOUND_BASE_MARK.use                    = true
   key._SIGNATURES.use                         = true
   key._INVALID_SIGNATURE.use                  = true
   key._VALIDATED_SIGNATURE.use                = true
@@ -1647,7 +1632,6 @@ container.
   key.$CHALK_LOAD_COUNT.use                   = true
   key.$CHALK_PUBLIC_KEY.use                   = true
   key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = true
-  key.$CHALK_ATTESTATION_TOKEN.use            = true
   key.$CHALK_COMPONENT_CACHE.use              = false
   key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = true
   key.$CHALK_MEMOIZE.use                      = true
@@ -1706,14 +1690,12 @@ and keep the run-time key.
   key.INJECTOR_COMMIT_ID.use                  = true
   key.INJECTOR_ARGV.use                       = true
   key.INJECTOR_ENV.use                        = true
-  key.TENANT_ID_WHEN_CHALKED.use              = true
 
   # Runtime host keys.
   key._ACTION_ID.use                          = true
   key._EXEC_ID.use                            = true
   key._ARGV.use                               = true
   key._ENV.use                                = true
-  key._TENANT_ID.use                          = true
   key._OPERATION.use                          = true
   key._TIMESTAMP.use                          = true
   key._DATE.use                               = false # Go with _DATETIME
@@ -2174,7 +2156,6 @@ and keep the run-time key.
   key._REPO_BUILD_CONTEXT_SKIPPED_FILES.use   = true
   key.DOCKER_BUILD_CONTEXT_SNAPSHOTS.use      = true
   key._REPO_LIST_DIGESTS.use                  = true
-  key._FOUND_BASE_MARK.use                    = true
   key._SIGNATURES.use                         = true
   key._INVALID_SIGNATURE.use                  = true
   key._VALIDATED_SIGNATURE.use                = true
@@ -2189,7 +2170,6 @@ and keep the run-time key.
   key.$CHALK_LOAD_COUNT.use                   = true
   key.$CHALK_PUBLIC_KEY.use                   = true
   key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = true
-  key.$CHALK_ATTESTATION_TOKEN.use            = true
   key.$CHALK_COMPONENT_CACHE.use              = false
   key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = true
   key.$CHALK_MEMOIZE.use                      = true
@@ -2248,7 +2228,6 @@ report_template usage {
   ~key._OPERATION.use                         = true
   ~key._TIMESTAMP.use                         = true
   ~key._OP_CHALK_COUNT.use                    = true
-  ~key._TENANT_ID.use                         = true
   ~key._OP_CHALKER_COMMIT_ID.use              = true
   ~key._OP_CHALKER_VERSION.use                = true
   ~key._OP_PLATFORM.use                       = true

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -510,7 +510,6 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key._REPO_BUILD_CONTEXT_SKIPPED_FILES.use   = true
   ~key.DOCKER_BUILD_CONTEXT_SNAPSHOTS.use      = true
   ~key._REPO_LIST_DIGESTS.use                  = true
-  ~key._FOUND_BASE_MARK.use                    = true
   ~key._SIGNATURES.use                         = true
   ~key._INVALID_SIGNATURE.use                  = true
   ~key._VALIDATED_SIGNATURE.use                = true
@@ -542,7 +541,6 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.$CHALK_LOAD_COUNT.use                   = true
   ~key.$CHALK_PUBLIC_KEY.use                   = true
   ~key.$CHALK_ENCRYPTED_PRIVATE_KEY.use        = false
-  ~key.$CHALK_ATTESTATION_TOKEN.use            = true
   ~key.$CHALK_COMPONENT_CACHE.use              = false
   ~key.$CHALK_SAVED_COMPONENT_PARAMETERS.use   = false
   ~key.$CHALK_MEMOIZE.use                      = false

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -170,8 +170,11 @@ proc pinBuildSectionBaseImages*(ctx: DockerInvocation) =
 
 proc addVirtualLabels(ctx: DockerInvocation, chalk: ChalkObj) =
   trace("docker: adding virtual label args via --label flags")
+  ctx.addedLabels = newOrderedTable[string, string]()
   let labelOpt = attrGetOpt[TableRef[string, string]]("docker.custom_labels")
   if labelOpt.isSome():
+    for k, v in labelOpt.get():
+      ctx.addedLabels[k] = v
     ctx.newCmdLine.addLabelArgs(labelOpt.get())
   let labelTemplName = attrGet[string]("docker.label_template")
   if labelTemplName == "":
@@ -180,6 +183,10 @@ proc addVirtualLabels(ctx: DockerInvocation, chalk: ChalkObj) =
     labelTemplate = "mark_template." & labelTemplName
     hostLabelsToAdd = hostInfo.filterByTemplate(labelTemplate)
     artLabelsToAdd  = chalk.collectedData.filterByTemplate(labelTemplate)
+  for k, v in hostLabelsToAdd:
+    ctx.addedLabels[k] = if v.kind == MkStr: unpack[string](v) else: v.boxToJson()
+  for k, v in artLabelsToAdd:
+    ctx.addedLabels[k] = if v.kind == MkStr: unpack[string](v) else: v.boxToJson()
   var args: seq[string] = @[]
   args.addLabelArgs(hostLabelsToAdd)
   args.addLabelArgs(artLabelsToAdd)
@@ -189,8 +196,11 @@ proc addVirtualLabels(ctx: DockerInvocation, chalk: ChalkObj) =
 
 proc addLabels(ctx: DockerInvocation, chalk: ChalkObj) =
   trace("docker: adding labels to Dockerfile")
+  ctx.addedLabels = newOrderedTable[string, string]()
   let labelOpt = attrGetOpt[TableRef[string, string]]("docker.custom_labels")
   if labelOpt.isSome():
+    for k, v in labelOpt.get():
+      ctx.addedLabels[k] = v
     ctx.addedInstructions.addLabelCmds(labelOpt.get())
   let labelTemplName = attrGet[string]("docker.label_template")
   if labelTemplName == "":
@@ -199,6 +209,10 @@ proc addLabels(ctx: DockerInvocation, chalk: ChalkObj) =
     labelTemplate    = "mark_template." & labelTemplName
     hostLabelsToAdd  = hostInfo.filterByTemplate(labelTemplate)
     artLabelsToAdd   = chalk.collectedData.filterByTemplate(labelTemplate)
+  for k, v in hostLabelsToAdd:
+    ctx.addedLabels[k] = if v.kind == MkStr: unpack[string](v) else: v.boxToJson()
+  for k, v in artLabelsToAdd:
+    ctx.addedLabels[k] = if v.kind == MkStr: unpack[string](v) else: v.boxToJson()
   var added: seq[string] = @[]
   added.addLabelCmds(hostLabelsToAdd)
   added.addLabelCmds(artLabelsToAdd)
@@ -459,6 +473,7 @@ proc collectBeforeChalkTime(chalk: ChalkObj, ctx: DockerInvocation) =
 proc collectBeforeBuild*(chalk: ChalkObj, ctx: DockerInvocation) =
   let dict = chalk.collectedData
   dict.setIfNeeded("DOCKER_CHALK_ADDED_TO_DOCKERFILE", ctx.addedInstructions)
+  dict.setIfNeeded("DOCKER_CHALK_ADDED_LABELS",        ctx.addedLabels)
   dict.setIfNeeded("DOCKER_FILE_CHALKED",              ctx.getUpdatedDockerFile())
 
 proc collectAfterBuild(ctx: DockerInvocation, chalksByPlatform: TableRef[DockerPlatform, ChalkObj]) =

--- a/src/docker/collect.nim
+++ b/src/docker/collect.nim
@@ -52,11 +52,11 @@ let dockerImageAutoMap: JsonToChalkKeysMapping = {
   "Config:Shell":                               ("_IMAGE_SHELL", identity),
   "Config:Entrypoint":                          ("_IMAGE_ENTRYPOINT", identity),
   "Config:Cmd":                                 ("_IMAGE_CMD", identity),
-  "Config:Hostname":                            ("_IMAGE_HOSTNAMES", JsonTransformer((x: JsonNode) =>
+  "Config:Hostname":                            ("_IMAGE_HOSTNAME", JsonTransformer((x: JsonNode) =>
                                                    `%`(extractDockerHashList(x.getStrElems())))),
   "Config:Domainname":                          ("_IMAGE_DOMAINNAME", identity),
   "Config:User":                                ("_IMAGE_USER", identity),
-  "Config:ExposedPorts":                        ("_IMAGE_EXPOSEDPORTS", identity),
+  "Config:ExposedPorts":                        ("_IMAGE_EXPOSED_PORTS", identity),
   "Config:Env":                                 ("_IMAGE_ENV", identity),
   "Config:Image":                               ("_IMAGE_NAME", identity),
   "Config:Healthcheck:Test":                    ("_IMAGE_HEALTHCHECK_TEST", identity),
@@ -197,7 +197,7 @@ let dockerContainerAutoMap: JsonToChalkKeysMapping = {
   "NetworkSettings:Gateway":                    ("_INSTANCE_GATEWAY", identity),
   "NetworkSettings:GlobalIPv6Address":          ("_INSTANCE_GLOBAL_IPV6_ADDRESS", identity),
   "NetworkSettings:GlobalIPv6PrefixLen":        ("_INSTANCE_GLOBAL_IPV6_PREFIX_LEN", identity),
-  "NetworkSettings:IPAddress":                  ("_INSTANCE_IPADDRESS", identity),
+  "NetworkSettings:IPAddress":                  ("_INSTANCE_IP", identity),
   "NetworkSettings:IPPrefixLen":                ("_INSTANCE_IP_PREFIX_LEN", identity),
   "NetworkSettings:IPv6Gateway":                ("_INSTANCE_IPV6_GATEWAY", identity),
   "NetworkSettings:MacAddress":                 ("_INSTANCE_MAC", identity),

--- a/src/plugins/system.nim
+++ b/src/plugins/system.nim
@@ -111,7 +111,6 @@ proc applySubstitutions(obj: ChalkObj) {.inline.} =
     `ts?`     = obj.lookupCollectedKey("TIMESTAMP_WHEN_CHALKED")
     `path?`   = obj.lookupCollectedKey("PATH_WHEN_CHALKED")
     `hash?`   = obj.lookupCollectedKey("HASH")
-    `tenant?` = obj.lookupCollectedKey("TENANT_ID_WHEN_CHALKED")
     `random?` = obj.lookupCollectedKey("CHALK_RAND")
   var
     subs: seq[(string, string)] = @[]
@@ -119,7 +118,6 @@ proc applySubstitutions(obj: ChalkObj) {.inline.} =
   if `cid?`.isSome():    subs.add(("{chalk_id}", unpack[string](`cid?`.get())))
   if `ts?`.isSome():     subs.add(("{now}", $(unpack[int](`ts?`.get()))))
   if `path?`.isSome():   subs.add(("{path}", unpack[string](`path?`.get())))
-  if `tenant?`.isSome(): subs.add(("{tenant}", unpack[string](`tenant?`.get())))
   if `random?`.isSome(): subs.add(("{random}", unpack[string](`random?`.get())))
   if `hash?`.isSome():   subs.add(("{hash}", unpack[string](`hash?`.get())))
 
@@ -231,6 +229,7 @@ proc sysGetRunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
   result.setIfNeeded("_OP_EXE_PATH",          getAppDir())
   result.setIfNeeded("_OP_ARGV",              @[getMyAppPath()] & commandLineParams())
   result.setIfNeeded("_OP_HOSTNAME",          getHostname())
+  result.setIfNeeded("_OP_PUBLIC_IPV4_ADDR",  getMyIpV4Addr())
   result.setIfNeeded("_OP_UNMARKED_COUNT",    len(getUnmarked()))
   result.setIfNeeded("_TIMESTAMP",            startTime.toUnixInMs())
   result.setIfNeeded("_DATE",                 startTime.forReport().format(timesDateFormat))
@@ -268,7 +267,7 @@ proc sysGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
   result.setIfNeeded("DATETIME_WHEN_CHALKED", startTime.forReport().format(timesIso8601Format))
   result.setIfNeeded("TIMESTAMP_WHEN_CHALKED", startTime.toUnixInMs())
   result.setIfNeeded("PLATFORM_WHEN_CHALKED", getChalkPlatform())
-  result.setIfNeeded("PUBLIC_IPV4_ADDR_WHEN_CHALKED", pack(getMyIpV4Addr()))
+  result.setIfNeeded("PUBLIC_IPV4_ADDR_WHEN_CHALKED", getMyIpV4Addr())
 
   when defined(posix):
     result.setIfNeeded("HOST_SYSNAME_WHEN_CHALKED", uinfo.sysname)

--- a/src/types.nim
+++ b/src/types.nim
@@ -473,6 +473,7 @@ type
       vctlDockerFileLoc*:     string # path within version control
       inDockerFile*:          string
       addedPlatform*:         OrderedTableRef[string, seq[string]]
+      addedLabels*:           OrderedTableRef[string, string]
       addedInstructions*:     seq[string]
       updateDockerignore*:    bool
       existingDockerignore*:  string

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -1441,6 +1441,11 @@ def test_docker_labels(chalk: Chalk, random_hex: str):
         },
         DOCKER_ANNOTATIONS={"hello": "there"},
         _IMAGE_ANNOTATIONS={"hello": "there"},
+        DOCKER_CHALK_ADDED_LABELS={
+            "HELLO": "CRASH_OVERRIDE_TEST_LABEL",
+            "COMMIT_ID": str,
+            "BRANCH": str,
+        },
     )
 
     inspected = Docker.inspect(tag)

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -1416,13 +1416,23 @@ def test_k8s(chalk_copy: Chalk, server_http: str, tmp_path: Path):
     )
 
 
-def test_docker_labels(chalk: Chalk, random_hex: str):
+def test_docker_labels(chalk: Chalk, random_hex: str, tmp_data_dir: Path):
     tag = f"{REGISTRY}/test_image_{random_hex}"
 
-    # build container with env vars
+    # use a fresh git repo as build context so BRANCH is always available,
+    # even in CI where the main checkout runs on a detached HEAD
+    context_dir = tmp_data_dir / "context"
+    shutil.copytree(DOCKERFILES / "valid" / "sample_1", context_dir)
+    git = Git(context_dir)
+    git.init(branch="main")
+    git.add()
+    git.commit()
+    commit_id = git.latest_commit
+
     _, build = chalk.docker_build(
         buildx=True,
         dockerfile=DOCKERFILES / "valid" / "sample_1" / "Dockerfile",
+        context=context_dir,
         tag=tag,
         config=CONFIGS / "docker_heartbeat.c4m",
         labels={"foo": "bar"},
@@ -1443,8 +1453,8 @@ def test_docker_labels(chalk: Chalk, random_hex: str):
         _IMAGE_ANNOTATIONS={"hello": "there"},
         DOCKER_CHALK_ADDED_LABELS={
             "HELLO": "CRASH_OVERRIDE_TEST_LABEL",
-            "COMMIT_ID": str,
-            "BRANCH": str,
+            "COMMIT_ID": commit_id,
+            "BRANCH": "main",
         },
     )
 


### PR DESCRIPTION
## Summary

- Remove never-set keys: `TENANT_ID_WHEN_CHALKED`, `_TENANT_ID`, `$CHALK_API_REFRESH_TOKEN`, `$CHALK_ATTESTATION_TOKEN`, `$CHALK_DATA_API_KEY`, `$CHALK_SECRET_ENDPOINT_URI`, `_FOUND_BASE_MARK`
- Fix three docker image key name mismatches (`_IMAGE_HOSTNAME`, `_IMAGE_EXPOSED_PORTS`, `_INSTANCE_IP`) that caused them to always be absent from reports
- Populate `_OP_PUBLIC_IPV4_ADDR` in every chalk operation report
- Implement `DOCKER_CHALK_ADDED_LABELS`: track labels chalk injects during docker build

## Test plan

- [x] `make tests args="test_docker.py::test_build -x"` — verifies `DOCKER_CHALK_ADDED_LABELS` assertion
- [x] `make tests args="test_docker.py::test_docker_labels -x"` — verifies labels with custom label


🤖 Generated with [Claude Code](https://claude.com/claude-code)