### PR TITLE
build: fix Makefile variable expansion on macOS (GNU Make 3.81)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ git clone git@github.com:crashappsec/$(1).git $(2)
 git --git-dir=$(2)/.git --work-tree=$(2) checkout $(3)
 endef
 else
-CON4M_VERSION ?= $(shell grep '# con4m:' chalk.nimble | grep -oE '[a-f0-9]{40}')
-NIMUTILS_VERSION ?= $(shell grep '# nimutils:' chalk.nimble | grep -oE '[a-f0-9]{40}')
+CON4M_VERSION ?= $(shell awk '/con4m:/{print $$NF}' chalk.nimble)
+NIMUTILS_VERSION ?= $(shell awk '/nimutils:/{print $$NF}' chalk.nimble)
 define clone-sibling
 git init $(2)
 git -C $(2) fetch --depth=1 https://github.com/crashappsec/$(1).git $(3)


### PR DESCRIPTION
## Summary

- GNU Make 3.81 (macOS/Xcode) treats `#` as a comment character even inside `$(shell ...)`, so `$(shell grep '# nimutils:' chalk.nimble | ...)` was truncated at the `#`, leaving the shell call unclosed — causing `Makefile:19: *** unterminated call to function 'shell': missing ')'.  Stop.` on every macOS CI run.
- Replace both `grep '# nimutils:'` / `grep '# con4m:'` patterns with `awk '/nimutils:/{print $NF}'` / `awk '/con4m:/{print $NF}'`, which contain no `#` and produce identical output.
- Linux (GNU Make 4.x) was unaffected because 4.x fixed this comment-inside-shell-function bug; macOS Xcode ships 3.81.

## Test plan

```shell
# Verify SHA extraction still works locally:
make nimutils_version
make con4m_version
# Then watch macOS CI pass in chalk-release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)