### PR TITLE
feat: send X-Chalk-Attempt header on sink and object store requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,10 @@
   - `X-Chalk-Action-Id` (same as `_ACTION_ID`)
   - `X-Content-Length`
   - `X-Chalk-Digest-Sha256`
+  - `X-Chalk-Attempt` — 1-based attempt counter, incremented on each retry
 
-  ([#688](https://github.com/crashappsec/chalk/pull/688))
+  ([#688](https://github.com/crashappsec/chalk/pull/688),
+  [#693](https://github.com/crashappsec/chalk/pull/693))
 
 - `presign` sink now supports `x-forward-headers`: header names listed in that
   response header are copied from the redirect response into the upload PUT,

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -21,7 +21,7 @@ requires "nim >= 2.0.8"
 # out these commits when the repos are absent.  In interactive shells the
 # Makefile defaults to the `dev` branch instead.
 # con4m:    f2364ee578f22aa0a4ad94e68173c24fe0d5038e
-# nimutils: f58ed57c49f5b12785da1a1d9b9868bd9774f8a6
+# nimutils: b34b2d79274cd69d10be19f42e2c68d6f6c96203
 requires "unicodedb == 0.12.0"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT
 requires "https://github.com/NimParsers/parsetoml == 0.7.1" # MIT

--- a/src/object_store/presign.nim
+++ b/src/object_store/presign.nim
@@ -107,7 +107,8 @@ proc request(self:           ObjectStorePresign,
                                  retries            = 2,
                                  firstRetryDelayMs  = 100,
                                  maxRedirects       = 0,
-                                 acceptStatusCodes  = [200..399])
+                                 acceptStatusCodes  = [200..399],
+                                 attemptHeader      = chalkAttemptHeader)
   trace("object store: " & $httpMethod & " " & $url & " -> " & $signResponse.code)
 
   if signResponse.code notin [Http302, Http307]:
@@ -135,7 +136,8 @@ proc request(self:           ObjectStorePresign,
                              body              = body,
                              retries           = 2,
                              firstRetryDelayMs = 100,
-                             rejectStatusCodes = [500..599])
+                             rejectStatusCodes = [500..599],
+                             attemptHeader     = chalkAttemptHeader)
   trace("object store: " & $httpMethod & " @" & $uri.hostname & " (" & $len(body) & " bytes) -> " & $response.code)
 
   let updatedRef = deepCopy(keyRef)

--- a/src/types.nim
+++ b/src/types.nim
@@ -538,6 +538,7 @@ const
   emptyMark*          = "{ \"MAGIC\" : \"" & magicUTF8 & "\" }"
   implName*           = "chalk-reference"
   chalkSpecName*      = "configs/chalk.c42spec"
+  chalkAttemptHeader* = "X-Chalk-Attempt"
   getoptConfName*     = "configs/getopts.c4m"
   baseConfName*       = "configs/base_*.c4m"
   sbomConfName*       = "configs/sbomconfig.c4m"

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -442,6 +442,7 @@ proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
       retries            = 2,
       firstRetryDelayMs  = 100,
       acceptStatusCodes  = [200..299],
+      attemptHeader      = chalkAttemptHeader,
     )
     resetSinkFailures(cfg)
     cfg.iolog(t, "Post " & response.status)
@@ -470,6 +471,7 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
       firstRetryDelayMs  = 100,
       maxRedirects       = 0,
       acceptStatusCodes  = [302..302, 307..307],
+      attemptHeader      = chalkAttemptHeader,
     )
   except HttpStatusError as e:
     dumpExOnDebug()
@@ -506,6 +508,7 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
       retries            = 2,
       firstRetryDelayMs  = 100,
       acceptStatusCodes  = [200..299],
+      attemptHeader      = chalkAttemptHeader,
     )
     resetSinkFailures(cfg)
     cfg.iolog(t, "Presign " & response.status)

--- a/tests/functional/server/chalk.py
+++ b/tests/functional/server/chalk.py
@@ -76,6 +76,7 @@ async def _check_chalk_core_headers(
         "x-chalk-action-id",
         "x-content-length",
         "x-chalk-digest-sha256",
+        "x-chalk-attempt",
     ]:
         if not request.headers.get(header):
             raise HTTPException(status_code=400, detail=f"missing {header} header")
@@ -116,6 +117,11 @@ async def accept_presign_report(
         raise HTTPException(
             status_code=400,
             detail="x-presign-test forwarded header missing or has wrong value",
+        )
+    if not request.headers.get("x-chalk-attempt"):
+        raise HTTPException(
+            status_code=400,
+            detail="missing x-chalk-attempt header",
         )
     return await accept_report(
         reports=reports, request=request, response=response, db=db
@@ -300,6 +306,11 @@ async def object_get_presign(key: str, request: Request):
 
 @app.put("/presign/objects/{key}")
 async def object_create_presign(key: str, request: Request):
+    if not request.headers.get("x-chalk-attempt"):
+        raise HTTPException(
+            status_code=400,
+            detail="missing x-chalk-attempt header",
+        )
     redirect = request.url_for("object_create", key=key)
     return RedirectResponse(
         f"{redirect}?signature=foobar",
@@ -326,6 +337,11 @@ async def object_get(key: str):
 
 @app.put("/objects/{key}")
 async def object_create(key: str, request: Request):
+    if not request.headers.get("x-chalk-attempt"):
+        raise HTTPException(
+            status_code=400,
+            detail="missing x-chalk-attempt header",
+        )
     if key in objects:
         raise HTTPException(status_code=status.HTTP_412_PRECONDITION_FAILED)
     content_type = request.headers.get("content-type", "")


### PR DESCRIPTION
## Summary

- Adds `attemptHeader` parameter to `safeRequest` in nimutils (default empty = no header sent)
- Defines `chalkAttemptHeader = "X-Chalk-Attempt"` constant in `src/types.nim`
- All sink implementations (post, presign sign, presign upload) and object store presign (sign, upload) pass `chalkAttemptHeader`, sending `X-Chalk-Attempt: <n>` where `n` is 1-based retry count
- Bumps nimutils pin to `b34b2d7`
- Updates CHANGELOG entry for #688 to include the new header
- Functional test server validates `x-chalk-attempt` is present on all relevant endpoints

## Test plan

```shell
make tests args="test_docker.py -x -k sink"
make tests args="test_docker.py -x -k object_store"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)