### PR TITLE
build: populate ~/.local/c0 on macOS before nimble build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,20 @@ watch: $(SOURCES)
 ../con4m/README.md:
 	$(call clone-sibling,con4m,$(@D),$(CON4M_VERSION))
 
+# On macOS the build runs on the host (no Docker). Populate ~/.local/c0 with
+# the pre-built static libs from nimutils/files/deps/ and the bundled C
+# headers from nimutils/nimutils/c/ - exactly what the Dockerfile does for
+# Linux. Uses libgit2.a as a stamp: skip if already present.
+ifeq "$(shell uname -s 2>/dev/null)" "Darwin"
+MACOS_DEPS_STAMP := $(HOME)/.local/c0/libs/libgit2.a
+
+$(MACOS_DEPS_STAMP): ../nimutils/README.md
+	bash ../nimutils/bin/buildlibs.sh ../nimutils/files/deps
+	NIMUTILS_DIR=../nimutils bash ../nimutils/bin/header_install.sh
+
+nimble.paths: $(MACOS_DEPS_STAMP)
+endif
+
 nimble.paths: ../nimutils/README.md ../con4m/README.md
 	echo '--path:"$(abspath $(dir $(shell find ../nimutils -name nimutils.nim)))"' > $@
 	echo '--path:"$(abspath $(dir $(shell find ../con4m -name con4m.nim)))"' >> $@


### PR DESCRIPTION
## Summary

- On Linux, chalk compiles inside Docker where `buildlibs.sh` and `header_install.sh` already populate `~/.local/c0` with pre-built static libs and bundled C headers (`openssl/`, `git2.h`, etc.).
- On macOS the build runs on the host with no Docker, so that directory was never populated — causing `openssl/bio.h file not found` and `git2.h file not found` compile errors.
- Adds a macOS-only `ifeq` block that runs `buildlibs.sh` (copies pre-built `.a` files from `nimutils/files/deps/macosx-{arch}/`) and `header_install.sh` (copies `nimutils/c/` headers) as a dependency of `nimble.paths`, so setup runs automatically right after nimutils is cloned and before the Nim build starts. Uses `libgit2.a` as a stamp to skip the step on subsequent builds.

## Test plan

```shell
# CI passed on macmake/macci branches in chalk-release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)