### PR TITLE
fix: parse FROM flags correctly when multiple spaces follow command name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,12 @@
 
   ([#679](https://github.com/crashappsec/chalk/pull/679))
 
+- `FROM --platform=<var>` instructions with multiple spaces between `FROM` and
+  `--platform` were incorrectly parsed: the flag was not recognized and the
+  platform flag string was used as the image name instead.
+
+  ([#681](https://github.com/crashappsec/chalk/pull/681))
+
 - File sinks and the report cache no longer emit continuous errors when chalk
   runs in a container with a read-only root filesystem. A file sink whose
   destination directory is not writable is now disabled at startup with a

--- a/src/docker/dockerfile.nim
+++ b/src/docker/dockerfile.nim
@@ -730,6 +730,10 @@ proc topLevelCmdParse(s: string): (string, string) =
         name &= $(item)
       continue
 
+    # skip any additional whitespace between command name and arguments
+    if rest.len == 0 and item.isWhiteSpace():
+      continue
+
     rest &= $(item)
 
   return (name.toUpperAscii(), rest)

--- a/tests/functional/data/dockerfiles/valid/from_platform/Dockerfile
+++ b/tests/functional/data/dockerfiles/valid/from_platform/Dockerfile
@@ -1,3 +1,3 @@
-FROM --platform=linux/arm64 alpine
+FROM     --platform=linux/arm64 alpine
 ARG TARGETPLATFORM
 RUN env | grep PLATFORM


### PR DESCRIPTION
## Summary

- `topLevelCmdParse` only consumed the first whitespace character after the command name, so any extra spaces ended up as a leading space in `rawArg`
- This caused `basicParseAllFlags` to see a leading `ltSpace` token and bail immediately with no flags, treating `--platform=<var>` as the image name instead of a flag
- Fix: skip all whitespace between command name and arguments, not just the first character

## Test plan

```
make tests args="test_docker.py::test_build_platform -x"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)