### PR TITLE
feat: add _ERR_INFO and _FAILED_KEYS runtime artifact keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### New Features
 
+- Two new runtime artifact keys capture errors and failures that occur
+  **after** the chalk mark has already been embedded into the image (e.g.
+  registry queries, provenance, SBOM collection, and build-context upload).
+  Because the chalk mark is already written at that point, these cannot
+  appear in the chalk-time originals:
+  - `_ERR_INFO` — superset of `ERR_INFO`; contains the full error log
+    accumulated through the end of the operation.
+  - `_FAILED_KEYS` — superset of `FAILED_KEYS`; includes failures from
+    post-build steps.
+
+  All report templates except `report_all` now subscribe to the new keys
+  instead of the chalk-time originals. `report_all` subscribes to both.
+
+  ([#692](https://github.com/crashappsec/chalk/pull/692))
+
 - `post` and `presign` sinks now send chalk metadata headers with every
   request, enabling server-side routing and auditing without parsing the body:
   - `X-Chalk-Version`

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -2163,6 +2163,27 @@ variable that controls console logging output.
 """
 }
 
+keyspec _ERR_INFO {
+    kind:             RunTimeArtifact
+    type:             list[string]
+    standard:         true
+    system:           true
+    since:            "1.1.4"
+    normalized_order: high() - 500
+    shortdoc:         "Errors collected during chalk time and post-build operations"
+    doc:              """
+This captures all errors and logging information reported during chalk
+insertion and any subsequent operations (such as registry queries,
+provenance, and SBOM collection) that occur after the chalk mark is
+embedded. This is a superset of ERR_INFO, which is snapshotted at
+chalk time before the build runs.
+
+Only messages of a log level at least as severe as that found in the
+configuration variable `chalk_log_level` are captured. By default,
+this value is set to "error".
+"""
+}
+
 keyspec FAILED_KEYS {
   kind:     ChalkTimeArtifact
   type:     dict[string, list[`x]]
@@ -2176,6 +2197,39 @@ AWS EC2 instance metadata if IMDSv2 is disabled for that instance.
 This key reports all known errors and reasons why that key could
 not be collected so that further action can be taken to be able
 to collect that metadata in the future.
+
+Each entry maps a key name to a list of error objects. Using a list
+allows multiple distinct failures for the same key to be recorded
+without later errors overwriting earlier ones. Each error object has:
+
+- `code` - a machine-readable error code string
+- `error` - a human-readable error message
+- `description` - a longer explanation and remediation hint
+"""
+}
+
+keyspec _FAILED_KEYS {
+  kind:     RunTimeArtifact
+  type:     dict[string, list[`x]]
+  standard: true
+  since:    "1.1.4"
+  shortdoc: "Keys and errors why chalk could not collect them (including post-build)"
+  doc:      """
+This key reports all known errors and reasons why chalk could not
+collect some metadata, including operations that occur after the
+chalk mark has already been embedded into the artifact.
+
+This is a superset of FAILED_KEYS, which is snapshotted at chalk
+time before the build runs. _FAILED_KEYS includes failures from
+post-build operations such as registry queries, provenance, and
+SBOM collection.
+
+For example, if a build context upload fails after the chalk mark
+has already been embedded into the image, the failure is recorded
+under the `_REPO_BUILD_CONTEXTS` key with a code of
+`CONTEXT_UPLOAD_FAILED` or `CONTEXT_TOO_LARGE`. These failures
+cannot appear in FAILED_KEYS because the chalk mark was already
+written before the upload was attempted.
 
 Each entry maps a key name to a list of error objects. Using a list
 allows multiple distinct failures for the same key to be recorded

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -70,7 +70,7 @@ plugin attestation {
     ~enabled: true
     pre_chalk_keys:  ["METADATA_HASH", "ERR_INFO", "FAILED_KEYS", "METADATA_ID",
                       "SIGNING", "SIGNATURE", "INJECTOR_PUBLIC_KEY"]
-    post_chalk_keys: ["_SIGNATURES"]
+    post_chalk_keys: ["_SIGNATURES", "_ERR_INFO", "_FAILED_KEYS"]
     ~priority:       high() - 1
     doc: """
 Like the `system` module, this module is non-overridable keys added by

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -149,6 +149,7 @@ report and subtract from it.
   key.SBOM.use                                = true
   key.SAST.use                                = true
   key.ERR_INFO.use                            = true
+  key._ERR_INFO.use                           = true
   key.SIGNING.use                             = true
   key.METADATA_HASH.use                       = true
   key.METADATA_ID.use                         = true
@@ -433,6 +434,7 @@ report and subtract from it.
   key._OP_CLOUD_METADATA.use                  = true
   key._OP_FAILED_KEYS.use                     = true
   key.FAILED_KEYS.use                         = true
+  key._FAILED_KEYS.use                        = true
   key._NETWORK_PARTIAL_TRACEROUTE_IPS.use     = true
   key._OP_ERRORS.use                          = true
   key._OP_HOST_REPORT_KEYS.use                = true
@@ -620,7 +622,8 @@ doc: """
   key._OP_HOST_MACHINE.use                    = true
   key._OP_CLOUD_METADATA.use                  = true
   key._OP_FAILED_KEYS.use                     = true
-  key.FAILED_KEYS.use                         = true
+  key.FAILED_KEYS.use                         = false
+  key._FAILED_KEYS.use                        = true
   key._NETWORK_PARTIAL_TRACEROUTE_IPS.use     = true
   key._OP_ERRORS.use                          = true
   key._OP_HOST_REPORT_KEYS.use                = true
@@ -841,7 +844,8 @@ doc: """
   key.SECRET_SCANNER.use                      = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
-  key.ERR_INFO.use                            = true
+  key.ERR_INFO.use                            = false
+  key._ERR_INFO.use                           = true
   key.SIGNING.use                             = false
   key.METADATA_HASH.use                       = true
   key.METADATA_ID.use                         = true
@@ -1206,7 +1210,8 @@ container.
   key._OP_HOST_MACHINE.use                    = true
   key._OP_CLOUD_METADATA.use                  = true
   key._OP_FAILED_KEYS.use                     = true
-  key.FAILED_KEYS.use                         = true
+  key.FAILED_KEYS.use                         = false
+  key._FAILED_KEYS.use                        = true
   key._NETWORK_PARTIAL_TRACEROUTE_IPS.use     = true
   key._CHALK_EXTERNAL_ACTION_AUDIT.use        = true
   key._OP_ERRORS.use                          = true
@@ -1403,7 +1408,8 @@ container.
   key.SECRET_SCANNER.use                      = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
-  key.ERR_INFO.use                            = true
+  key.ERR_INFO.use                            = false
+  key._ERR_INFO.use                           = true
   key.SIGNING.use                             = false
   key.METADATA_HASH.use                       = true
   key.METADATA_ID.use                         = true
@@ -1753,7 +1759,8 @@ and keep the run-time key.
   key._OP_HOST_MACHINE.use                    = true
   key._OP_CLOUD_METADATA.use                  = true
   key._OP_FAILED_KEYS.use                     = true
-  key.FAILED_KEYS.use                         = true
+  key.FAILED_KEYS.use                         = false
+  key._FAILED_KEYS.use                        = true
   key._NETWORK_PARTIAL_TRACEROUTE_IPS.use     = true
   key._CHALK_EXTERNAL_ACTION_AUDIT.use        = true
   key._OP_ERRORS.use                          = true
@@ -1950,7 +1957,8 @@ and keep the run-time key.
   key.SECRET_SCANNER.use                      = true
   key.SBOM.use                                = true
   key.SAST.use                                = true
-  key.ERR_INFO.use                            = true
+  key.ERR_INFO.use                            = false
+  key._ERR_INFO.use                           = true
   key.SIGNING.use                             = false
   key.METADATA_HASH.use                       = true
   key.METADATA_ID.use                         = true
@@ -2347,7 +2355,8 @@ running insert commands.
   key._TIMESTAMP_TAGGED.use                   = true
   key._TAG_MESSAGE.use                        = true
   key.EMBEDDED_CHALK.use                      = true
-  key.ERR_INFO.use                            = true
+  key.ERR_INFO.use                            = false
+  key._ERR_INFO.use                           = true
   key._DOCKER_CLIENT_VERSION.use              = false
   key._DOCKER_SERVER_VERSION.use              = false
   key._DOCKER_BUILDX_VERSION.use              = false
@@ -2456,7 +2465,8 @@ running commands that do NOT insert chalk marks.
   key._TIMESTAMP_TAGGED.use                   = true
   key._TAG_MESSAGE.use                        = true
   key.EMBEDDED_CHALK.use                      = true
-  key.ERR_INFO.use                            = true
+  key.ERR_INFO.use                            = false
+  key._ERR_INFO.use                           = true
   key._DOCKER_CLIENT_VERSION.use              = false
   key._DOCKER_SERVER_VERSION.use              = false
   key._DOCKER_BUILDX_VERSION.use              = false

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -79,7 +79,8 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key._OP_HOST_MACHINE.use                           = true
   ~key._OP_CLOUD_METADATA.use                         = true
   ~key._OP_FAILED_KEYS.use                            = true
-  ~key.FAILED_KEYS.use                                = true
+  ~key.FAILED_KEYS.use                                = false
+  ~key._FAILED_KEYS.use                               = true
   ~key._NETWORK_PARTIAL_TRACEROUTE_IPS.use            = true
   ~key._CHALK_EXTERNAL_ACTION_AUDIT.use               = true
   ~key._OP_ERRORS.use                                 = true
@@ -272,7 +273,8 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.SECRET_SCANNER.use                      = true
   ~key.SBOM.use                                = true
   ~key.SAST.use                                = true
-  ~key.ERR_INFO.use                            = true
+  ~key.ERR_INFO.use                            = false
+  ~key._ERR_INFO.use                           = true
   ~key.SIGNING.use                             = false
   ~key.METADATA_HASH.use                       = true
   ~key.METADATA_ID.use                         = true

--- a/src/plugins/system.nim
+++ b/src/plugins/system.nim
@@ -305,6 +305,8 @@ proc attestationGetChalkTimeArtifactInfo*(self: Plugin, obj: ChalkObj):
 proc attestationGetRunTimeArtifactInfo(self: Plugin, obj: ChalkObj, insert: bool):
                                        ChalkDict {.cdecl.} =
   result = ChalkDict()
+  result.setIfNeeded("_ERR_INFO", obj.err)
+  result.setIfNeeded("_FAILED_KEYS", obj.failedKeys)
   if insert and obj.willSignBySigStore():
     try:
       result.update(obj.signBySigStore())

--- a/tests/functional/test_git.py
+++ b/tests/functional/test_git.py
@@ -287,7 +287,7 @@ def test_tag_refetch_ssl_cert_failure(
     result = chalk_copy.insert(artifact, env={"SSL_CERT_FILE": str(bad_cert)})
     assert result.mark.has(
         TAG="v1.0.0",
-        FAILED_KEYS={
+        _FAILED_KEYS={
             "_TAG": [
                 {
                     "code": "GIT_REFETCH_FAILED",


### PR DESCRIPTION
## Summary

- Adds `_ERR_INFO` (`RunTimeArtifact`, `list[string]`) and `_FAILED_KEYS` (`RunTimeArtifact`, `dict[string, list[x]]`) keyspecs, populated in `attestationGetRunTimeArtifactInfo` after all post-build collection completes
- `ERR_INFO` and `FAILED_KEYS` are snapshotted at chalk time before the build runs; post-build errors (registry queries, provenance, SBOM, build-context upload) accumulate in `chalk.err`/`obj.failedKeys` afterward but never update those snapshots — the new keys capture the complete picture
- All report templates except `report_all` now subscribe to the new keys and disable the chalk-time originals; `report_all` subscribes to both

## Test plan

```shell
make tests args="test_docker.py -x -k build -s"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)