### PR TITLE
feat: add chalk metadata headers to post and presign sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@
 
 ### New Features
 
-- `post` and `presign` sinks now send `X-Chalk-Version` and `X-Chalk-Action-Id`
-  headers with every request, enabling server-side routing and auditing without
-  parsing the body.
+- `post` and `presign` sinks now send chalk metadata headers with every
+  request, enabling server-side routing and auditing without parsing the body:
+  - `X-Chalk-Version`
+  - `X-Chalk-Operation` (same as `_OPERATION`)
+  - `X-Chalk-Action-Id` (same as `_ACTION_ID`)
+  - `X-Content-Length`
+  - `X-Chalk-Digest-Sha256`
+
   ([#688](https://github.com/crashappsec/chalk/pull/688))
 
 - `presign` sink now supports `x-forward-headers`: header names listed in that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Chalk Release Notes
 
+## Unreleased
+
+### New Features
+
+- `post` and `presign` sinks now send `X-Chalk-Version` and `X-Chalk-Action-Id`
+  headers with every request, enabling server-side routing and auditing without
+  parsing the body.
+  ([#688](https://github.com/crashappsec/chalk/pull/688))
+
+- `presign` sink now supports `x-forward-headers`: header names listed in that
+  response header are copied from the redirect response into the upload PUT,
+  enabling metadata injection (e.g. `X-Amz-Meta-*`) that cannot be encoded in
+  the presigned URL itself.
+  ([#688](https://github.com/crashappsec/chalk/pull/688))
+
 ## 1.1.3
 
 **July 6, 2026**

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -190,6 +190,11 @@ content-type field will be `application/json`. Changing this value
 doesn't change what is posted; it is only there in case a particular
 endpoint requires a different value.
 
+Chalk always includes the following headers in every POST request:
+
+* `X-Chalk-Version` - version of chalk sending the report
+* `X-Chalk-Action-Id` - action ID of this chalk run (same as `_ACTION_ID`)
+
 If HTTPS is used, the connection will fail if the server doesn't have
 a valid certificate. Unless you provide a specific certificate via the
 `pinned_cert_file` field, self-signed certificates will not be
@@ -237,18 +242,34 @@ sink presign {
   ~auth:                 false
   shortdoc:              "HTTP/HTTPS Presign PUT"
   doc:                   """
-Sink which allows to upload reports to pre-signed URL.
+Sink which allows to upload reports to a pre-signed URL.
 
-All parameters are identical as `post` sink.
+All parameters are identical to the `post` sink.
 
-Pre-sign flow is as follows:
+Pre-sign flow:
 
-1. Send PUT to URI (without report)
-2. Receive 302/307 redirect with pre-signed URI in Location header
-3. Send full report to that URI by using HTTP PUT
+1. Send PUT to URI (without report body) with these headers:
+   * `X-Chalk-Version` - version of chalk sending the report
+   * `X-Chalk-Action-Id` - action ID of this chalk run (same as `_ACTION_ID`)
+2. Receive 302/307 redirect with pre-signed URI in `Location` header.
+3. Copy any headers listed in `x-forward-headers` response header into the upload request.
+4. Send full report body to pre-signed URI via PUT.
 
-This allows chalk to send reports to otherwise forbidden endpoints
-such as AWS S3 without any hard-coded credentials baked into chalk.
+The presign API can return these headers in the redirect response:
+
+* `x-forward-headers` - comma-delimited list of header names from the redirect response
+  that chalk should copy into the upload PUT request. This is useful for injecting
+  metadata that cannot be encoded in the presigned URL itself. For example:
+
+  ```
+  x-forward-headers: x-amz-meta-env
+  x-amz-meta-env: production
+  ```
+
+  causes chalk to include `x-amz-meta-env: production` in the upload request.
+
+This allows chalk to send reports to otherwise restricted endpoints
+such as AWS S3 without credentials baked into chalk.
 """
 }
 

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -190,7 +190,9 @@ content-type field will be `application/json`. Changing this value
 doesn't change what is posted; it is only there in case a particular
 endpoint requires a different value.
 
-Chalk always includes the following headers in every POST request:
+Chalk always includes the following headers in every POST request. These
+core headers take precedence over any same-named header supplied via the
+`headers` field, so a user-configured header cannot override them:
 
 * `X-Chalk-Version` - version of chalk sending the report
 * `X-Chalk-Action-Id` - action ID of this chalk run (same as `_ACTION_ID`)

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -195,7 +195,10 @@ core headers take precedence over any same-named header supplied via the
 `headers` field, so a user-configured header cannot override them:
 
 * `X-Chalk-Version` - version of chalk sending the report
+* `X-Chalk-Operation` - chalk operation (same as `_OPERATION`, e.g. `insert`, `build`)
 * `X-Chalk-Action-Id` - action ID of this chalk run (same as `_ACTION_ID`)
+* `X-Content-Length` - byte length of the request body
+* `X-Chalk-Digest-Sha256` - SHA-256 hex digest of the request body
 
 If HTTPS is used, the connection will fail if the server doesn't have
 a valid certificate. Unless you provide a specific certificate via the
@@ -252,7 +255,10 @@ Pre-sign flow:
 
 1. Send PUT to URI (without report body) with these headers:
    * `X-Chalk-Version` - version of chalk sending the report
+   * `X-Chalk-Operation` - chalk operation (same as `_OPERATION`, e.g. `insert`, `build`)
    * `X-Chalk-Action-Id` - action ID of this chalk run (same as `_ACTION_ID`)
+   * `X-Content-Length` - byte length of the report body to be uploaded
+   * `X-Chalk-Digest-Sha256` - SHA-256 hex digest of the report body to be uploaded
 2. Receive 302/307 redirect with pre-signed URI in `Location` header.
 3. Copy any headers listed in `x-forward-headers` response header into the upload request.
 4. Send full report body to pre-signed URI via PUT.

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -1113,6 +1113,7 @@ In all cases chalk includes these headers to presign endpoints:
 * `X-Content-Length` - similar to `Content-Length` but is sent to presigning API
 * `X-Chalk-Digest-Sha256` - raw digest of the uploaded content to check for transmission errors
 * `X-Chalk-Version`
+* `X-Chalk-Operation` - same as `_OPERATION` (e.g. `insert`, `build`)
 * `X-Chalk-Action-Id` - same as `_ACTION_ID` which can be used to associate object to original
   report which created it.
 

--- a/src/object_store/presign.nim
+++ b/src/object_store/presign.nim
@@ -84,7 +84,7 @@ proc request(self:           ObjectStorePresign,
   var signHeaders = newHttpHeaders(@[
     ("X-Content-Length",     $len(body)),
     ("X-Chalk-Digest-Sha256", keyRef.digest),
-  ]).update(getChalkCoreHeaders()).update(contentTypeHeaders).update(self.headers)
+  ]).update(contentTypeHeaders).update(self.headers).withChalkCoreHeaders()
   if auth != nil:
     signHeaders = auth.implementation.injectHeaders(auth, signHeaders)
 

--- a/src/object_store/presign.nim
+++ b/src/object_store/presign.nim
@@ -82,12 +82,9 @@ proc request(self:           ObjectStorePresign,
         ("Content-Type", contentType),
       ])
   var signHeaders = newHttpHeaders(@[
-    ("X-Content-Length", $len(body)),
+    ("X-Content-Length",     $len(body)),
     ("X-Chalk-Digest-Sha256", keyRef.digest),
-    ("X-Chalk-Version", getChalkExeVersion()),
-    # TODO expose better API for action id interaction
-    ("X-Chalk-Action-Id", unpack[string](hostInfo["_ACTION_ID"])),
-  ]).update(contentTypeHeaders).update(self.headers)
+  ]).update(getChalkCoreHeaders()).update(contentTypeHeaders).update(self.headers)
   if auth != nil:
     signHeaders = auth.implementation.injectHeaders(auth, signHeaders)
 
@@ -118,26 +115,17 @@ proc request(self:           ObjectStorePresign,
     raise newException(ValueError, "Presign requires 302/307 redirect but received: " & signResponse.status)
 
   if not signResponse.headers.hasKey("location"):
-    raise newException(ValueError, "Presign edirect Location header missing")
+    raise newException(ValueError, "Presign redirect Location header missing")
 
   let uri = parseUri(signResponse.headers["location"])
   if uri.scheme == "":
     trace("object store: " & $uri)
-    raise newException(ValueError, "Presign edirect Location header needs to be absolute URL")
+    raise newException(ValueError, "Presign redirect Location header needs to be absolute URL")
 
-  var
-    names   = newSeq[string]()
-    headers = newHttpHeaders(@[
-      ("Content-Length", $len(body)),
-    ]).update(contentTypeHeaders)
-  if signResponse.headers.hasKey("x-forward-headers"):
-    names = signResponse.headers["x-forward-headers"].strip().split(',')
-    for i in names:
-      let name = i.strip()
-      if signResponse.headers.hasKey(name):
-        headers[name] = signResponse.headers[name]
-
-  trace("object store: " & $httpMethod & " @" & uri.hostname & " (" & $len(body) & "bytes) forwarding: " & $names)
+  let headers = newHttpHeaders(@[
+    ("Content-Length", $len(body)),
+  ]).update(contentTypeHeaders).applyForwardedHeaders(signResponse)
+  trace("object store: " & $httpMethod & " @" & uri.hostname & " (" & $len(body) & " bytes)")
   let response = safeRequest(url               = uri,
                              headers           = headers,
                              timeout           = self.timeout,

--- a/src/object_store/presign.nim
+++ b/src/object_store/presign.nim
@@ -81,10 +81,10 @@ proc request(self:           ObjectStorePresign,
       newHttpHeaders(@[
         ("Content-Type", contentType),
       ])
-  var signHeaders = newHttpHeaders(@[
-    ("X-Content-Length",     $len(body)),
-    ("X-Chalk-Digest-Sha256", keyRef.digest),
-  ]).update(contentTypeHeaders).update(self.headers).withChalkCoreHeaders()
+  var signHeaders = newHttpHeaders().update(contentTypeHeaders).update(self.headers).addChalkCoreHeaders(
+    body   = body,
+    digest = keyRef.digest,
+  )
   if auth != nil:
     signHeaders = auth.implementation.injectHeaders(auth, signHeaders)
 
@@ -124,7 +124,7 @@ proc request(self:           ObjectStorePresign,
 
   let headers = newHttpHeaders(@[
     ("Content-Length", $len(body)),
-  ]).update(contentTypeHeaders).applyForwardedHeaders(signResponse)
+  ]).update(contentTypeHeaders).addForwardedHeaders(signResponse)
   trace("object store: " & $httpMethod & " @" & uri.hostname & " (" & $len(body) & " bytes)")
   let response = safeRequest(url               = uri,
                              headers           = headers,

--- a/src/object_store/presign.nim
+++ b/src/object_store/presign.nim
@@ -136,7 +136,7 @@ proc request(self:           ObjectStorePresign,
                              retries           = 2,
                              firstRetryDelayMs = 100,
                              rejectStatusCodes = [500..599])
-  trace("object store: " & $httpMethod & " @" & $uri.hostname & " (" & $len(body) & "bytes) -> " & $response.code)
+  trace("object store: " & $httpMethod & " @" & $uri.hostname & " (" & $len(body) & " bytes) -> " & $response.code)
 
   let updatedRef = deepCopy(keyRef)
   updatedRef.query = signResponse.headers.getOrDefault("x-chalk-object-query")

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -324,6 +324,10 @@ proc lookupCollectedKey*(obj: ChalkObj, k: string): Option[Box] =
   if k in obj.collectedData: return some(obj.collectedData[k])
   return none(Box)
 
+proc lookupCollectedKey*(k: string): Option[Box] =
+  if k in hostInfo: return some(hostInfo[k])
+  return none(Box)
+
 proc setArgs*(a: seq[string]) =
   collectionCtx.args = a
 proc getArgs*(): seq[string] = collectionCtx.args

--- a/src/utils/http.nim
+++ b/src/utils/http.nim
@@ -10,6 +10,9 @@ import std/[
   httpcore,
   strutils,
 ]
+import pkg/nimutils/[
+  sha,
+]
 import ".."/[
   config,
   run_management,
@@ -36,17 +39,25 @@ proc mustGetInt*(headers: HttpHeaders, header: string, msg: string): int =
   except:
     raise newException(ValueError, msg & ": invalid integer: " & value)
 
-proc withChalkCoreHeaders*(headers: HttpHeaders): HttpHeaders =
+proc addChalkCoreHeaders*(
+    headers: HttpHeaders,
+    body:    string,
+    digest  = "",
+): HttpHeaders =
   ## Merges chalk core headers into `headers`, applying them last so they
   ## take precedence over any same-named user-configured header.
   ## _ACTION_ID is guarded: absent when no report template subscribes it.
-  headers["X-Chalk-Version"] = getChalkExeVersion()
+  ## digest defaults to sha256(body) when not provided.
+  headers["X-Chalk-Version"]       = getChalkExeVersion()
+  headers["X-Chalk-Operation"]     = getBaseCommandName()
+  headers["X-Content-Length"]      = $len(body)
+  headers["X-Chalk-Digest-Sha256"] = if digest != "": digest else: body.sha256Hex()
   let actionId = lookupCollectedKey("_ACTION_ID")
   if actionId.isSome():
     headers["X-Chalk-Action-Id"] = unpack[string](actionId.get())
   return headers
 
-proc applyForwardedHeaders*(headers: HttpHeaders, response: Response): HttpHeaders =
+proc addForwardedHeaders*(headers: HttpHeaders, response: Response): HttpHeaders =
   ## Copies headers listed in the response's x-forward-headers into headers.
   ## Allows the sign server to request that specific response headers be
   ## forwarded to the actual upload request (e.g. extra metadata headers).

--- a/src/utils/http.nim
+++ b/src/utils/http.nim
@@ -47,6 +47,12 @@ proc getChalkCoreHeaders*(): HttpHeaders =
   if actionId.isSome():
     result["X-Chalk-Action-Id"] = unpack[string](actionId.get())
 
+proc withChalkCoreHeaders*(headers: HttpHeaders): HttpHeaders =
+  ## Merges the guaranteed chalk core headers into `headers`, applying them
+  ## last so they take precedence over any same-named user-configured header.
+  ## This upholds the "always includes" guarantee documented in base_sinks.c4m.
+  return headers.update(getChalkCoreHeaders())
+
 proc applyForwardedHeaders*(headers: HttpHeaders, response: Response): HttpHeaders =
   ## Copies headers listed in the response's x-forward-headers into headers.
   ## Allows the sign server to request that specific response headers be

--- a/src/utils/http.nim
+++ b/src/utils/http.nim
@@ -10,6 +10,10 @@ import std/[
   httpcore,
   strutils,
 ]
+import ".."/[
+  config,
+  types,
+]
 
 export httpclient
 export httpcore
@@ -30,3 +34,21 @@ proc mustGetInt*(headers: HttpHeaders, header: string, msg: string): int =
     return parseInt(value)
   except:
     raise newException(ValueError, msg & ": invalid integer: " & value)
+
+proc getChalkCoreHeaders*(): HttpHeaders =
+  return newHttpHeaders(@[
+    ("X-Chalk-Version",   getChalkExeVersion()),
+    ("X-Chalk-Action-Id", unpack[string](hostInfo["_ACTION_ID"])),
+  ])
+
+proc applyForwardedHeaders*(headers: HttpHeaders, response: Response): HttpHeaders =
+  ## Copies headers listed in the response's x-forward-headers into headers.
+  ## Allows the sign server to request that specific response headers be
+  ## forwarded to the actual upload request (e.g. extra metadata headers).
+  if not response.headers.hasKey("x-forward-headers"):
+    return headers
+  for item in response.headers["x-forward-headers"].strip().split(','):
+    let name = item.strip()
+    if response.headers.hasKey(name):
+      headers[name] = response.headers[name]
+  return headers

--- a/src/utils/http.nim
+++ b/src/utils/http.nim
@@ -36,22 +36,15 @@ proc mustGetInt*(headers: HttpHeaders, header: string, msg: string): int =
   except:
     raise newException(ValueError, msg & ": invalid integer: " & value)
 
-proc getChalkCoreHeaders*(): HttpHeaders =
-  result = newHttpHeaders(@[
-    ("X-Chalk-Version", getChalkExeVersion()),
-  ])
-  # _ACTION_ID is only present in hostInfo when an active report template
-  # subscribes it, so guard the read and omit the header when it is absent
-  # rather than raising and dropping the report.
+proc withChalkCoreHeaders*(headers: HttpHeaders): HttpHeaders =
+  ## Merges chalk core headers into `headers`, applying them last so they
+  ## take precedence over any same-named user-configured header.
+  ## _ACTION_ID is guarded: absent when no report template subscribes it.
+  headers["X-Chalk-Version"] = getChalkExeVersion()
   let actionId = lookupCollectedKey("_ACTION_ID")
   if actionId.isSome():
-    result["X-Chalk-Action-Id"] = unpack[string](actionId.get())
-
-proc withChalkCoreHeaders*(headers: HttpHeaders): HttpHeaders =
-  ## Merges the guaranteed chalk core headers into `headers`, applying them
-  ## last so they take precedence over any same-named user-configured header.
-  ## This upholds the "always includes" guarantee documented in base_sinks.c4m.
-  return headers.update(getChalkCoreHeaders())
+    headers["X-Chalk-Action-Id"] = unpack[string](actionId.get())
+  return headers
 
 proc applyForwardedHeaders*(headers: HttpHeaders, response: Response): HttpHeaders =
   ## Copies headers listed in the response's x-forward-headers into headers.

--- a/src/utils/http.nim
+++ b/src/utils/http.nim
@@ -12,6 +12,7 @@ import std/[
 ]
 import ".."/[
   config,
+  run_management,
   types,
 ]
 
@@ -36,10 +37,15 @@ proc mustGetInt*(headers: HttpHeaders, header: string, msg: string): int =
     raise newException(ValueError, msg & ": invalid integer: " & value)
 
 proc getChalkCoreHeaders*(): HttpHeaders =
-  return newHttpHeaders(@[
-    ("X-Chalk-Version",   getChalkExeVersion()),
-    ("X-Chalk-Action-Id", unpack[string](hostInfo["_ACTION_ID"])),
+  result = newHttpHeaders(@[
+    ("X-Chalk-Version", getChalkExeVersion()),
   ])
+  # _ACTION_ID is only present in hostInfo when an active report template
+  # subscribes it, so guard the read and omit the header when it is absent
+  # rather than raising and dropping the report.
+  let actionId = lookupCollectedKey("_ACTION_ID")
+  if actionId.isSome():
+    result["X-Chalk-Action-Id"] = unpack[string](actionId.get())
 
 proc applyForwardedHeaders*(headers: HttpHeaders, response: Response): HttpHeaders =
   ## Copies headers listed in the response's x-forward-headers into headers.

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -37,6 +37,9 @@ import pkg/nimutils/[
   file,
   net,
 ]
+import "."/[
+  http,
+]
 
 const defaultLogSearchPath = @["/var/log/", "~/.log/", "."]
 
@@ -369,10 +372,11 @@ proc httpParams(cfg: SinkConfig): tuple[
 proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
     params   = cfg.httpParams()
+    headers  = getChalkCoreHeaders().update(params.headers)
     response = safeRequest(
       url                = params.uri,
       timeout            = params.timeout,
-      headers            = params.headers,
+      headers            = headers,
       disallowHttp       = params.disallowHttp,
       pinnedCert         = params.pinnedCert,
       preferBundledCerts = params.preferBundledCerts,
@@ -388,10 +392,11 @@ proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
 proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
     params      = cfg.httpParams()
+    signHeaders = getChalkCoreHeaders().update(params.headers)
     signResponse = safeRequest(
       url                = params.uri,
       timeout            = params.timeout,
-      headers            = params.headers,
+      headers            = signHeaders,
       disallowHttp       = params.disallowHttp,
       pinnedCert         = params.pinnedCert,
       preferBundledCerts = params.preferBundledCerts,
@@ -414,8 +419,10 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
     raise newException(ValueError, "Presign redirect Location header needs to be absolute URL")
 
   let
-    response = safeRequest(
+    uploadHeaders = newHttpHeaders().applyForwardedHeaders(signResponse)
+    response      = safeRequest(
       url                = uri,
+      headers            = uploadHeaders,
       timeout            = params.timeout,
       disallowHttp       = params.disallowHttp,
       pinnedCert         = params.pinnedCert,

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -372,7 +372,7 @@ proc httpParams(cfg: SinkConfig): tuple[
 proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
     params   = cfg.httpParams()
-    headers  = params.headers.withChalkCoreHeaders()
+    headers  = params.headers.addChalkCoreHeaders(body = msg)
     response = safeRequest(
       url                = params.uri,
       timeout            = params.timeout,
@@ -392,7 +392,7 @@ proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
 proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
     params      = cfg.httpParams()
-    signHeaders = params.headers.withChalkCoreHeaders()
+    signHeaders = params.headers.addChalkCoreHeaders(body = msg)
     signResponse = safeRequest(
       url                = params.uri,
       timeout            = params.timeout,
@@ -419,7 +419,7 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
     raise newException(ValueError, "Presign redirect Location header needs to be absolute URL")
 
   let
-    uploadHeaders = newHttpHeaders().applyForwardedHeaders(signResponse)
+    uploadHeaders = newHttpHeaders().addForwardedHeaders(signResponse)
     response      = safeRequest(
       url                = uri,
       headers            = uploadHeaders,

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -372,7 +372,7 @@ proc httpParams(cfg: SinkConfig): tuple[
 proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
     params   = cfg.httpParams()
-    headers  = getChalkCoreHeaders().update(params.headers)
+    headers  = params.headers.withChalkCoreHeaders()
     response = safeRequest(
       url                = params.uri,
       timeout            = params.timeout,
@@ -392,7 +392,7 @@ proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
 proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
     params      = cfg.httpParams()
-    signHeaders = getChalkCoreHeaders().update(params.headers)
+    signHeaders = params.headers.withChalkCoreHeaders()
     signResponse = safeRequest(
       url                = params.uri,
       timeout            = params.timeout,

--- a/tests/functional/server/chalk.py
+++ b/tests/functional/server/chalk.py
@@ -71,9 +71,33 @@ async def presign_report_url(
     request: Request,
     response: Response,
 ):
-    return RedirectResponse(
-        request.url_for("accept_report"),
+    if not request.headers.get("x-chalk-version"):
+        raise HTTPException(status_code=400, detail="missing X-Chalk-Version header")
+    if not request.headers.get("x-chalk-action-id"):
+        raise HTTPException(status_code=400, detail="missing X-Chalk-Action-Id header")
+    redirect = RedirectResponse(
+        request.url_for("accept_presign_report"),
         status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+    )
+    redirect.headers["x-forward-headers"] = "x-presign-test"
+    redirect.headers["x-presign-test"] = "forwarded-value"
+    return redirect
+
+
+@app.put("/report/presign/accept", status_code=200)
+async def accept_presign_report(
+    reports: list[dict],
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    if request.headers.get("x-presign-test") != "forwarded-value":
+        raise HTTPException(
+            status_code=400,
+            detail="x-presign-test forwarded header missing or has wrong value",
+        )
+    return await accept_report(
+        reports=reports, request=request, response=response, db=db
     )
 
 
@@ -86,9 +110,19 @@ async def error_500():
 @app.put("/report", status_code=200)
 async def accept_report(
     reports: list[dict],
+    request: Request,
     response: Response,
     db: Session = Depends(get_db),
 ):
+    if request.method == "POST":
+        if not request.headers.get("x-chalk-version"):
+            raise HTTPException(
+                status_code=400, detail="missing X-Chalk-Version header"
+            )
+        if not request.headers.get("x-chalk-action-id"):
+            raise HTTPException(
+                status_code=400, detail="missing X-Chalk-Action-Id header"
+            )
     try:
         for report in reports:
             operation = report.get("_OPERATION")

--- a/tests/functional/server/chalk.py
+++ b/tests/functional/server/chalk.py
@@ -3,6 +3,7 @@
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
 import asyncio
+import hashlib
 import json
 import os
 import pathlib
@@ -66,15 +67,35 @@ async def ping(stats: list[schemas.Stat], db: Session = Depends(get_db)):
         return {"ping": "pong"}
 
 
+async def _check_chalk_core_headers(
+    request: Request, verify_body: bool = False
+) -> None:
+    for header in [
+        "x-chalk-version",
+        "x-chalk-operation",
+        "x-chalk-action-id",
+        "x-content-length",
+        "x-chalk-digest-sha256",
+    ]:
+        if not request.headers.get(header):
+            raise HTTPException(status_code=400, detail=f"missing {header} header")
+    if verify_body:
+        body = await request.body()
+        if int(request.headers["x-content-length"]) != len(body):
+            raise HTTPException(status_code=400, detail="x-content-length mismatch")
+        expected = hashlib.sha256(body).hexdigest()
+        if request.headers["x-chalk-digest-sha256"] != expected:
+            raise HTTPException(
+                status_code=400, detail="x-chalk-digest-sha256 mismatch"
+            )
+
+
 @app.put("/report/presign", status_code=200)
 async def presign_report_url(
     request: Request,
     response: Response,
 ):
-    if not request.headers.get("x-chalk-version"):
-        raise HTTPException(status_code=400, detail="missing X-Chalk-Version header")
-    if not request.headers.get("x-chalk-action-id"):
-        raise HTTPException(status_code=400, detail="missing X-Chalk-Action-Id header")
+    await _check_chalk_core_headers(request)
     redirect = RedirectResponse(
         request.url_for("accept_presign_report"),
         status_code=status.HTTP_307_TEMPORARY_REDIRECT,
@@ -115,14 +136,7 @@ async def accept_report(
     db: Session = Depends(get_db),
 ):
     if request.method == "POST":
-        if not request.headers.get("x-chalk-version"):
-            raise HTTPException(
-                status_code=400, detail="missing X-Chalk-Version header"
-            )
-        if not request.headers.get("x-chalk-action-id"):
-            raise HTTPException(
-                status_code=400, detail="missing X-Chalk-Action-Id header"
-            )
+        await _check_chalk_core_headers(request, verify_body=True)
     try:
         for report in reports:
             operation = report.get("_OPERATION")

--- a/tests/unit/test_action_id_headers.nim
+++ b/tests/unit/test_action_id_headers.nim
@@ -1,10 +1,9 @@
-## Regression test for the unguarded _ACTION_ID read in getChalkCoreHeaders().
+## Regression test: _ACTION_ID guard in addChalkCoreHeaders.
 ##
-## Before the guard fix, calling getChalkCoreHeaders() while hostInfo lacked
-## _ACTION_ID raised `KeyError: key not found: _ACTION_ID` during header
-## construction, aborting the post/presign sink write before any HTTP request.
-## The X-Chalk-Action-Id header must now be omitted when _ACTION_ID is absent
-## and emitted when it is present, while X-Chalk-Version is always included.
+## Before the guard fix, reading _ACTION_ID while hostInfo lacked it raised
+## KeyError, aborting the post/presign sink write before any HTTP request.
+## X-Chalk-Action-Id must be omitted when _ACTION_ID is absent and emitted
+## when present; X-Chalk-Version is always included.
 
 import "../../src"/[
   config,
@@ -20,7 +19,7 @@ proc main() =
   # still emit X-Chalk-Version.
   if "_ACTION_ID" in hostInfo:
     hostInfo.del("_ACTION_ID")
-  let withoutActionId = getChalkCoreHeaders()
+  let withoutActionId = newHttpHeaders().addChalkCoreHeaders(body = "")
   assertEq(withoutActionId.hasKey("X-Chalk-Action-Id"), false)
   assertEq(withoutActionId.hasKey("X-Chalk-Version"),    true)
   assertEq($withoutActionId["X-Chalk-Version"],          getChalkExeVersion())
@@ -28,7 +27,7 @@ proc main() =
   # _ACTION_ID present: must emit X-Chalk-Action-Id carrying the collected id.
   let actionId = "00000000-0000-0000-0000-000000000000"
   hostInfo["_ACTION_ID"] = pack(actionId)
-  let withActionId = getChalkCoreHeaders()
+  let withActionId = newHttpHeaders().addChalkCoreHeaders(body = "")
   assertEq(withActionId.hasKey("X-Chalk-Action-Id"), true)
   assertEq($withActionId["X-Chalk-Action-Id"],       actionId)
   assertEq($withActionId["X-Chalk-Version"],         getChalkExeVersion())

--- a/tests/unit/test_action_id_headers.nim
+++ b/tests/unit/test_action_id_headers.nim
@@ -1,0 +1,36 @@
+## Regression test for the unguarded _ACTION_ID read in getChalkCoreHeaders().
+##
+## Before the guard fix, calling getChalkCoreHeaders() while hostInfo lacked
+## _ACTION_ID raised `KeyError: key not found: _ACTION_ID` during header
+## construction, aborting the post/presign sink write before any HTTP request.
+## The X-Chalk-Action-Id header must now be omitted when _ACTION_ID is absent
+## and emitted when it is present, while X-Chalk-Version is always included.
+
+import "../../src"/[
+  config,
+  types,
+  utils/http,
+]
+
+template assertEq(a, b: untyped) =
+  doAssert a == b, $a & " != " & $b
+
+proc main() =
+  # _ACTION_ID absent: must not raise, must omit X-Chalk-Action-Id, and must
+  # still emit X-Chalk-Version.
+  if "_ACTION_ID" in hostInfo:
+    hostInfo.del("_ACTION_ID")
+  let withoutActionId = getChalkCoreHeaders()
+  assertEq(withoutActionId.hasKey("X-Chalk-Action-Id"), false)
+  assertEq(withoutActionId.hasKey("X-Chalk-Version"),    true)
+  assertEq($withoutActionId["X-Chalk-Version"],          getChalkExeVersion())
+
+  # _ACTION_ID present: must emit X-Chalk-Action-Id carrying the collected id.
+  let actionId = "00000000-0000-0000-0000-000000000000"
+  hostInfo["_ACTION_ID"] = pack(actionId)
+  let withActionId = getChalkCoreHeaders()
+  assertEq(withActionId.hasKey("X-Chalk-Action-Id"), true)
+  assertEq($withActionId["X-Chalk-Action-Id"],       actionId)
+  assertEq($withActionId["X-Chalk-Version"],         getChalkExeVersion())
+
+main()

--- a/tests/unit/test_core_header_precedence.nim
+++ b/tests/unit/test_core_header_precedence.nim
@@ -1,0 +1,46 @@
+## Regression test for grouped-004: the guaranteed chalk core headers must win.
+##
+## base_sinks.c4m documents that Chalk "always includes" X-Chalk-Version and
+## X-Chalk-Action-Id on every POST. Before the fix, postSinkOut/presignSinkOut
+## merged headers as getChalkCoreHeaders().update(params.headers), so a
+## user-configured header of the same name silently overrode the core value.
+## withChalkCoreHeaders() now applies the core headers last so they take
+## precedence, upholding the documented guarantee.
+
+import "../../src"/[
+  config,
+  types,
+  utils/http,
+]
+
+template assertEq(a, b: untyped) =
+  doAssert a == b, $a & " != " & $b
+
+proc main() =
+  let actionId = "11111111-1111-1111-1111-111111111111"
+  hostInfo["_ACTION_ID"] = pack(actionId)
+
+  # User config supplies colliding core-header names plus an unrelated header.
+  let userHeaders = newHttpHeaders(@[
+    ("X-Chalk-Version",   "user-bogus-version"),
+    ("X-Chalk-Action-Id", "user-bogus-action"),
+    ("X-Test-Header",     "keep-me"),
+  ])
+  let merged = userHeaders.withChalkCoreHeaders()
+
+  # Core headers win over the colliding user values.
+  assertEq($merged["X-Chalk-Version"],   getChalkExeVersion())
+  assertEq($merged["X-Chalk-Action-Id"], actionId)
+  # Non-colliding user headers are preserved.
+  assertEq($merged["X-Test-Header"], "keep-me")
+
+  # When _ACTION_ID is absent, X-Chalk-Version still wins over a colliding user
+  # value and no X-Chalk-Action-Id is emitted (chalk does not supply one).
+  hostInfo.del("_ACTION_ID")
+  let withoutActionId = newHttpHeaders(@[
+    ("X-Chalk-Version", "user-bogus-version"),
+  ]).withChalkCoreHeaders()
+  assertEq($withoutActionId["X-Chalk-Version"], getChalkExeVersion())
+  assertEq(withoutActionId.hasKey("X-Chalk-Action-Id"), false)
+
+main()

--- a/tests/unit/test_core_header_precedence.nim
+++ b/tests/unit/test_core_header_precedence.nim
@@ -1,11 +1,10 @@
-## Regression test for grouped-004: the guaranteed chalk core headers must win.
+## Regression test: guaranteed chalk core headers must win over user config.
 ##
-## base_sinks.c4m documents that Chalk "always includes" X-Chalk-Version and
-## X-Chalk-Action-Id on every POST. Before the fix, postSinkOut/presignSinkOut
-## merged headers as getChalkCoreHeaders().update(params.headers), so a
-## user-configured header of the same name silently overrode the core value.
-## withChalkCoreHeaders() now applies the core headers last so they take
-## precedence, upholding the documented guarantee.
+## base_sinks.c4m documents that Chalk "always includes" the five core headers
+## on every POST/presign request and that they take precedence over any
+## same-named header supplied via the `headers` field.
+## addChalkCoreHeaders() applies core headers last so they override the
+## user-configured values, upholding the documented guarantee.
 
 import "../../src"/[
   config,
@@ -20,26 +19,35 @@ proc main() =
   let actionId = "11111111-1111-1111-1111-111111111111"
   hostInfo["_ACTION_ID"] = pack(actionId)
 
+  let body = "test-body"
+
   # User config supplies colliding core-header names plus an unrelated header.
   let userHeaders = newHttpHeaders(@[
-    ("X-Chalk-Version",   "user-bogus-version"),
-    ("X-Chalk-Action-Id", "user-bogus-action"),
-    ("X-Test-Header",     "keep-me"),
+    ("X-Chalk-Version",       "user-bogus-version"),
+    ("X-Chalk-Operation",     "user-bogus-operation"),
+    ("X-Chalk-Action-Id",     "user-bogus-action"),
+    ("X-Content-Length",      "user-bogus-length"),
+    ("X-Chalk-Digest-Sha256", "user-bogus-digest"),
+    ("X-Test-Header",         "keep-me"),
   ])
-  let merged = userHeaders.withChalkCoreHeaders()
+  let merged = userHeaders.addChalkCoreHeaders(body = body)
 
   # Core headers win over the colliding user values.
-  assertEq($merged["X-Chalk-Version"],   getChalkExeVersion())
-  assertEq($merged["X-Chalk-Action-Id"], actionId)
+  assertEq($merged["X-Chalk-Version"],       getChalkExeVersion())
+  assertEq($merged["X-Chalk-Operation"],     getBaseCommandName())
+  assertEq($merged["X-Chalk-Action-Id"],     actionId)
+  assertEq($merged["X-Content-Length"],      $len(body))
+  assertEq(merged.hasKey("X-Chalk-Digest-Sha256"), true)
+  doAssert $merged["X-Chalk-Digest-Sha256"] != "user-bogus-digest"
   # Non-colliding user headers are preserved.
   assertEq($merged["X-Test-Header"], "keep-me")
 
-  # When _ACTION_ID is absent, X-Chalk-Version still wins over a colliding user
-  # value and no X-Chalk-Action-Id is emitted (chalk does not supply one).
+  # When _ACTION_ID is absent, the other four core headers still win and
+  # no X-Chalk-Action-Id is emitted (chalk does not supply one).
   hostInfo.del("_ACTION_ID")
   let withoutActionId = newHttpHeaders(@[
     ("X-Chalk-Version", "user-bogus-version"),
-  ]).withChalkCoreHeaders()
+  ]).addChalkCoreHeaders(body = body)
   assertEq($withoutActionId["X-Chalk-Version"], getChalkExeVersion())
   assertEq(withoutActionId.hasKey("X-Chalk-Action-Id"), false)
 


### PR DESCRIPTION
## Summary

- `post` and `presign` sinks now send five chalk metadata headers with every
  request, enabling server-side routing and auditing without parsing the body:
  - `X-Chalk-Version`
  - `X-Chalk-Operation` (same as `_OPERATION`, e.g. `insert`, `build`)
  - `X-Chalk-Action-Id` (same as `_ACTION_ID`)
  - `X-Content-Length`
  - `X-Chalk-Digest-Sha256`
- Core headers are applied last so they take precedence over any same-named
  header supplied via the sink `headers` field.
- `presign` sink now supports `x-forward-headers`: header names listed in that
  response header are copied from the redirect response into the upload PUT,
  enabling metadata injection (e.g. `X-Amz-Meta-*`) that cannot be encoded in
  a presigned URL.
- `addChalkCoreHeaders()` and `addForwardedHeaders()` added to
  `src/utils/http.nim`, shared by both sinks and the presign object store.
- Test server (`tests/functional/server/chalk.py`) validates all five headers
  on every request and verifies digest/content-length match on POST.

## Test plan

```shell
make tests args="test_sink.py::test_post_http_fastapi test_sink.py::test_presign_http_fastapi -x -s"
make unit-tests args="pattern tests/unit/test_core_header_precedence.nim"
make unit-tests args="pattern tests/unit/test_action_id_headers.nim"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)