### PR TITLE
feat: add DNS sink, per-chalk reporting, and timing/heartbeat keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 ### New Features
 
+- Four new runtime host keys for timing and heartbeat tracking:
+  - `_MONOTIME` — monotonic clock value at the start of the current operation,
+    in milliseconds (kernel monotonic time, suitable for elapsed-time math).
+  - `_SINCE_TIMESTAMP` — milliseconds elapsed since the chalk process started
+    (wall-clock delta between `_TIMESTAMP` and the process start time).
+  - `_SINCE_MONOTIME` — milliseconds elapsed since the chalk process started
+    (monotonic delta, unaffected by clock adjustments).
+  - `_HEARTBEAT_COUNT` — 1-based counter incremented on each heartbeat tick;
+    only present in heartbeat reports (absent in the initial `exec` report).
+
+  ([#695](https://github.com/crashappsec/chalk/pull/695))
+
+- New `dns` sink type that encodes chalk key values into a DNS lookup hostname,
+  providing a telemetry channel that works in environments where HTTPS egress
+  is restricted. Example:
+
+  ```con4m
+  sink_config my_dns_beacon {
+    sink:            "dns"
+    domain_template: "{METADATA_ID}.beacons.example.com"
+    dns_server:      "10.0.0.1:5353"
+  }
+  subscribe("report", "my_dns_beacon")
+  ```
+
+  ([#694](https://github.com/crashappsec/chalk/pull/694))
+
 - `outconf` sections now support `per_chalk_reports: true`, and `custom_report`
   sections now support `per_chalk: true`. When enabled, chalk emits one report
   per chalk mark (with `_CHALKS` containing exactly that mark) instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,23 @@
 
 - New `dns` sink type that encodes chalk key values into a DNS lookup hostname,
   providing a telemetry channel that works in environments where HTTPS egress
-  is restricted. Example:
+  is restricted. Key values are substituted into a `domain_template` using
+  `{KEY}` placeholders. Per-key `normalize` callbacks transform values before
+  substitution, which is useful for keys whose string representation may exceed
+  the 63-character DNS label limit:
 
   ```con4m
+  func trunc16(v: string) {
+    return slice(v, 0, 16)
+  }
+
   sink_config my_dns_beacon {
     sink:            "dns"
-    domain_template: "{METADATA_ID}.beacons.example.com"
+    domain_template: "{_COMMIT_ID}.{METADATA_ID}.beacons.example.com"
     dns_server:      "10.0.0.1:5353"
+    normalize _COMMIT_ID {
+      callback: func trunc16
+    }
   }
   subscribe("report", "my_dns_beacon")
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@
   is restricted. Key values are substituted into a `domain_template` using
   `{KEY}` placeholders. Per-key `normalize` callbacks transform values before
   substitution, which is useful for keys whose string representation may exceed
-  the 63-character DNS label limit:
+  the 63-character DNS label limit. The sink emits one lookup per chalk mark in
+  `_CHALKS`, falling back to a single lookup with report-level keys only when no
+  chalk marks are present. Set `require_chalk_mark: true` to suppress the
+  fallback and skip emission entirely when no marks are present:
 
   ```con4m
   func trunc16(v: string) {
@@ -29,12 +32,11 @@
   }
 
   sink_config my_dns_beacon {
-    sink:            "dns"
-    domain_template: "{_COMMIT_ID}.{METADATA_ID}.beacons.example.com"
-    dns_server:      "10.0.0.1:5353"
-    normalize _COMMIT_ID {
-      callback: func trunc16
-    }
+    sink:               "dns"
+    domain_template:    "{_COMMIT_ID}.{METADATA_ID}.beacons.example.com"
+    dns_server:         "10.0.0.1:5353"
+    require_chalk_mark: true
+    normalize._COMMIT_ID.callback: func trunc16
   }
   subscribe("report", "my_dns_beacon")
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### New Features
 
+- `outconf` sections now support `per_chalk_reports: true`, and `custom_report`
+  sections now support `per_chalk: true`. When enabled, chalk emits one report
+  per chalk mark (with `_CHALKS` containing exactly that mark) instead of
+  bundling all marks into a single report. Host-level keys are repeated verbatim
+  in each report.
+  ([#694](https://github.com/crashappsec/chalk/pull/694))
+
 - Two new runtime artifact keys capture errors and failures that occur
   **after** the chalk mark has already been embedded into the image (e.g.
   registry queries, provenance, SBOM collection, and build-context upload).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,29 @@ services:
         aliases:
           - metadata.google.internal
 
+  # UDP DNS server for DNS sink functional tests
+  dns:
+    build:
+      context: ./tests/functional
+    entrypoint: python
+    command: -m functional.server.dns_server
+    networks:
+      chalk:
+        aliases:
+          - dns.chalk.local
+    ports:
+      - "5354:5354/udp"
+      - "8054:8054"
+    working_dir: /tests
+    volumes:
+      - ./tests:/tests
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - sh -c "curl -f http://localhost:8054/health"
+      start_period: 10s
+      interval: 1s
+
   # simple server for serving static files
   static:
     build:
@@ -181,6 +204,8 @@ services:
       server-tls:
         condition: service_healthy
       imds:
+        condition: service_healthy
+      dns:
         condition: service_healthy
     environment:
       AWS_REGION: ${AWS_REGION:-us-east-1}

--- a/docs/design-dns-sink.md
+++ b/docs/design-dns-sink.md
@@ -94,16 +94,65 @@ Users are expected to craft templates that only reference keys that will be
 collected for the operations they subscribe to; the placeholder is a safety
 valve, not an invitation to use arbitrary key names.
 
+### Key normalization
+
+Each `sink_config` can include `normalize.KEYNAME.callback` subsections to
+transform a key's string value before it is substituted into the template.
+This is the primary mechanism for handling values that may exceed the 63-character
+DNS label limit (e.g. SHA-256 commit IDs):
+
+```con4m
+func trunc16(v: string) {
+  return slice(v, 0, 16)
+}
+
+sink_config my_dns {
+  sink:            "dns"
+  domain_template: "{_COMMIT_ID}.{METADATA_ID}.chalk.example.com"
+  dns_server:      "10.0.0.1"
+  normalize _COMMIT_ID {
+    callback: func trunc16
+  }
+}
+```
+
+The `callback` field type is `func(`x) -> `y` — a generic function that
+receives the raw Box value of the key (a string, int, float, or bool as
+stored in the report) and returns a Box of any type. The returned Box is
+stringified with `$box` for DNS label substitution, which for scalar types
+gives the natural string representation: no quoting for strings, plain
+integer decimal for ints, `true`/`false` for bools, and a float with
+a decimal point for floats. Float values will always contain a `.` in the
+DNS label; add a normalize callback to strip it if needed.
+
+If the callback raises or returns no value, the key's original string
+representation is used and a `warn` is emitted.
+
+Normalization is applied after key lookup but before the placeholder fallback:
+if the key is not found, the placeholder is substituted directly without
+calling the normalizer. Non-scalar key values (arrays, objects) that cannot
+be converted to a Box are also substituted with the placeholder.
+
+The callback for each key is fetched on demand from the con4m attribute store
+(`sink_config.<name>.normalize.<key>.callback`) via `attrGetOpt[CallbackObj]`
+at the point of substitution — only for keys that actually appear in the
+template, avoiding unnecessary config traversal.
+
+**Design decision:** Normalization lives in `sink_config`, not in the keyspec
+or report template, because it is a property of how a specific sink renders
+values — not a property of the key itself. Different DNS sinks targeting
+different backends may need different truncation strategies for the same key.
+
 ### Hostname sanitization
 
-The sink does not perform additional sanitization beyond the `"x"` fallback.
-If a key value contains characters that are invalid in a DNS label (e.g.
-underscores in some strict resolver configurations), the resulting lookup
-will simply fail and count toward the error threshold. Users are responsible
-for selecting keys whose rendered values produce DNS-safe labels. Keys
-that are likely to contain only alphanumeric characters and hyphens (such
-as `METADATA_ID`, `CHALK_ID`, hash values, and ID-format strings) are the
-most reliable choices.
+The sink does not perform additional sanitization beyond the `"x"` fallback
+and any user-supplied `normalize` callbacks. If a key value (after normalization)
+contains characters that are invalid in a DNS label (e.g. underscores in
+some strict resolver configurations), the resulting lookup will simply fail
+and count toward the error threshold. Users are responsible for selecting
+keys whose rendered values produce DNS-safe labels. Keys that are likely to
+contain only alphanumeric characters and hyphens (such as `METADATA_ID`,
+`CHALK_ID`, hash values, and ID-format strings) are the most reliable choices.
 
 ## Template Substitution Engine
 
@@ -132,11 +181,19 @@ The DNS sink supplies its own callback that reads from parsed JSON instead of
 from a `ChalkObj`:
 
 ```nim
-proc dnsSinkLookup(key: string, report: JsonNode, placeholder: string, cfgName: string): string
+proc dnsSinkLookup(
+  key:         string,
+  report:      JsonNode,
+  placeholder: string,
+  cfgName:     string,
+): string
 ```
 
 The `cfgName` parameter is the sink config name used in warning messages when
-a key is not found.
+a key is not found and for dynamic callback lookup: `applyDnsNormalizer` fetches
+the con4m callback for each key on demand via `attrGetOpt[CallbackObj]` at the
+path `sink_config.<cfgName>.normalize.<key>.callback`, so only keys that actually
+appear in the template are looked up.
 
 **Design decision:** Making the callback the extension point (rather than, say,
 a method on an interface type) keeps the engine simple and avoids any object
@@ -295,13 +352,13 @@ many were chalked.
 
 ## Source Locations
 
-| Path                          | Role                                                                         |
-| ----------------------------- | ---------------------------------------------------------------------------- |
-| `src/utils/dns.nim`           | `dnsLookup`, Punycode encoder, IDNA validation, server address parsing       |
-| `src/utils/substitutions.nim` | Generic `{KEY}` template engine; callback-based lookup                       |
-| `src/docker/util.nim`         | Thin `applySubstitutions(s, ChalkObj)` wrapper over the generic engine       |
-| `src/utils/sink_impls.nim`    | `dnsSinkOut`, `addDnsSink` — DNS sink output function and registration       |
-| `src/configs/base_sinks.c4m`  | `sink dns { ... }` — con4m schema for DNS sink parameters                    |
-| `src/configs/chalk.c42spec`   | `sink_config_check` — validation for `record_type` and `dns_timeout`         |
-| `src/sinks.nim`               | `getSinkConfigByName` — int param handling for `dns_timeout`                 |
-| `tests/unit/test_dns.nim`     | Unit tests: Punycode (RFC 3492 vectors), IDNA, server parsing, lookup errors |
+| Path                          | Role                                                                               |
+| ----------------------------- | ---------------------------------------------------------------------------------- |
+| `src/utils/dns.nim`           | `dnsLookup`, Punycode encoder, IDNA validation, server address parsing             |
+| `src/utils/substitutions.nim` | Generic `{KEY}` template engine; callback-based lookup                             |
+| `src/docker/util.nim`         | Thin `applySubstitutions(s, ChalkObj)` wrapper over the generic engine             |
+| `src/utils/sink_impls.nim`    | `dnsSinkOut`, `dnsSinkLookup`, `applyDnsNormalizer`, `addDnsSink`                  |
+| `src/configs/base_sinks.c4m`  | `sink dns { ... }` — con4m schema for DNS sink parameters                          |
+| `src/configs/chalk.c42spec`   | `object normalize` — per-key callback spec; `sink_config_check` — field validation |
+| `src/sinks.nim`               | `getSinkConfigByName` — int param handling for `dns_timeout`                       |
+| `tests/unit/test_dns.nim`     | Unit tests: Punycode (RFC 3492 vectors), IDNA, server parsing, lookup errors       |

--- a/docs/design-dns-sink.md
+++ b/docs/design-dns-sink.md
@@ -337,15 +337,21 @@ mechanism as the HTTP sinks. When consecutive failures reach the
 `disable_after_errors` threshold, the sink sets `cfg.enabled = false` and
 logs an error.
 
-**Design decision:** All DNS errors are soft (threshold-based) rather than
-distinguishing hard vs. soft as the HTTP sinks do. HTTP sinks classify 4xx
-responses as hard errors (immediate disable) because they indicate a
-configuration problem. DNS has no equivalent — a lookup failure could be
-transient (SERVFAIL, NXDOMAIN for a typo, network blip) or permanent (bad
-template rendering a malformed name), and there is no status code to
-distinguish them. The threshold approach ensures transient failures do not
-permanently disable the sink while repeated failures still trigger the
-disable.
+**Design decision:** DNS errors are split into two categories, mirroring the
+HTTP sink convention:
+
+- **Hard errors (immediate disable):** A `ValueError` raised by `toAsciiDomain`
+  before any socket is opened — e.g., a rendered label exceeds 63 characters or
+  the full hostname exceeds 253 characters. These indicate a structural
+  configuration bug (a template that will always produce an invalid hostname
+  regardless of retries), so the sink is disabled immediately without waiting
+  for the `disable_after_errors` threshold.
+
+- **Soft errors (threshold-based):** All other failures — timeouts, SERVFAIL,
+  NXDOMAIN, socket errors, and RCODE != 0 responses. These count toward the
+  `disable_after_errors` counter. Transient failures (network blips, intermittent
+  SERVFAIL) will recover on the next successful lookup, which resets the counter
+  via `resetSinkFailures(cfg)`.
 
 Successful lookups reset the counter via `resetSinkFailures(cfg)`, consistent
 with the other network sinks.

--- a/docs/design-dns-sink.md
+++ b/docs/design-dns-sink.md
@@ -246,13 +246,21 @@ entirely. This allows targeting a specific recursive resolver not listed in
 authoritative server.
 
 The query is a standard A/AAAA/ANY question with the Recursion Desired bit
-set. The response is read back and inspected only for the RCODE field
-(bits 0-3 of byte 3 of the header); a non-zero RCODE raises `IOError`. The
-response payload is otherwise discarded.
+set. Each query uses a cryptographically random 16-bit transaction ID
+(`secureRand[uint16]()`). The response is inspected for the transaction ID
+(bytes 0-1) and the RCODE field (bits 0-3 of byte 3); a non-zero RCODE raises
+`IOError`. The response payload is otherwise discarded.
 
-A `select`-based timeout is applied before the `recvFrom` call. If no
-response arrives within `timeoutMs` milliseconds, `IOError` is raised with a
-`"timed out"` message, which the sink counts as a soft error toward the
+Source filtering is delegated to the kernel: `connect()` is called on the UDP
+socket before sending, which causes the kernel to discard datagrams not
+originating from the configured resolver address and port. This works
+correctly whether `dns_server` is an IP address or a hostname. For literal IP
+addresses `parseIpAddress` determines the socket family without a resolver
+call; for hostnames `getaddrinfo` is used.
+
+A `select`-based timeout is applied before each `recv` call. If no response
+arrives within `timeoutMs` milliseconds, `IOError` is raised with a `"timed
+out"` message, which the sink counts as a soft error toward the
 `disable_after_errors` threshold.
 
 ### Server address parsing

--- a/docs/design-dns-sink.md
+++ b/docs/design-dns-sink.md
@@ -32,6 +32,7 @@ sink_config my_dns_beacon {
   domain_template:         "{METADATA_ID}.{_EXEC_ID}.chalk.example.com"
   record_type:             "A"
   missing_key_placeholder: "x"
+  require_chalk_mark:      true
   disable_after_errors:    3
 }
 
@@ -40,14 +41,15 @@ subscribe("report", "my_dns_beacon")
 
 **Fields:**
 
-| Field                     | Type     | Required | Default | Description                                                                                                      |
-| ------------------------- | -------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
-| `domain_template`         | `string` | true     | -       | Hostname template. `{KEY}` placeholders are replaced with values from the report.                                |
-| `record_type`             | `string` | false    | `"A"`   | DNS record type to query. Accepted values: `"A"`, `"AAAA"`, `"any"` (see below).                                 |
-| `missing_key_placeholder` | `string` | false    | `"x"`   | Value substituted when a `{KEY}` placeholder cannot be resolved (see below).                                     |
-| `dns_server`              | `string` | false    | `""`    | Custom resolver address: `"8.8.8.8"`, `"8.8.8.8:5353"`, `"[::1]:5353"`. When empty, the system resolver is used. |
-| `dns_timeout`             | `int`    | false    | `5000`  | Timeout in milliseconds for custom resolver queries. Has no effect when `dns_server` is empty.                   |
-| `disable_after_errors`    | `int`    | false    | `3`     | Number of consecutive lookup failures before the sink is permanently disabled.                                   |
+| Field                     | Type     | Required | Default | Description                                                                                                                                         |
+| ------------------------- | -------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `domain_template`         | `string` | true     | -       | Hostname template. `{KEY}` placeholders are replaced with values from the report.                                                                   |
+| `record_type`             | `string` | false    | `"A"`   | DNS record type to query. Accepted values: `"A"`, `"AAAA"`, `"any"` (see below).                                                                    |
+| `missing_key_placeholder` | `string` | false    | `"x"`   | Value substituted when a `{KEY}` placeholder cannot be resolved (see below).                                                                        |
+| `dns_server`              | `string` | false    | `""`    | Custom resolver address: `"8.8.8.8"`, `"8.8.8.8:5353"`, `"[::1]:5353"`. When empty, the system resolver is used.                                    |
+| `dns_timeout`             | `int`    | false    | `5000`  | Timeout in milliseconds for custom resolver queries. Has no effect when `dns_server` is empty.                                                      |
+| `require_chalk_mark`      | `bool`   | false    | `false` | When `true`, skip emission entirely if the report contains no chalk marks. When `false`, fall back to a single lookup using report-level keys only. |
+| `disable_after_errors`    | `int`    | false    | `3`     | Number of consecutive lookup failures before the sink is permanently disabled.                                                                      |
 
 ## Template Substitution
 
@@ -60,12 +62,18 @@ to the same key.
 
 ### Lookup order
 
-When a placeholder is encountered, the sink searches for the key in this order:
+The sink emits one DNS lookup per chalk mark in `_CHALKS`. For each mark,
+key lookup proceeds in this order:
 
 1. Top-level report fields (host-level keys, e.g. `_OPERATION`, `_EXEC_ID`,
    `_TIMESTAMP`).
-2. The first chalk mark in `_CHALKS[0]` (chalk-time keys, e.g. `METADATA_ID`,
+2. The current chalk mark's fields (chalk-time keys, e.g. `METADATA_ID`,
    `CHALK_ID`, `HASH`).
+
+When `_CHALKS` is absent or empty the sink falls back to a single lookup
+using only report-level keys (chalk-time keys will resolve to the placeholder).
+Set `require_chalk_mark: true` to suppress this fallback and skip emission
+entirely when no marks are present.
 
 Both sources are extracted by parsing the JSON report string passed to the
 sink output function. The report string is a JSON array `[ { ... } ]`
@@ -344,19 +352,16 @@ with the other network sinks.
 
 ## Interaction with Per-Chalk Reporting
 
+The DNS sink iterates `_CHALKS` internally and emits one lookup per mark,
+so it handles multi-mark reports naturally regardless of whether per-chalk
+mode is enabled.
+
 When `per_chalk_reports: true` is set on the `outconf` section (or
 `per_chalk: true` on a `custom_report` section), the reporting pipeline emits
-one report per chalk mark rather than one bundled report. Because the DNS
-sink's template substitution reads `_CHALKS[0]` from the incoming JSON report,
-per-chalk mode is the most natural fit: each emitted report contains exactly
-one chalk mark, so `_CHALKS[0]` always refers to the mark for the artifact
-currently being reported.
-
-Without per-chalk mode, `_CHALKS[0]` refers to the first chalk mark in a
-potentially multi-mark bundle. Keys from other marks in the same report are
-not accessible, so templates that reference chalk-time keys such as
-`METADATA_ID` will reflect only the first artifact's values regardless of how
-many were chalked.
+one report per chalk mark. Combined with the sink's internal iteration, this
+means one lookup is emitted per mark — the same result as without per-chalk
+mode — but each report is smaller and the sink processes exactly one mark at
+a time rather than iterating a bundle.
 
 ## Source Locations
 

--- a/docs/design-dns-sink.md
+++ b/docs/design-dns-sink.md
@@ -1,0 +1,307 @@
+# Design: DNS Sink
+
+This document describes the design and intent behind the `dns` sink type,
+including the motivation, key decisions made during implementation, and the
+shared infrastructure it introduces.
+
+## Motivation
+
+Enterprise networks commonly enforce egress policies that block outbound
+HTTPS connections to unknown destinations, either via TLS inspection or
+domain blocklists. These policies prevent chalk from sending telemetry
+over conventional HTTP/HTTPS sinks to arbitrary endpoints.
+
+DNS traffic is rarely blocked at the same granularity: resolvers are
+whitelisted by infrastructure teams and DNSSEC/DoT is the exception rather
+than the rule. This makes DNS lookups a practical out-of-band channel for
+emitting lightweight, structured metadata about chalk operations — enough
+to confirm that a binary was chalked, or that an exec heartbeat fired,
+without relying on TCP or TLS connectivity.
+
+The `dns` sink makes one DNS lookup per report. The response is discarded.
+The hostname itself carries the payload: chalk keys are substituted into a
+configurable domain template, and the DNS lookup encodes the resulting
+labels in-flight through the resolver hierarchy to the authoritative
+nameserver, where they can be logged.
+
+## Configuration
+
+```con4m
+sink_config my_dns_beacon {
+  sink:                    "dns"
+  domain_template:         "{METADATA_ID}.{_EXEC_ID}.chalk.example.com"
+  record_type:             "A"
+  missing_key_placeholder: "x"
+  disable_after_errors:    3
+}
+
+subscribe("report", "my_dns_beacon")
+```
+
+**Fields:**
+
+| Field                     | Type     | Required | Default | Description                                                                                                      |
+| ------------------------- | -------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `domain_template`         | `string` | true     | -       | Hostname template. `{KEY}` placeholders are replaced with values from the report.                                |
+| `record_type`             | `string` | false    | `"A"`   | DNS record type to query. Accepted values: `"A"`, `"AAAA"`, `"any"` (see below).                                 |
+| `missing_key_placeholder` | `string` | false    | `"x"`   | Value substituted when a `{KEY}` placeholder cannot be resolved (see below).                                     |
+| `dns_server`              | `string` | false    | `""`    | Custom resolver address: `"8.8.8.8"`, `"8.8.8.8:5353"`, `"[::1]:5353"`. When empty, the system resolver is used. |
+| `dns_timeout`             | `int`    | false    | `5000`  | Timeout in milliseconds for custom resolver queries. Has no effect when `dns_server` is empty.                   |
+| `disable_after_errors`    | `int`    | false    | `3`     | Number of consecutive lookup failures before the sink is permanently disabled.                                   |
+
+## Template Substitution
+
+### Syntax
+
+Placeholders use the `{KEY_NAME}` format, consistent with how docker push
+tag templates work in Chalk (e.g. `tags: ["{BRANCH}-latest"]`). Key names
+are case-insensitive: `{exec_id}`, `{EXEC_ID}`, and `{Exec_Id}` all resolve
+to the same key.
+
+### Lookup order
+
+When a placeholder is encountered, the sink searches for the key in this order:
+
+1. Top-level report fields (host-level keys, e.g. `_OPERATION`, `_EXEC_ID`,
+   `_TIMESTAMP`).
+2. The first chalk mark in `_CHALKS[0]` (chalk-time keys, e.g. `METADATA_ID`,
+   `CHALK_ID`, `HASH`).
+
+Both sources are extracted by parsing the JSON report string passed to the
+sink output function. The report string is a JSON array `[ { ... } ]`
+containing a single object; the sink unwraps `[0]` before key lookup.
+
+### Missing and non-scalar keys
+
+If a key is not found in either source, or its value is an array or object
+(not a scalar), the placeholder is replaced with the value of
+`missing_key_placeholder` (default `"x"`). This guarantees that the rendered
+hostname is always syntactically valid — every label contains at least one
+valid character — regardless of what keys the template references or what data
+was collected for a particular operation.
+
+When a key is not found, the sink also emits a `warn`-level log message
+identifying the sink config name, the missing key, and the placeholder that
+was substituted. This makes misconfigured templates immediately visible in
+chalk's trace output without failing the lookup.
+
+**Design decision:** The hardcoded default `"x"` ensures a valid DNS label
+even when the user has not set `missing_key_placeholder`. An empty string
+would produce consecutive dots and an invalid hostname; raising an error would
+silently drop the report. Users who want a more recognizable sentinel (e.g.
+`"unknown"` or `"0"`) can set `missing_key_placeholder` explicitly.
+Users are expected to craft templates that only reference keys that will be
+collected for the operations they subscribe to; the placeholder is a safety
+valve, not an invitation to use arbitrary key names.
+
+### Hostname sanitization
+
+The sink does not perform additional sanitization beyond the `"x"` fallback.
+If a key value contains characters that are invalid in a DNS label (e.g.
+underscores in some strict resolver configurations), the resulting lookup
+will simply fail and count toward the error threshold. Users are responsible
+for selecting keys whose rendered values produce DNS-safe labels. Keys
+that are likely to contain only alphanumeric characters and hyphens (such
+as `METADATA_ID`, `CHALK_ID`, hash values, and ID-format strings) are the
+most reliable choices.
+
+## Template Substitution Engine
+
+Template substitution was previously only used for docker push tag rendering
+in `src/docker/util.nim`. To share the same `{KEY}` parser with the DNS sink
+(and any future sinks), the generic engine was extracted to
+`src/utils/substitutions.nim`.
+
+```nim
+proc applySubstitutions*(s: string, lookup: proc(key: string): string): string
+```
+
+The function takes a format string and a caller-supplied lookup callback. Each
+`{KEY}` token is extracted, uppercased, and passed to `lookup`; the return
+value is spliced into the result. Malformed brace sequences (e.g. `{{`, or `}`
+without a preceding `{`) raise `ValueError`.
+
+The docker tag wrapper in `src/docker/util.nim` remains unchanged for callers:
+
+```nim
+proc applySubstitutions*(s: string, chalk: ChalkObj): string =
+  s.applySubstitutions(proc(key: string): string = chalk.getChalkKey(key))
+```
+
+The DNS sink supplies its own callback that reads from parsed JSON instead of
+from a `ChalkObj`:
+
+```nim
+proc dnsSinkLookup(key: string, report: JsonNode, placeholder: string, cfgName: string): string
+```
+
+The `cfgName` parameter is the sink config name used in warning messages when
+a key is not found.
+
+**Design decision:** Making the callback the extension point (rather than, say,
+a method on an interface type) keeps the engine simple and avoids any object
+hierarchy. Nim closures capture the lookup context naturally.
+
+## DNS Lookup Mechanism
+
+All DNS logic lives in `src/utils/dns.nim`. The public API is a single
+procedure:
+
+```nim
+proc dnsLookup*(
+    domain:    string,
+    server:    string   = "",
+    qtype:     DnsQtype = DnsQtype.A,
+    timeoutMs: int      = 5000,
+)
+```
+
+`dnsLookup` validates and IDNA-encodes the hostname (see below), then
+dispatches to one of two backends depending on whether `server` is set.
+
+### System resolver (`server = ""`)
+
+When no custom server is configured, `dnsLookup` calls POSIX `getaddrinfo`.
+This is a blocking OS resolver call that respects `/etc/resolv.conf`,
+search domains, and the system's NDots setting. The response is freed
+immediately with `freeAddrInfo` and otherwise ignored.
+
+The `ai_family` hint passed to `getaddrinfo` is derived from `qtype`:
+
+| `record_type` | `DnsQtype`  | `ai_family` | Description                  |
+| ------------- | ----------- | ----------- | ---------------------------- |
+| `"A"`         | `A = 1`     | `AF_INET`   | IPv4 A record (default)      |
+| `"AAAA"`      | `AAAA = 28` | `AF_INET6`  | IPv6 AAAA record             |
+| `"any"`       | `ANY = 255` | `AF_UNSPEC` | Resolver chooses (A or AAAA) |
+
+**Design decision:** `getaddrinfo` is the lowest-level portable DNS resolution
+primitive in the standard library. It requires no socket management, no event
+loop, and no threads. Its limitation — the OS resolver timeout cannot be
+overridden — is acceptable when no custom server is configured, because the
+system resolver is typically local and fast.
+
+### Custom resolver (`server != ""`)
+
+When `dns_server` is set, `dnsLookup` sends a raw UDP DNS query (RFC 1035)
+directly to the specified address and port, bypassing the system resolver
+entirely. This allows targeting a specific recursive resolver not listed in
+`/etc/resolv.conf`, useful for directing beacons toward a controlled
+authoritative server.
+
+The query is a standard A/AAAA/ANY question with the Recursion Desired bit
+set. The response is read back and inspected only for the RCODE field
+(bits 0-3 of byte 3 of the header); a non-zero RCODE raises `IOError`. The
+response payload is otherwise discarded.
+
+A `select`-based timeout is applied before the `recvFrom` call. If no
+response arrives within `timeoutMs` milliseconds, `IOError` is raised with a
+`"timed out"` message, which the sink counts as a soft error toward the
+`disable_after_errors` threshold.
+
+### Server address parsing
+
+`dns_server` is parsed by `parseServerPort`, which accepts:
+
+- `"8.8.8.8"` — IPv4, default port 53
+- `"8.8.8.8:5353"` — IPv4 with explicit port
+- `"[::1]"` — bracketed IPv6, default port 53
+- `"[::1]:5353"` — bracketed IPv6 with explicit port
+- `"::1"` or `"2001:db8::1"` — bare IPv6 (brackets optional), default port 53
+
+Parsing delegates to Nim's `std/uri.parseUri("dns://" & server)`. Bare IPv6
+addresses are not valid URI syntax, so `parseUri` misparses them (splitting on
+the last `:` gives a truncated hostname and a non-numeric port fragment).
+This mismatch is detected by a round-trip check: if
+`hostname + ":" + port != server`, the parse was malformed and the whole string
+is used as the hostname with the default port.
+
+### Record type validation
+
+`record_type` is validated in the `sink_config_check` function in
+`chalk.c42spec`. Invalid values (e.g. `"CNAME"`, `"TXT"`) are rejected at
+config load time, before any DNS lookup is attempted:
+
+```c4m
+elif conffield == "record_type" {
+  v := attr_get(path + "." + conffield, string)
+  if not contains(["A", "AAAA", "any"], v) {
+    return (conffield + ": must be one of \"A\", \"AAAA\", or \"any\" (got: \"" + v + "\")")
+  }
+}
+```
+
+**Design decision:** Most authoritative DNS logging infrastructure is built
+around A record queries. `"A"` is the default because it is the most
+universally supported record type and the most common target for DNS-based
+telemetry pipelines. Record types that cannot be meaningfully sent as a query
+hostname (e.g. `CNAME`, `TXT`, `MX`) are excluded entirely rather than
+silently ignored at runtime.
+
+## Hostname Validation and IDNA Encoding
+
+Before any lookup is attempted, `dnsLookup` calls `toAsciiDomain`, which:
+
+1. Splits the hostname on `.`.
+2. For each label, checks whether it is pure ASCII. Non-ASCII labels are
+   Punycode-encoded (RFC 3492) and prefixed with `xn--` (IDNA 2003).
+3. Validates that each encoded label is at most 63 characters and the full
+   name is at most 253 characters (RFC 1035 wire-format limit minus the
+   root null byte).
+
+`ValueError` is raised before any socket is opened if the hostname is invalid.
+This means template rendering errors that produce an oversized label are caught
+early and counted as a lookup failure toward `disable_after_errors`.
+
+The Punycode encoder (`punycodeEncode` in `src/utils/dns.nim`) is implemented
+from scratch per RFC 3492, since Nim's standard library has no IDNA support.
+It is tested against all 18 reference strings from RFC 3492 Section 7.1.
+
+## Error Handling
+
+DNS lookup failures are treated as soft errors. They are counted in the
+shared `sinkConsecFailures` table (keyed by sink config name) using the same
+mechanism as the HTTP sinks. When consecutive failures reach the
+`disable_after_errors` threshold, the sink sets `cfg.enabled = false` and
+logs an error.
+
+**Design decision:** All DNS errors are soft (threshold-based) rather than
+distinguishing hard vs. soft as the HTTP sinks do. HTTP sinks classify 4xx
+responses as hard errors (immediate disable) because they indicate a
+configuration problem. DNS has no equivalent — a lookup failure could be
+transient (SERVFAIL, NXDOMAIN for a typo, network blip) or permanent (bad
+template rendering a malformed name), and there is no status code to
+distinguish them. The threshold approach ensures transient failures do not
+permanently disable the sink while repeated failures still trigger the
+disable.
+
+Successful lookups reset the counter via `resetSinkFailures(cfg)`, consistent
+with the other network sinks.
+
+## Interaction with Per-Chalk Reporting
+
+When `per_chalk_reports: true` is set on the `outconf` section (or
+`per_chalk: true` on a `custom_report` section), the reporting pipeline emits
+one report per chalk mark rather than one bundled report. Because the DNS
+sink's template substitution reads `_CHALKS[0]` from the incoming JSON report,
+per-chalk mode is the most natural fit: each emitted report contains exactly
+one chalk mark, so `_CHALKS[0]` always refers to the mark for the artifact
+currently being reported.
+
+Without per-chalk mode, `_CHALKS[0]` refers to the first chalk mark in a
+potentially multi-mark bundle. Keys from other marks in the same report are
+not accessible, so templates that reference chalk-time keys such as
+`METADATA_ID` will reflect only the first artifact's values regardless of how
+many were chalked.
+
+## Source Locations
+
+| Path                          | Role                                                                         |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `src/utils/dns.nim`           | `dnsLookup`, Punycode encoder, IDNA validation, server address parsing       |
+| `src/utils/substitutions.nim` | Generic `{KEY}` template engine; callback-based lookup                       |
+| `src/docker/util.nim`         | Thin `applySubstitutions(s, ChalkObj)` wrapper over the generic engine       |
+| `src/utils/sink_impls.nim`    | `dnsSinkOut`, `addDnsSink` — DNS sink output function and registration       |
+| `src/configs/base_sinks.c4m`  | `sink dns { ... }` — con4m schema for DNS sink parameters                    |
+| `src/configs/chalk.c42spec`   | `sink_config_check` — validation for `record_type` and `dns_timeout`         |
+| `src/sinks.nim`               | `getSinkConfigByName` — int param handling for `dns_timeout`                 |
+| `tests/unit/test_dns.nim`     | Unit tests: Punycode (RFC 3492 vectors), IDNA, server parsing, lookup errors |

--- a/src/attestation_api.nim
+++ b/src/attestation_api.nim
@@ -340,7 +340,7 @@ proc signBySigStore*(chalk: ChalkObj,
       annotations:  %*({
         "dev.sigstore.bundle.content":       "dsse-envelope",
         "dev.sigstore.bundle.predicateType": "https://sigstore.dev/cosign/sign/v1",
-        "org.opencontainers.image.created":  startTime.utc.format(timesIso8601Format),
+        "org.opencontainers.image.created":  opTime.utc.format(timesIso8601Format),
       }),
       config: DockerManifest(
         kind:         DockerManifestType.config,

--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -203,9 +203,10 @@ proc doHeartbeat(chalkOpt: Option[ChalkObj], pid: Pid, fn: (pid: Pid) -> bool) =
 
   while true:
     sleep(sleepInterval)
-    # reset stats which includes the startTime
+    # reset stats which includes the opTime
     # so that each heartbeat has accurate timestamp
     clearReportingState()
+    incHeartbeatCount()
     chalkOpt.doHeartbeatReport()
     if fn(pid):
       break

--- a/src/config.nim
+++ b/src/config.nim
@@ -110,6 +110,9 @@ proc getReportTemplate*(spec = ""): string =
   result = "report_template." & tmplName
   result.copyReportTemplateKeys()
 
+proc getPerChalkReports*(): bool =
+  attrGetOpt[bool](getOutputConfig() & ".per_chalk_reports").get(false)
+
 proc forceKeys(keynames: openArray[string], templateRef: string) =
   let section     = templateRef & ".key"
 

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -5498,6 +5498,67 @@ The value is a 64-bit (secure) random value, encoded as hex.
 """
 }
 
+keyspec _HEARTBEAT_COUNT {
+    kind:           RunTimeHost
+    type:           int
+    standard:       true
+    system:         true
+    conf_as_system: true
+    since:          "1.2.0"
+    shortdoc:       "Number of heartbeats emitted in this execution"
+    doc:            """
+Counter incremented by one on each periodic heartbeat report during a
+`chalk exec --heartbeat` run. The first heartbeat has `_HEARTBEAT_COUNT`
+of 1. Only present in heartbeat reports.
+"""
+}
+
+keyspec _MONOTIME {
+    kind:           RunTimeHost
+    type:           int
+    standard:       true
+    system:         true
+    conf_as_system: true
+    since:          "1.2.0"
+    shortdoc:       "Kernel monotonic clock at report time (ms since boot)"
+    doc:            """
+Milliseconds from the kernel monotonic clock at the time of this report.
+Unlike `_TIMESTAMP`, this clock never goes backwards and is unaffected
+by NTP or wall-clock adjustments. Use `_SINCE_MONOTIME` for elapsed time
+since process start; use this field to compare two reports from the same host.
+"""
+}
+
+keyspec _SINCE_TIMESTAMP {
+    kind:           RunTimeHost
+    type:           int
+    standard:       true
+    system:         true
+    conf_as_system: true
+    since:          "1.2.0"
+    shortdoc:       "Wall-clock milliseconds elapsed since process start"
+    doc:            """
+Milliseconds elapsed since the chalk process started, measured via the
+wall clock (`_TIMESTAMP` family). Resets to 0 at process launch; for
+heartbeat reports this grows monotonically across ticks.
+"""
+}
+
+keyspec _SINCE_MONOTIME {
+    kind:           RunTimeHost
+    type:           int
+    standard:       true
+    system:         true
+    conf_as_system: true
+    since:          "1.2.0"
+    shortdoc:       "Monotonic milliseconds elapsed since process start"
+    doc:            """
+Milliseconds elapsed since the chalk process started, measured via the
+kernel monotonic clock. Immune to NTP/wall-clock adjustments. Preferred
+over `_SINCE_TIMESTAMP` for measuring real elapsed time.
+"""
+}
+
 keyspec _ARGV {
     kind:           RunTimeHost
     type:           list[string]

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -52,7 +52,7 @@
 ##     the more basic per-op stuff such as "_CHALKS" and "ACTION_ID" I did not.
 
 ## CHALK SCHEMA
-chalk_version :=   "1.1.4-dev"
+chalk_version :=   "1.2.0-dev"
 ascii_magic   :=   "dadfedabbadabbed"
 
 # Field starting with an underscore (_) are "system" metadata fields, that

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -2168,7 +2168,7 @@ keyspec _ERR_INFO {
     type:             list[string]
     standard:         true
     system:           true
-    since:            "1.1.4"
+    since:            "1.2.0"
     normalized_order: high() - 500
     shortdoc:         "Errors collected during chalk time and post-build operations"
     doc:              """
@@ -2212,7 +2212,7 @@ keyspec _FAILED_KEYS {
   kind:     RunTimeArtifact
   type:     dict[string, list[`x]]
   standard: true
-  since:    "1.1.4"
+  since:    "1.2.0"
   shortdoc: "Keys and errors why chalk could not collect them (including post-build)"
   doc:      """
 This key reports all known errors and reasons why chalk could not

--- a/src/configs/base_plugins.c4m
+++ b/src/configs/base_plugins.c4m
@@ -44,7 +44,8 @@ plugin system {
                     "_OP_EXE_NAME", "_OP_EXE_PATH", "_OP_ARGV", "_OP_HOSTNAME",
                     "_OP_HOST_REPORT_KEYS", "_OP_UNMARKED_COUNT", "_TIMESTAMP",
                     "_DATE", "_TIME", "_TZ_OFFSET", "_DATETIME", "_ENV",
-                    "_EXEC_ID"]
+                    "_EXEC_ID", "_HEARTBEAT_COUNT",
+                    "_MONOTIME", "_SINCE_TIMESTAMP", "_SINCE_MONOTIME"]
 
   ~priority:       0
   doc: """

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -405,6 +405,7 @@ report and subtract from it.
   key._OPERATION.use                          = true
   key._OP_EXIT_CODE.use                       = true
   key._TIMESTAMP.use                          = true
+  key._MONOTIME.use                           = true
   key._DATE.use                               = true
   key._TIME.use                               = true
   key._TZ_OFFSET.use                          = true
@@ -594,6 +595,7 @@ doc: """
   key._OPERATION.use                          = true
   key._OP_EXIT_CODE.use                       = true
   key._TIMESTAMP.use                          = true
+  key._MONOTIME.use                           = true
   key._DATE.use                               = true
   key._TIME.use                               = true
   key._TZ_OFFSET.use                          = true
@@ -1182,6 +1184,7 @@ container.
   key._ENV.use                                = true
   key._OPERATION.use                          = true
   key._TIMESTAMP.use                          = true
+  key._MONOTIME.use                           = true
   key._DATE.use                               = false # Go with _DATETIME
   key._TIME.use                               = false
   key._TZ_OFFSET.use                          = false
@@ -1731,6 +1734,7 @@ and keep the run-time key.
   key._ENV.use                                = true
   key._OPERATION.use                          = true
   key._TIMESTAMP.use                          = true
+  key._MONOTIME.use                           = true
   key._DATE.use                               = false # Go with _DATETIME
   key._TIME.use                               = false
   key._TZ_OFFSET.use                          = false
@@ -2306,6 +2310,8 @@ running insert commands.
 """
   key._OPERATION.use                          = true
   key._DATETIME.use                           = true
+  key._TIMESTAMP.use                          = true
+  key._MONOTIME.use                           = true
   key._CHALKS.use                             = true
   key._COLLECTED_ARTIFACTS.use                = true
   key._OP_ARGV.use                            = true

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023, Crash Override, Inc.
+## Copyright (c) 2023-2026, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -283,6 +283,33 @@ The presign API can return these headers in the redirect response:
 
 This allows chalk to send reports to otherwise restricted endpoints
 such as AWS S3 without credentials baked into chalk.
+"""
+}
+
+sink dns {
+  ~domain_template:         true
+  ~record_type:             false
+  ~missing_key_placeholder: false
+  ~dns_server:              false
+  ~dns_timeout:             false
+  ~disable_after_errors:    false
+  shortdoc: "DNS lookup with a templated hostname"
+  doc:      """
+
+| Parameter                 | Type     | Required | Default  | Description                                                                             |
+|---------------------------|----------|----------|----------|-----------------------------------------------------------------------------------------|
+| `domain_template`         | `string` | true     | -        | Hostname template; `{KEY}` placeholders are replaced with values from the report.       |
+| `record_type`             | `string` | false    | `"A"`    | DNS record type: `"A"` (IPv4), `"AAAA"` (IPv6), or `"any"`. Validated at config load. |
+| `missing_key_placeholder` | `string` | false    | `"x"`    | Value used when a `{KEY}` placeholder cannot be resolved.                               |
+| `dns_server`              | `string` | false    | `""`     | Custom DNS resolver, e.g. `"8.8.8.8"`, `"8.8.8.8:5353"`, or `"[::1]:5353"`. When empty, the system resolver is used. |
+| `dns_timeout`             | `int`    | false    | `5000`   | Timeout for custom resolver queries in milliseconds. Requires `dns_server`.                            |
+| `disable_after_errors`    | `int`    | false    | `3`      | Consecutive lookup failures before the sink is disabled.                                |
+
+Emits one DNS lookup per report. The response is discarded; only the DNS
+query itself carries the payload. Keys from `_CHALKS[0]` and top-level
+report fields are available for substitution in `domain_template`.
+
+See `docs/design-dns-sink.md` for full design rationale.
 """
 }
 

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -303,7 +303,7 @@ sink dns {
 | `record_type`             | `string` | false    | `"A"`    | DNS record type: `"A"` (IPv4), `"AAAA"` (IPv6), or `"any"`. Validated at config load. |
 | `missing_key_placeholder` | `string` | false    | `"x"`    | Value used when a `{KEY}` placeholder cannot be resolved.                               |
 | `dns_server`              | `string` | false    | `""`     | Custom DNS resolver, e.g. `"8.8.8.8"`, `"8.8.8.8:5353"`, or `"[::1]:5353"`. When empty, the system resolver is used. |
-| `dns_timeout`             | `int`    | false    | `5000`   | Timeout for custom resolver queries in milliseconds. Requires `dns_server`.                            |
+| `dns_timeout`             | `int`    | false    | `5000`   | Timeout in milliseconds for custom resolver queries. Has no effect when `dns_server` is empty: the system resolver (`getaddrinfo`) does not support per-call timeouts. |
 | `disable_after_errors`    | `int`    | false    | `3`      | Consecutive lookup failures before the sink is disabled.                                |
 
 Emits one DNS lookup per report. The response is discarded; only the DNS

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -293,6 +293,7 @@ sink dns {
   ~dns_server:              false
   ~dns_timeout:             false
   ~disable_after_errors:    false
+  ~require_chalk_mark:      false
   shortdoc: "DNS lookup with a templated hostname"
   doc:      """
 

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -309,6 +309,25 @@ Emits one DNS lookup per report. The response is discarded; only the DNS
 query itself carries the payload. Keys from `_CHALKS[0]` and top-level
 report fields are available for substitution in `domain_template`.
 
+Use `normalize.KEYNAME.callback` subsections to transform key values before
+substitution. This is useful for keys whose string representation may exceed
+the 63-character DNS label limit:
+
+```con4m
+func trunc16(v: string) {
+  return slice(v, 0, 16)
+}
+
+sink_config my_dns {
+  sink:            "dns"
+  domain_template: "{_COMMIT_ID}.{METADATA_ID}.chalk.test"
+  dns_server:      "10.0.0.1"
+  normalize _COMMIT_ID {
+    callback: func trunc16
+  }
+}
+```
+
 See `docs/design-dns-sink.md` for full design rationale.
 """
 }

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -1542,6 +1542,17 @@ integrity check passes, even if this makes marks forgable.
 """
   }
 
+  field per_chalk_reports {
+    type:    bool
+    default: false
+    doc:     """
+When set to `true`, instead of emitting one report with all chalk marks
+bundled in `_CHALKS`, chalk emits one report per chalk mark with
+`_CHALKS` containing only that single mark. Host-level keys are repeated
+verbatim in each report.
+"""
+  }
+
   field doc {
     type:     string
     require:  false
@@ -1689,6 +1700,17 @@ That is, if the current chalk command is not in this list, then the
 report will NOT run.
 
 If not specified, reports apply to any command that reports.
+"""
+  }
+
+  field per_chalk {
+    type:    bool
+    default: false
+    doc:     """
+When set to `true`, instead of emitting one report with all chalk marks
+bundled in `_CHALKS`, chalk emits one report per chalk mark with
+`_CHALKS` containing only that single mark. Host-level keys are repeated
+verbatim in each report.
 """
   }
 

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -155,6 +155,43 @@ for multiple reports allows to de-duplicate SBOM data between builds.
   }
 }
 
+object normalize {
+  user_def_ok: true
+  doc: """
+Per-key normalization callbacks for sink output. Each subsection name is a
+chalk key name. The `callback` field receives the raw Box value of the key
+and its return value is converted to a string for substitution into sink
+templates such as a DNS `domain_template`.
+
+Example:
+
+```
+func trunc16(v: string) {
+  return slice(v, 0, 16)
+}
+
+sink_config my_dns {
+  sink:            "dns"
+  domain_template: "{_COMMIT_ID}.{METADATA_ID}.chalk.test"
+  normalize _COMMIT_ID {
+    callback: func trunc16
+  }
+}
+```
+"""
+
+  field callback {
+    type:    func (`x) -> `y
+    require: false
+    doc: """
+A function that receives the raw Box value of the key and returns a Box.
+The return value is stringified (via `$box`) for substitution into a sink
+template. Floats will include a decimal point; add a normalize callback to
+strip it if needed.
+"""
+  }
+}
+
 object mark_template {
   user_def_ok:   false
   doc: """
@@ -1032,6 +1069,8 @@ in this section are defined by the `sink` configuration named in this
 field.
 """
   }
+
+  allow normalize {}
 }
 
 object_store_types := ["", "presign"]

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023-2025, Crash Override, Inc.
+## Copyright (c) 2023-2026, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -4998,6 +4998,21 @@ func sink_config_check(path) {
       t := attr_type(path + "." + conffield)
       if not typecmp(t, list[string]) {
           return conffield + ": Field must be a list[string]"
+      }
+    }
+    elif conffield == "record_type" {
+      v := attr_get(path + "." + conffield, string)
+      if not contains(["A", "AAAA", "any"], v) {
+        return (conffield + ": must be one of \"A\", \"AAAA\", or \"any\" (got: \"" + v + "\")")
+      }
+    }
+    elif conffield == "dns_timeout" {
+      t := attr_type(path + "." + conffield)
+      if not typecmp(t, int) {
+        return conffield + ": This field must be a positive integer (milliseconds)"
+      }
+      if attr_get(path + "." + conffield, int) <= 0 {
+        return conffield + ": This field must be a positive integer (milliseconds)"
       }
     }
     elif not typecmp(attr_type(path + "." + conffield), string) {

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -5027,7 +5027,8 @@ func sink_config_check(path) {
           return conffield + ": This field must be a positive integer"
       }
     }
-    elif contains(["enabled", "use_search_path", "disallow_http", "prefer_bundled_certs"], conffield) {
+    elif contains(["enabled", "use_search_path", "disallow_http", "prefer_bundled_certs",
+                   "require_chalk_mark"], conffield) {
       t := attr_type(path + "." + conffield)
       if not typecmp(t, bool) {
           return conffield + ": Field must be `true` or `false`"

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -51,6 +51,7 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key._OPERATION.use                                 = true
   ~key._OP_EXIT_CODE.use                              = true
   ~key._TIMESTAMP.use                                 = true
+  ~key._MONOTIME.use                                  = true
   ~key._DATE.use                                      = false # Go with _DATETIME
   ~key._TIME.use                                      = false
   ~key._TZ_OFFSET.use                                 = false

--- a/src/docker/util.nim
+++ b/src/docker/util.nim
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023-2024, Crash Override, Inc.
+## Copyright (c) 2023-2026, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -14,6 +14,7 @@ import ".."/[
   types,
   utils/json,
   utils/strings,
+  utils/substitutions,
 ]
 
 proc isCI*(): bool =
@@ -158,28 +159,10 @@ proc getChalkKey*(chalk: ChalkObj, key: string): string =
 
   raise newException(KeyError, "key could not be collected")
 
-proc applySubstitutions*(s: string, chalk: ChalkObj): string =
-  var
-    key   = ""
-    inKey = false
-  for c in s:
-    if c == '{':
-      if inKey:
-        raise newException(ValueError, s & ": invalid format string. '{' is repeated without closing previous occurance")
-      inKey = true
-      key   = ""
-      continue
-    elif c == '}':
-      if not inKey:
-        raise newException(ValueError, s & ": invalid format string. '{' is occurring without matching '}'")
-      inKey = false
-      if key != "":
-        result &= chalk.getChalkKey(key.toUpperAscii())
-      continue
-    if inKey:
-      key.add(c)
-    else:
-      result.add(c)
+proc applySubstitutions(s: string, chalk: ChalkObj): string =
+  return s.applySubstitutions(
+    proc(key: string): string = chalk.getChalkKey(key),
+  )
 
 proc getValue*(secret: DockerSecret): string =
   if secret.src != "":

--- a/src/plugins/system.nim
+++ b/src/plugins/system.nim
@@ -221,6 +221,9 @@ proc sysGetRunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
       chalks += 1
   result.setIfNeeded("_OPERATION",            getBaseCommandName())
   result.setIfNeeded("_EXEC_ID",              execId)
+  let hbCount = getHeartbeatCount()
+  if hbCount > 0:
+    result.setIfNeeded("_HEARTBEAT_COUNT",    hbCount)
   result.setIfNeeded("_OP_CHALKER_VERSION",   getChalkExeVersion())
   result.setIfNeeded("_OP_PLATFORM",          getChalkPlatform())
   result.setIfNeeded("_OP_CHALKER_COMMIT_ID", getChalkCommitId())
@@ -231,11 +234,14 @@ proc sysGetRunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
   result.setIfNeeded("_OP_HOSTNAME",          getHostname())
   result.setIfNeeded("_OP_PUBLIC_IPV4_ADDR",  getMyIpV4Addr())
   result.setIfNeeded("_OP_UNMARKED_COUNT",    len(getUnmarked()))
-  result.setIfNeeded("_TIMESTAMP",            startTime.toUnixInMs())
-  result.setIfNeeded("_DATE",                 startTime.forReport().format(timesDateFormat))
-  result.setIfNeeded("_TIME",                 startTime.forReport().format(timesTimeFormat))
-  result.setIfNeeded("_TZ_OFFSET",            startTime.forReport().format(timesTzFormat))
-  result.setIfNeeded("_DATETIME",             startTime.forReport().format(timesIso8601Format))
+  result.setIfNeeded("_TIMESTAMP",            opTime.toUnixInMs())
+  result.setIfNeeded("_DATE",                 opTime.forReport().format(timesDateFormat))
+  result.setIfNeeded("_TIME",                 opTime.forReport().format(timesTimeFormat))
+  result.setIfNeeded("_TZ_OFFSET",            opTime.forReport().format(timesTzFormat))
+  result.setIfNeeded("_DATETIME",             opTime.forReport().format(timesIso8601Format))
+  result.setIfNeeded("_MONOTIME",             opMonoTime.toMs())
+  result.setIfNeeded("_SINCE_MONOTIME",       (opMonoTime - processMonoTime).inMilliseconds())
+  result.setIfNeeded("_SINCE_TIMESTAMP",      opTime.toUnixInMs() - processStartTime.toUnixInMs())
 
   if isSubscribedKey("_ENV"):
     result["_ENV"] = getEnvDict()
@@ -245,11 +251,11 @@ proc sysGetRunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
     result.setIfNeeded("_OP_HOST_REPORT_KEYS", reportKeys)
 
   when defined(posix):
-    result.setIfNeeded("_OP_HOST_SYSNAME", uinfo.sysname)
-    result.setIfNeeded("_OP_HOST_RELEASE", uinfo.release)
-    result.setIfNeeded("_OP_HOST_VERSION", uinfo.version)
-    result.setIfNeeded("_OP_HOST_NODENAME", uinfo.nodename)
-    result.setIfNeeded("_OP_HOST_MACHINE", uinfo.machine)
+    result.setIfNeeded("_OP_HOST_SYSNAME",    uinfo.sysname)
+    result.setIfNeeded("_OP_HOST_RELEASE",    uinfo.release)
+    result.setIfNeeded("_OP_HOST_VERSION",    uinfo.version)
+    result.setIfNeeded("_OP_HOST_NODENAME",   uinfo.nodename)
+    result.setIfNeeded("_OP_HOST_MACHINE",    uinfo.machine)
 
 proc sysGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
   result           = ChalkDict()
@@ -258,23 +264,23 @@ proc sysGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
   let pubKeyOpt = selfChalkGetKey("$CHALK_PUBLIC_KEY")
   if pubKeyOpt.isSome():
     result["INJECTOR_PUBLIC_KEY"] = pubKeyOpt.get()
-  result.setIfNeeded("INJECTOR_VERSION", getChalkExeVersion())
-  result.setIfNeeded("INJECTOR_COMMIT_ID", getChalkCommitId())
-  result.setIfNeeded("INJECTOR_ENV", getEnvDict())
-  result.setIfNeeded("DATE_CHALKED", startTime.forReport().format(timesDateFormat))
-  result.setIfNeeded("TIME_CHALKED", startTime.forReport().format(timesTimeFormat))
-  result.setIfNeeded("TZ_OFFSET_WHEN_CHALKED", startTime.forReport().format(timesTzFormat))
-  result.setIfNeeded("DATETIME_WHEN_CHALKED", startTime.forReport().format(timesIso8601Format))
-  result.setIfNeeded("TIMESTAMP_WHEN_CHALKED", startTime.toUnixInMs())
-  result.setIfNeeded("PLATFORM_WHEN_CHALKED", getChalkPlatform())
+  result.setIfNeeded("INJECTOR_VERSION",              getChalkExeVersion())
+  result.setIfNeeded("INJECTOR_COMMIT_ID",            getChalkCommitId())
+  result.setIfNeeded("INJECTOR_ENV",                  getEnvDict())
+  result.setIfNeeded("DATE_CHALKED",                  opTime.forReport().format(timesDateFormat))
+  result.setIfNeeded("TIME_CHALKED",                  opTime.forReport().format(timesTimeFormat))
+  result.setIfNeeded("TZ_OFFSET_WHEN_CHALKED",        opTime.forReport().format(timesTzFormat))
+  result.setIfNeeded("DATETIME_WHEN_CHALKED",         opTime.forReport().format(timesIso8601Format))
+  result.setIfNeeded("TIMESTAMP_WHEN_CHALKED",        opTime.toUnixInMs())
+  result.setIfNeeded("PLATFORM_WHEN_CHALKED",         getChalkPlatform())
   result.setIfNeeded("PUBLIC_IPV4_ADDR_WHEN_CHALKED", getMyIpV4Addr())
 
   when defined(posix):
-    result.setIfNeeded("HOST_SYSNAME_WHEN_CHALKED", uinfo.sysname)
-    result.setIfNeeded("HOST_RELEASE_WHEN_CHALKED", uinfo.release)
-    result.setIfNeeded("HOST_VERSION_WHEN_CHALKED", uinfo.version)
-    result.setIfNeeded("HOST_NODENAME_WHEN_CHALKED", uinfo.nodename)
-    result.setIfNeeded("HOST_MACHINE_WHEN_CHALKED", uinfo.machine)
+    result.setIfNeeded("HOST_SYSNAME_WHEN_CHALKED",   uinfo.sysname)
+    result.setIfNeeded("HOST_RELEASE_WHEN_CHALKED",   uinfo.release)
+    result.setIfNeeded("HOST_VERSION_WHEN_CHALKED",   uinfo.version)
+    result.setIfNeeded("HOST_NODENAME_WHEN_CHALKED",  uinfo.nodename)
+    result.setIfNeeded("HOST_MACHINE_WHEN_CHALKED",   uinfo.machine)
 
   if isSubscribedKey("INJECTOR_CHALK_ID") and selfChalk != nil:
     result.setIfNeeded("INJECTOR_CHALK_ID", selfChalk.callGetChalkId())
@@ -325,7 +331,7 @@ proc metsysGetRunTimeHostInfo(self: Plugin, objs: seq[ChalkObj]):
   if isSubscribedKey("_CHALK_RUN_TIME"):
     let
       monoEndTime = getMonoTime()
-      diff        = monoEndTime - monoStartTime
+      diff        = monoEndTime - opMonoTime
       inMs        = diff.inMilliseconds()
     result["_CHALK_RUN_TIME"] = pack(inMs)
 

--- a/src/reporting.nim
+++ b/src/reporting.nim
@@ -76,43 +76,50 @@ proc setPerChalkReports(tmpl: string, key: string, chalks: seq[ChalkObj]) =
   elif key in hostInfo:
     hostInfo.del(key)
 
-proc setPerChalkReports(tmpl: string) =
-  ## Adds the `_CHALKS` key in the `hostinfo` global to the current
-  ## collection context with whatever items were requested in the
-  ## reporting template passed.
+proc buildHostReport*(tmpl: string): string =
   setPerChalkReports(tmpl, "_CHALKS",              getAllChalks())
   setPerChalkReports(tmpl, "_COLLECTED_ARTIFACTS", getAllArtifacts())
-
-proc buildHostReport*(tmpl: string): string =
-  setPerChalkReports(tmpl)
   return objectifyByTemplate(
     hostInfo.filterByTemplate(tmpl),
     objectsData,
     tmpl,
   ).toJson(tmpl)
 
-proc doCommandReport(): string =
+proc buildHostReportForChalk(chalk: ChalkObj, tmpl: string): string =
+  setPerChalkReports(tmpl, "_CHALKS",              @[chalk])
+  setPerChalkReports(tmpl, "_COLLECTED_ARTIFACTS", getAllArtifacts())
+  return objectifyByTemplate(
+    hostInfo.filterByTemplate(tmpl),
+    objectsData,
+    tmpl,
+  ).toJson(tmpl)
+
+proc doCommandReport(topic: string) =
   let
     unmarked       = getUnmarked()
     reportTemplate = getReportTemplate()
-    # The above goes from the string name to the object.
 
-  if attrGet[bool]("skip_command_report"):
-    info("Skipping the command report as per the `skip_command_report` directive")
-    result = ""
+  trace(reportTemplate & ": Generating command report.")
+  if len(unmarked) != 0:
+    hostInfo["_UNMARKED"] = pack(unmarked)
+
+  if getPerChalkReports():
+    for chalk in getAllChalks():
+      let report = buildHostReportForChalk(chalk, reportTemplate)
+      if report != "":
+        safePublish(topic, report)
   else:
-    trace(reportTemplate & ": Generating command report.")
-    if len(unmarked) != 0:
-      hostInfo["_UNMARKED"] = pack(unmarked)
-
-    result = buildHostReport(reportTemplate)
+    let report = buildHostReport(reportTemplate)
+    if report != "":
+      safePublish(topic, report)
 
 proc doEmbeddedReport(): Box =
   let
     unmarked       = getUnmarked()
     reportTemplate = getReportTemplate()
 
-  setPerChalkReports(reportTemplate)
+  setPerChalkReports(reportTemplate, "_CHALKS",              getAllChalks())
+  setPerChalkReports(reportTemplate, "_COLLECTED_ARTIFACTS", getAllArtifacts())
 
   if len(unmarked) != 0:
     hostInfo["_UNMARKED"] = pack(unmarked)
@@ -155,7 +162,16 @@ proc doCustomReporting() =
         warn("Report '" & topic & "' sink config is invalid. Skipping.")
 
     trace(topic & ": generating custom report")
-    safePublish(topic, buildHostReport(templateToUse))
+    let perChalk = attrGetOpt[bool](spec & ".per_chalk").get(false)
+    if perChalk:
+      for chalk in getAllChalks():
+        let report = buildHostReportForChalk(chalk, templateToUse)
+        if report != "":
+          safePublish(topic, report)
+    else:
+      let report = buildHostReport(templateToUse)
+      if report != "":
+        safePublish(topic, report)
 
 proc doReporting*(topic="report", clearState = false) {.exportc, cdecl.} =
   if inSubscan():
@@ -168,9 +184,10 @@ proc doReporting*(topic="report", clearState = false) {.exportc, cdecl.} =
     if skipCommand and skipCustom:
       return
     collectRunTimeHostInfo()
-    let report = doCommandReport()
-    if report != "":
-      safePublish(topic, report)
+    if skipCommand:
+      info("Skipping the command report as per the `skip_command_report` directive")
+    else:
+      doCommandReport(topic)
     if not skipCustom:
       doCustomReporting()
     writeReportCache()

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -26,6 +26,12 @@ import "."/[
 
 var ctxStack = @[CollectionCtx()]
 
+proc incHeartbeatCount*() =
+  ctxStack[0].heartbeatCount += 1
+
+proc getHeartbeatCount*(): int =
+  ctxStack[0].heartbeatCount
+
 # This is for when we're doing a `conf load`.  We force silence, turning off
 # all logging of merit.
 proc startTestRun*() =
@@ -69,9 +75,11 @@ proc inSubscan*(): bool =
   return len(ctxStack) > 1
 
 proc clearReportingState*() =
-  startTime       = getTime().utc
-  monoStartTime   = getMonoTime()
+  opTime     = getTime().utc
+  opMonoTime = getMonoTime()
+  let savedHeartbeatCount = ctxStack[0].heartbeatCount
   ctxStack        = @[CollectionCtx()]
+  ctxStack[0].heartbeatCount = savedHeartbeatCount
   hostInfo        = ChalkDict()
   objectsData     = ObjectsDict()
   subscribedKeys  = Table[string, bool]()

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -320,7 +320,7 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
       discard setOverride(getChalkScope(), section & ".pinned_cert_file", some(pack(path)))
       # Can't delete from a dict while we're iterating over it.
       deleteList.add(k)
-    of "on_write_msg":
+    of "on_write_msg", "normalize":
       discard
     of "log_search_path":
       let boxOpt = attrGetOpt[Box](section & "." & k)

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -306,7 +306,8 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
       sinkName    = attrGetOpt[string](section & "." & k).getOrElse("")
     of "auth":
       authName    = attrGetOpt[string](section & "." & k).getOrElse("")
-    of "use_search_path", "disallow_http", "prefer_bundled_certs":
+    of "use_search_path", "disallow_http", "prefer_bundled_certs",
+       "require_chalk_mark":
       let boxOpt = attrGetOpt[Box](section & "." & k)
       if boxOpt.isSome():
         if boxOpt.get().kind != MkBool:

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023-2025, Crash Override, Inc.
+## Copyright (c) 2023-2026, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -351,7 +351,7 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
         else:
           # Nimutils wants this param as a string.
           opts[k] = $(unpack[int](boxOpt.get()))
-    of "disable_after_errors":
+    of "disable_after_errors", "dns_timeout":
       let boxOpt = attrGetOpt[Box](section & "." & k)
       if boxOpt.isSome():
         if boxOpt.get().kind != MkInt or unpack[int](boxOpt.get()) <= 0:

--- a/src/types.nim
+++ b/src/types.nim
@@ -215,6 +215,7 @@ type
     args*:                     seq[string]
     contextDirectories*:       seq[string]
     baseChalk*:                ChalkObj
+    heartbeatCount*:           int
 
   ArtifactIterationInfo* = ref object
     filePaths*:       seq[string]

--- a/src/utils/dns.nim
+++ b/src/utils/dns.nim
@@ -18,6 +18,7 @@ import std/[
   uri,
 ]
 import pkg/nimutils/[
+  logging,
   random,
 ]
 
@@ -284,6 +285,8 @@ proc dnsLookup*(
   ## When `server` is empty the system resolver is used (via getaddrinfo).
   ## `server` may include a port: "8.8.8.8:5353" or "[::1]:5353".
   let ascii = toAsciiDomain(domain)
+  let srv   = if server == "": "system resolver" else: server
+  trace("dns: " & ascii & " via " & srv)
   if server == "":
     dnsLookupSystem(ascii, qtype)
     return

--- a/src/utils/dns.nim
+++ b/src/utils/dns.nim
@@ -9,11 +9,16 @@
 ## Supports a configurable resolver address, which getaddrinfo does not.
 
 import std/[
+  monotimes,
   net,
   nativesockets,
   posix,
   strutils,
+  times,
   uri,
+]
+import pkg/nimutils/[
+  random,
 ]
 
 type DnsQtype* = enum
@@ -185,8 +190,6 @@ proc parseServerPort*(server: string): (string, Port) =
 # DNS wire format
 # ---------------------------------------------------------------------------
 
-var dnsQueryId {.global.}: uint16 = 0
-
 proc addUint16(s: var string, v: uint16) =
   s.add(char(v shr 8))
   s.add(char(v and 0xff))
@@ -214,6 +217,44 @@ proc buildDnsQuery(domain: string, qtype: DnsQtype, id: uint16): string =
 # ---------------------------------------------------------------------------
 # Resolver
 # ---------------------------------------------------------------------------
+
+proc connectUdpSocket(host: string, port: Port): Socket =
+  # Determine socket family without a resolver call when host is a literal IP.
+  # For hostnames, call getaddrinfo for family detection only, then free the
+  # result before creating the socket to avoid any lifetime issues.
+  let family =
+    try:
+      if parseIpAddress(host).family == IpAddressFamily.IPv6:
+        Domain.AF_INET6
+      else:
+        Domain.AF_INET
+    except ValueError:
+      var
+        hints: AddrInfo
+        res:   ptr AddrInfo
+      hints.ai_socktype = cint(SockType.SOCK_DGRAM)
+      let gaiRet = getaddrinfo(host.cstring, nil, addr hints, res)
+      if gaiRet != 0 or res == nil:
+        if res != nil:
+          freeAddrInfo(res)
+        raise newException(
+          IOError,
+          "DNS: cannot resolve server '" & host & "'",
+        )
+      let f =
+        if res.ai_family == posix.AF_INET6:
+          Domain.AF_INET6
+        else:
+          Domain.AF_INET
+      freeAddrInfo(res)
+      f
+  result = newSocket(
+    domain   = family,
+    sockType = SockType.SOCK_DGRAM,
+    protocol = Protocol.IPPROTO_UDP,
+    buffered = false,
+  )
+  result.connect(host, port)
 
 proc dnsLookupSystem(domain: string, qtype: DnsQtype) =
   var hints: AddrInfo
@@ -244,40 +285,48 @@ proc dnsLookup*(
     return
 
   let
+    id           = secureRand[uint16]()
     (host, port) = parseServerPort(server)
-    packet       = buildDnsQuery(ascii, qtype, dnsQueryId)
-    sock         = newSocket(
-      domain   = Domain.AF_INET,
-      sockType = SockType.SOCK_DGRAM,
-      protocol = Protocol.IPPROTO_UDP,
-      buffered = false,
-    )
-  inc dnsQueryId
+    packet       = buildDnsQuery(ascii, qtype, id)
+
+  # connect() on a UDP socket installs a kernel-level filter: only datagrams
+  # from this address/port are delivered.
+  let sock = connectUdpSocket(host, port)
   defer: sock.close()
 
-  sock.sendTo(host, port, packet)
+  discard posix.send(
+    sock.getFd(),
+    cast[pointer](unsafeAddr packet[0]),
+    packet.len,
+    cint(0),
+  )
 
-  var fds = @[sock.getFd()]
-  if selectRead(fds, timeoutMs) == 0:
-    raise newException(
-      IOError,
-      "DNS query timed out for '" & ascii & "'",
-    )
-
-  var
-    response = newString(512)
-    fromAddr: string
-    fromPort: Port
-  let n = sock.recvFrom(response, 512, fromAddr, fromPort)
-  if n < 4:
-    raise newException(
-      IOError,
-      "DNS response truncated for '" & ascii & "'",
-    )
-
-  let rcode = uint8(response[3]) and 0x0f
-  if rcode != 0:
-    raise newException(
-      IOError,
-      "DNS lookup failed for '" & ascii & "' (rcode=" & $rcode & ")",
-    )
+  # Loop discarding datagrams that do not match our transaction ID.
+  let deadline = getMonoTime() + initDuration(milliseconds = timeoutMs)
+  while true:
+    let remaining = int(inMilliseconds(deadline - getMonoTime()))
+    if remaining <= 0:
+      raise newException(
+        IOError,
+        "DNS query timed out for '" & ascii & "'",
+      )
+    var fds = @[sock.getFd()]
+    if selectRead(fds, remaining) == 0:
+      raise newException(
+        IOError,
+        "DNS query timed out for '" & ascii & "'",
+      )
+    var response = newString(512)
+    let n = sock.recv(response, 512)
+    if n < 4:
+      continue
+    if uint8(response[0]) != uint8(id shr 8) or
+       uint8(response[1]) != uint8(id and 0xff):
+      continue
+    let rcode = uint8(response[3]) and 0x0f
+    if rcode != 0:
+      raise newException(
+        IOError,
+        "DNS lookup failed for '" & ascii & "' (rcode=" & $rcode & ")",
+      )
+    break

--- a/src/utils/dns.nim
+++ b/src/utils/dns.nim
@@ -312,7 +312,8 @@ proc dnsLookup*(
     cint(0),
   )
 
-  # Loop discarding datagrams that do not match our transaction ID.
+  # Loop discarding datagrams that do not match our transaction ID or are not
+  # responses (QR=1, RFC 1035 §4.1.1).
   let deadline = getMonoTime() + initDuration(milliseconds = timeoutMs)
   while true:
     let remaining = int(inMilliseconds(deadline - getMonoTime()))
@@ -333,6 +334,8 @@ proc dnsLookup*(
       continue
     if uint8(response[0]) != uint8(id shr 8) or
        uint8(response[1]) != uint8(id and 0xff):
+      continue
+    if (uint8(response[2]) and 0x80) == 0:
       continue
     let rcode = uint8(response[3]) and 0x0f
     if rcode != 0:

--- a/src/utils/dns.nim
+++ b/src/utils/dns.nim
@@ -240,11 +240,12 @@ proc connectUdpSocket(host: string, port: Port): Socket =
       hints.ai_socktype = cint(SockType.SOCK_DGRAM)
       let gaiRet = getaddrinfo(host.cstring, nil, addr hints, res)
       if gaiRet != 0 or res == nil:
+        let reason = if gaiRet != 0: ": " & $gai_strerror(gaiRet) else: ""
         if res != nil:
           freeAddrInfo(res)
         raise newException(
           IOError,
-          "DNS: cannot resolve server '" & host & "'",
+          "DNS: cannot resolve server '" & host & "'" & reason,
         )
       let f =
         if res.ai_family == posix.AF_INET6:
@@ -272,7 +273,10 @@ proc dnsLookupSystem(domain: string, qtype: DnsQtype) =
   if res != nil:
     freeAddrInfo(res)
   if ret != 0:
-    raise newException(IOError, "DNS lookup failed for '" & domain & "'")
+    raise newException(
+      IOError,
+      "DNS lookup failed for '" & domain & "': " & $gai_strerror(ret),
+    )
 
 proc dnsLookup*(
     domain:    string,

--- a/src/utils/dns.nim
+++ b/src/utils/dns.nim
@@ -1,0 +1,283 @@
+##
+## Copyright (c) 2023-2026, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+## Minimal DNS A/AAAA query client (RFC 1035) with Punycode/IDNA support.
+## Supports a configurable resolver address, which getaddrinfo does not.
+
+import std/[
+  net,
+  nativesockets,
+  posix,
+  strutils,
+  uri,
+]
+
+type DnsQtype* = enum
+  A    = 1
+  AAAA = 28
+  ANY  = 255
+
+# ---------------------------------------------------------------------------
+# Punycode (RFC 3492)
+# ---------------------------------------------------------------------------
+
+const
+  punBase     = 36
+  punTmin     = 1
+  punTmax     = 26
+  punSkew     = 38
+  punDamp     = 700
+  punInitBias = 72
+  punInitN    = 128
+
+proc punDigit(d: int): char =
+  if d < 26: char(ord('a') + d)
+  else:      char(ord('0') + d - 26)
+
+proc punAdapt(delta, numPoints: int, first: bool): int =
+  var d = if first: delta div punDamp else: delta div 2
+  d += d div numPoints
+  var k = 0
+  while d > (punBase - punTmin) * punTmax div 2:
+    d  = d div (punBase - punTmin)
+    k += punBase
+  k + (punBase - punTmin + 1) * d div (d + punSkew)
+
+proc utf8Codepoints(s: string): seq[int] =
+  var i = 0
+  while i < s.len:
+    let b = uint8(s[i])
+    let (cp, w) =
+      if   b < 0x80: (int(b),                                      1)
+      elif b < 0xE0: (((int(b) and 0x1F) shl 6) or
+                       (int(uint8(s[i+1])) and 0x3F),               2)
+      elif b < 0xF0: (((int(b) and 0x0F) shl 12) or
+                       ((int(uint8(s[i+1])) and 0x3F) shl 6) or
+                       (int(uint8(s[i+2])) and 0x3F),               3)
+      else:          (((int(b) and 0x07) shl 18) or
+                       ((int(uint8(s[i+1])) and 0x3F) shl 12) or
+                       ((int(uint8(s[i+2])) and 0x3F) shl 6) or
+                       (int(uint8(s[i+3])) and 0x3F),               4)
+    result.add(cp)
+    i += w
+
+proc punycodeEncode*(s: string): string =
+  ## Encodes a Unicode string to Punycode (RFC 3492), without the xn-- prefix.
+  let input = utf8Codepoints(s)
+
+  var basic = 0
+  for cp in input:
+    if cp < 0x80:
+      result.add(char(cp))
+      basic += 1
+  if basic > 0:
+    result.add('-')
+
+  var
+    n     = punInitN
+    delta = 0
+    bias  = punInitBias
+    h     = basic
+    b     = basic
+
+  while h < input.len:
+    var m = int.high
+    for cp in input:
+      if cp >= n and cp < m:
+        m = cp
+
+    delta += (m - n) * (h + 1)
+    n = m
+
+    for cp in input:
+      if cp < n:
+        delta += 1
+      elif cp == n:
+        var q = delta
+        var k = punBase
+        while true:
+          let t =
+            if k <= bias + punTmin: punTmin
+            elif k >= bias + punTmax: punTmax
+            else: k - bias
+          if q < t:
+            break
+          result.add(punDigit(t + (q - t) mod (punBase - t)))
+          q = (q - t) div (punBase - t)
+          k += punBase
+        result.add(punDigit(q))
+        bias = punAdapt(delta, h + 1, h == b)
+        delta = 0
+        h += 1
+
+    delta += 1
+    n += 1
+
+# ---------------------------------------------------------------------------
+# Hostname validation and IDNA encoding
+# ---------------------------------------------------------------------------
+
+proc toAsciiDomain*(domain: string): string =
+  ## Converts `domain` to ASCII-compatible encoding (IDNA-lite).
+  ## Labels with non-ASCII characters are Punycode-encoded with an xn-- prefix.
+  ## Raises ValueError if any label exceeds 63 chars or the full name exceeds
+  ## 253 chars (= 255 bytes in DNS wire format: each label has a length prefix
+  ## byte plus content, and the name is terminated by a null byte).
+  var labels: seq[string]
+  for label in domain.split('.'):
+    if label.len == 0:
+      labels.add("")
+      continue
+    var ascii = true
+    for c in label:
+      if ord(c) > 127:
+        ascii = false
+        break
+    let encoded = if ascii: label
+                  else:     "xn--" & punycodeEncode(label)
+    if encoded.len > 63:
+      raise newException(
+        ValueError,
+        "DNS label '" & encoded & "' exceeds 63-character limit",
+      )
+    labels.add(encoded)
+  result = labels.join(".")
+  if result.len > 253:
+    raise newException(
+      ValueError,
+      "DNS hostname exceeds 253-character limit (got " & $result.len & ")",
+    )
+
+# ---------------------------------------------------------------------------
+# Server address / port parsing
+# ---------------------------------------------------------------------------
+
+proc tryPort(s: string): int =
+  try:
+    let p = parseInt(s)
+    if p in 1 .. 65535: p else: -1
+  except ValueError:
+    -1
+
+proc parseServerPort*(server: string): (string, Port) =
+  ## Parses "host[:port]". Accepts IPv4 ("1.2.3.4:5353"), plain IPv4 ("1.2.3.4"),
+  ## bracketed IPv6 ("[::1]:5353" or "[::1]"), and bare IPv6 ("::1").
+  ## Returns (host, port); default port is 53.
+  const defaultPort = Port(53)
+  let parsed = parseUri("dns://" & server)
+  if not server.startsWith('['):
+    # parseUri misparses bare IPv6 by splitting on the last ':':
+    #   "::1"         -> hostname="",     port="1"    (empty hostname)
+    #   "2001:db8::1" -> hostname="2001", port="db81" (reconstructs to "2001:db81" != server)
+    # Detect by round-tripping: if hostname[:port] doesn't reconstruct server, it's a misparse.
+    let roundtrip = if parsed.port == "": parsed.hostname
+                    else: parsed.hostname & ":" & parsed.port
+    if parsed.hostname == "" or roundtrip != server:
+      return (server, defaultPort)
+  let p = tryPort(parsed.port)
+  return (parsed.hostname, if p > 0: Port(p) else: defaultPort)
+
+# ---------------------------------------------------------------------------
+# DNS wire format
+# ---------------------------------------------------------------------------
+
+var dnsQueryId {.global.}: uint16 = 0
+
+proc addUint16(s: var string, v: uint16) =
+  s.add(char(v shr 8))
+  s.add(char(v and 0xff))
+
+proc encodeDnsName(domain: string): string =
+  for label in domain.split('.'):
+    if label.len == 0:
+      continue
+    result.add(char(label.len))
+    result.add(label)
+  result.add('\x00')
+
+proc buildDnsQuery(domain: string, qtype: DnsQtype, id: uint16): string =
+  result = newStringOfCap(64)
+  result.addUint16(id)
+  result.addUint16(0x0100)  # flags: RD=1
+  result.addUint16(1)       # QDCOUNT
+  result.addUint16(0)       # ANCOUNT
+  result.addUint16(0)       # NSCOUNT
+  result.addUint16(0)       # ARCOUNT
+  result.add(encodeDnsName(domain))
+  result.addUint16(uint16(qtype))
+  result.addUint16(1)       # QCLASS = IN
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+proc dnsLookupSystem(domain: string, qtype: DnsQtype) =
+  var hints: AddrInfo
+  hints.ai_family = case qtype
+                    of DnsQtype.AAAA: posix.AF_INET6.cint
+                    of DnsQtype.ANY:  posix.AF_UNSPEC.cint
+                    else:             posix.AF_INET.cint
+  var res: ptr AddrInfo
+  let ret = getaddrinfo(domain.cstring, nil, addr hints, res)
+  if res != nil:
+    freeAddrInfo(res)
+  if ret != 0:
+    raise newException(IOError, "DNS lookup failed for '" & domain & "'")
+
+proc dnsLookup*(
+    domain:    string,
+    server:    string   = "",
+    qtype:     DnsQtype = DnsQtype.A,
+    timeoutMs: int      = 5000,
+) =
+  ## Resolves `domain` via DNS, raising ValueError on an invalid hostname or
+  ## IOError on lookup failure / timeout.
+  ## When `server` is empty the system resolver is used (via getaddrinfo).
+  ## `server` may include a port: "8.8.8.8:5353" or "[::1]:5353".
+  let ascii = toAsciiDomain(domain)
+  if server == "":
+    dnsLookupSystem(ascii, qtype)
+    return
+
+  let
+    (host, port) = parseServerPort(server)
+    packet       = buildDnsQuery(ascii, qtype, dnsQueryId)
+    sock         = newSocket(
+      domain   = Domain.AF_INET,
+      sockType = SockType.SOCK_DGRAM,
+      protocol = Protocol.IPPROTO_UDP,
+      buffered = false,
+    )
+  inc dnsQueryId
+  defer: sock.close()
+
+  sock.sendTo(host, port, packet)
+
+  var fds = @[sock.getFd()]
+  if selectRead(fds, timeoutMs) == 0:
+    raise newException(
+      IOError,
+      "DNS query timed out for '" & ascii & "'",
+    )
+
+  var
+    response = newString(512)
+    fromAddr: string
+    fromPort: Port
+  let n = sock.recvFrom(response, 512, fromAddr, fromPort)
+  if n < 4:
+    raise newException(
+      IOError,
+      "DNS response truncated for '" & ascii & "'",
+    )
+
+  let rcode = uint8(response[3]) and 0x0f
+  if rcode != 0:
+    raise newException(
+      IOError,
+      "DNS lookup failed for '" & ascii & "' (rcode=" & $rcode & ")",
+    )

--- a/src/utils/dns.nim
+++ b/src/utils/dns.nim
@@ -171,16 +171,18 @@ proc tryPort(s: string): int =
     -1
 
 proc parseServerPort*(server: string): (string, Port) =
-  ## Parses "host[:port]". Accepts IPv4 ("1.2.3.4:5353"), plain IPv4 ("1.2.3.4"),
-  ## bracketed IPv6 ("[::1]:5353" or "[::1]"), and bare IPv6 ("::1").
-  ## Returns (host, port); default port is 53.
+  ## Parses "host[:port]", returning (host, port). Default port is 53.
+  ## Accepted formats: "1.2.3.4", "1.2.3.4:5353", "[::1]", "[::1]:5353", "::1".
   const defaultPort = Port(53)
   let parsed = parseUri("dns://" & server)
   if not server.startsWith('['):
-    # parseUri misparses bare IPv6 by splitting on the last ':':
-    #   "::1"         -> hostname="",     port="1"    (empty hostname)
-    #   "2001:db8::1" -> hostname="2001", port="db81" (reconstructs to "2001:db81" != server)
-    # Detect by round-tripping: if hostname[:port] doesn't reconstruct server, it's a misparse.
+    # Bracketed IPv6 is valid URI syntax, so parseUri handles it correctly.
+    # Bare IPv6 is not: parseUri splits on the last ':', yielding a truncated
+    # hostname and a non-numeric port fragment:
+    #   "::1"         -> hostname="",     port="1"
+    #   "2001:db8::1" -> hostname="2001", port="db81"
+    # Detect the mismatch by round-tripping: reconstruct what parseUri saw and
+    # compare to the original input; inequality means it was a bare IPv6.
     let roundtrip = if parsed.port == "": parsed.hostname
                     else: parsed.hostname & ":" & parsed.port
     if parsed.hostname == "" or roundtrip != server:

--- a/src/utils/dns.nim
+++ b/src/utils/dns.nim
@@ -135,8 +135,10 @@ proc toAsciiDomain*(domain: string): string =
   var labels: seq[string]
   for label in domain.split('.'):
     if label.len == 0:
-      labels.add("")
-      continue
+      raise newException(
+        ValueError,
+        "DNS hostname contains an empty label (check for adjacent or trailing dots)",
+      )
     var ascii = true
     for c in label:
       if ord(c) > 127:

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023-2025, Crash Override, Inc.
+## Copyright (c) 2023-2026, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)
@@ -17,6 +17,7 @@
 ## ever called.
 
 import std/[
+  json,
   streams,
   tables,
   options,
@@ -41,7 +42,10 @@ import ".."/[
   types,
 ]
 import "."/[
+  dns,
   http,
+  json,
+  substitutions,
 ]
 
 const defaultLogSearchPath = @["/var/log/", "~/.log/", "."]
@@ -610,6 +614,80 @@ proc addPresignSink*() =
 
   registerSink("presign", record)
 
+proc dnsSinkScalar(node: JsonNode, placeholder: string): string =
+  case node.kind
+  of JString: return node.getStr()
+  of JInt:    return $node.getInt()
+  of JFloat:  return $node.getFloat()
+  of JBool:   return $node.getBool()
+  else:       return placeholder
+
+proc dnsSinkLookup(key: string, report: JsonNode, placeholder: string, cfgName: string): string =
+  if report.hasKey(key):
+    return dnsSinkScalar(report[key], placeholder)
+  if report.hasKey("_CHALKS"):
+    try:
+      let chalk = report["_CHALKS"].assertIs(JArray).assertHasLen()[0].assertIs(JObject)
+      if chalk.hasKey(key):
+        return dnsSinkScalar(chalk[key], placeholder)
+    except:
+      dumpExOnDebug()
+  warn("dns sink '" & cfgName & "': key '" & key & "' not found; using placeholder '" & placeholder & "'")
+  return placeholder
+
+proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
+  let
+    tmpl        = cfg.params.getOrDefault("domain_template", "")
+    placeholder = cfg.params.getOrDefault("missing_key_placeholder", "x")
+    recordType  = cfg.params.getOrDefault("record_type", "A")
+    dnsServer   = cfg.params.getOrDefault("dns_server", "")
+    timeoutMs   = parseInt(cfg.params.getOrDefault("dns_timeout", "5000"))
+
+  var report: JsonNode
+  try:
+    report = parseJson(msg).assertIs(JArray).assertHasLen()[0].assertIs(JObject)
+  except:
+    dumpExOnDebug()
+    error("dns sink '" & cfg.name & "': failed to decode report JSON")
+    return
+
+  let
+    domain = tmpl.applySubstitutions(
+      proc(key: string): string = dnsSinkLookup(key, report, placeholder, cfg.name),
+    )
+    qtype  = case recordType.toUpperAscii()
+             of "AAAA": DnsQtype.AAAA
+             of "ANY":  DnsQtype.ANY
+             else:      DnsQtype.A
+
+  try:
+    dnsLookup(
+      domain    = domain,
+      server    = dnsServer,
+      qtype     = qtype,
+      timeoutMs = timeoutMs,
+    )
+    resetSinkFailures(cfg)
+    cfg.iolog(t, "DNS: " & domain)
+  except:
+    dumpExOnDebug()
+    onHttpSinkError(cfg, getCurrentException(), false)
+
+proc addDnsSink*() =
+  var
+    record = SinkImplementation()
+    keys = {
+      "domain_template":         true,
+      "record_type":             false,
+      "missing_key_placeholder": false,
+      "dns_server":              false,
+      "dns_timeout":             false,
+      "disable_after_errors":    false,
+    }.toTable()
+  record.outputFunction = dnsSinkOut
+  record.keys           = keys
+  registerSink("dns", record)
+
 proc addDefaultSinks*() =
   addStdoutSink()
   addStderrSink()
@@ -618,3 +696,4 @@ proc addDefaultSinks*() =
   addS3Sink()
   addPostSink()
   addPresignSink()
+  addDnsSink()

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -39,6 +39,9 @@ import pkg/nimutils/[
   net,
 ]
 import ".."/[
+  chalkjson,
+  config,
+  con4mwrap,
   types,
 ]
 import "."/[
@@ -622,17 +625,47 @@ proc dnsSinkScalar(node: JsonNode, placeholder: string): string =
   of JBool:   return $node.getBool()
   else:       return placeholder
 
-proc dnsSinkLookup(key: string, report: JsonNode, placeholder: string, cfgName: string): string =
+proc applyDnsNormalizer(
+  node:        JsonNode,
+  placeholder: string,
+  key:         string,
+  cfgName:     string,
+): string =
+  let cbPath = "sink_config." & cfgName & ".normalize." & key & ".callback"
+  let cbOpt  = attrGetOpt[CallbackObj](cbPath)
+  if cbOpt.isNone():
+    return dnsSinkScalar(node, placeholder)
+  let box = nimJsonToBox(node)
+  if box.kind notin {MkStr, MkInt, MkFloat, MkBool}:
+    return placeholder
+  try:
+    let r = runCallback(cbOpt.get(), @[box])
+    if r.isSome():
+      return $(r.get())
+  except:
+    dumpExOnDebug()
+    warn("dns sink '" & cfgName & "': normalize callback for '" & key & "' failed")
+  return dnsSinkScalar(node, placeholder)
+
+proc dnsSinkLookup(
+  key:         string,
+  report:      JsonNode,
+  placeholder: string,
+  cfgName:     string,
+): string =
   if report.hasKey(key):
-    return dnsSinkScalar(report[key], placeholder)
-  if report.hasKey("_CHALKS"):
+    return applyDnsNormalizer(report[key], placeholder, key, cfgName)
+  elif report.hasKey("_CHALKS"):
     try:
       let chalk = report["_CHALKS"].assertIs(JArray).assertHasLen()[0].assertIs(JObject)
       if chalk.hasKey(key):
-        return dnsSinkScalar(chalk[key], placeholder)
+        return applyDnsNormalizer(chalk[key], placeholder, key, cfgName)
+      else:
+        warn("dns sink '" & cfgName & "': key '" & key & "' not found; using placeholder '" & placeholder & "'")
     except:
       dumpExOnDebug()
-  warn("dns sink '" & cfgName & "': key '" & key & "' not found; using placeholder '" & placeholder & "'")
+  else:
+    warn("dns sink '" & cfgName & "': key '" & key & "' not found; using placeholder '" & placeholder & "'")
   return placeholder
 
 proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
@@ -653,7 +686,8 @@ proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
 
   let
     domain = tmpl.applySubstitutions(
-      proc(key: string): string = dnsSinkLookup(key, report, placeholder, cfg.name),
+      proc(key: string): string =
+        dnsSinkLookup(key, report, placeholder, cfg.name),
     )
     qtype  = case recordType.toUpperAscii()
              of "AAAA": DnsQtype.AAAA

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -617,55 +617,40 @@ proc addPresignSink*() =
 
   registerSink("presign", record)
 
-proc dnsSinkScalar(node: JsonNode, placeholder: string): string =
-  case node.kind
-  of JString: return node.getStr()
-  of JInt:    return $node.getInt()
-  of JFloat:  return $node.getFloat()
-  of JBool:   return $node.getBool()
-  else:       return placeholder
-
 proc applyDnsNormalizer(
-  node:        JsonNode,
+  box:         Box,
   placeholder: string,
   key:         string,
   cfgName:     string,
 ): string =
+  if box.kind notin {MkStr, MkInt, MkFloat, MkBool}:
+    warn("dns sink '" & cfgName & "': key '" & key & "' is non-scalar (" & $box.kind & "); using placeholder '" & placeholder & "'")
+    return placeholder
   let cbPath = "sink_config." & cfgName & ".normalize." & key & ".callback"
   let cbOpt  = attrGetOpt[CallbackObj](cbPath)
   if cbOpt.isNone():
-    return dnsSinkScalar(node, placeholder)
-  let box = nimJsonToBox(node)
-  if box.kind notin {MkStr, MkInt, MkFloat, MkBool}:
-    return placeholder
+    return $box
   try:
     let r = runCallback(cbOpt.get(), @[box])
     if r.isSome():
       return $(r.get())
   except:
     dumpExOnDebug()
-    warn("dns sink '" & cfgName & "': normalize callback for '" & key & "' failed")
-  return dnsSinkScalar(node, placeholder)
+    warn("dns sink '" & cfgName & "': normalize callback for '" & key & "' failed: " & getCurrentExceptionMsg())
+  return $box
 
 proc dnsSinkLookup(
   key:         string,
-  report:      JsonNode,
+  report:      ChalkDict,
+  chalk:       ChalkDict,
   placeholder: string,
   cfgName:     string,
 ): string =
-  if report.hasKey(key):
+  if key in report:
     return applyDnsNormalizer(report[key], placeholder, key, cfgName)
-  elif report.hasKey("_CHALKS"):
-    try:
-      let chalk = report["_CHALKS"].assertIs(JArray).assertHasLen()[0].assertIs(JObject)
-      if chalk.hasKey(key):
-        return applyDnsNormalizer(chalk[key], placeholder, key, cfgName)
-      else:
-        warn("dns sink '" & cfgName & "': key '" & key & "' not found; using placeholder '" & placeholder & "'")
-    except:
-      dumpExOnDebug()
-  else:
-    warn("dns sink '" & cfgName & "': key '" & key & "' not found; using placeholder '" & placeholder & "'")
+  if key in chalk:
+    return applyDnsNormalizer(chalk[key], placeholder, key, cfgName)
+  warn("dns sink '" & cfgName & "': key '" & key & "' not found; using placeholder '" & placeholder & "'")
   return placeholder
 
 proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
@@ -680,33 +665,53 @@ proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
                   of "ANY":  DnsQtype.ANY
                   else:      DnsQtype.A
 
-  var report: JsonNode
+  var
+    report: ChalkDict
+    chalks: seq[ChalkDict] = @[]
   try:
-    report = parseJson(msg).assertIs(JArray).assertHasLen()[0].assertIs(JObject)
+    let reportJson = parseJson(msg).assertIs(JArray).assertHasLen()[0].assertIs(JObject)
+    report = unpack[ChalkDict](nimJsonToBox(reportJson))
+    if "_CHALKS" in reportJson:
+      let chalksJson = reportJson["_CHALKS"].assertIs(JArray)
+      for i, chalkJson in chalksJson.pairs():
+        try:
+          chalks.add(unpack[ChalkDict](nimJsonToBox(chalkJson.assertIs(JObject))))
+        except:
+          dumpExOnDebug()
+          warn(
+            "dns sink '" & cfg.name & "': failed to extract _CHALKS[" & $i & "]: " &
+            getCurrentExceptionMsg(),
+          )
   except:
     dumpExOnDebug()
     onHttpSinkError(cfg, getCurrentException(), hard = true)
-    return
 
-  try:
-    let domain = tmpl.applySubstitutions(
-      proc(key: string): string =
-        dnsSinkLookup(key, report, placeholder, cfg.name),
-    )
-    dnsLookup(
-      domain    = domain,
-      server    = dnsServer,
-      qtype     = qtype,
-      timeoutMs = timeoutMs,
-    )
-    resetSinkFailures(cfg)
-    cfg.iolog(t, "DNS: " & domain)
-  except ValueError:
-    dumpExOnDebug()
-    onHttpSinkError(cfg, getCurrentException(), hard = true)
-  except:
-    dumpExOnDebug()
-    onHttpSinkError(cfg, getCurrentException(), hard = false)
+  # Emit one DNS lookup per chalk mark; fall back to a single lookup with
+  # report-level keys only when no chalk marks are present.
+  if chalks.len == 0:
+    chalks.add(ChalkDict())
+
+  for chalkEntry in chalks:
+    let chalk = chalkEntry
+    try:
+      let domain = tmpl.applySubstitutions(
+        proc(key: string): string =
+          dnsSinkLookup(key, report, chalk, placeholder, cfg.name),
+      )
+      dnsLookup(
+        domain    = domain,
+        server    = dnsServer,
+        qtype     = qtype,
+        timeoutMs = timeoutMs,
+      )
+      resetSinkFailures(cfg)
+      cfg.iolog(t, "DNS: " & domain)
+    except ValueError:
+      dumpExOnDebug()
+      onHttpSinkError(cfg, getCurrentException(), hard = true)
+    except:
+      dumpExOnDebug()
+      onHttpSinkError(cfg, getCurrentException(), hard = false)
 
 proc addDnsSink*() =
   var

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -675,26 +675,24 @@ proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
     recordType  = cfg.params.getOrDefault("record_type", "A")
     dnsServer   = cfg.params.getOrDefault("dns_server", "")
     timeoutMs   = parseInt(cfg.params.getOrDefault("dns_timeout", "5000"))
+    qtype       = case recordType.toUpperAscii()
+                  of "AAAA": DnsQtype.AAAA
+                  of "ANY":  DnsQtype.ANY
+                  else:      DnsQtype.A
 
   var report: JsonNode
   try:
     report = parseJson(msg).assertIs(JArray).assertHasLen()[0].assertIs(JObject)
   except:
     dumpExOnDebug()
-    error("dns sink '" & cfg.name & "': failed to decode report JSON")
+    onHttpSinkError(cfg, getCurrentException(), hard = true)
     return
 
-  let
-    domain = tmpl.applySubstitutions(
+  try:
+    let domain = tmpl.applySubstitutions(
       proc(key: string): string =
         dnsSinkLookup(key, report, placeholder, cfg.name),
     )
-    qtype  = case recordType.toUpperAscii()
-             of "AAAA": DnsQtype.AAAA
-             of "ANY":  DnsQtype.ANY
-             else:      DnsQtype.A
-
-  try:
     dnsLookup(
       domain    = domain,
       server    = dnsServer,
@@ -703,9 +701,12 @@ proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
     )
     resetSinkFailures(cfg)
     cfg.iolog(t, "DNS: " & domain)
+  except ValueError:
+    dumpExOnDebug()
+    onHttpSinkError(cfg, getCurrentException(), hard = true)
   except:
     dumpExOnDebug()
-    onHttpSinkError(cfg, getCurrentException(), false)
+    onHttpSinkError(cfg, getCurrentException(), hard = false)
 
 proc addDnsSink*() =
   var

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -656,15 +656,16 @@ proc dnsSinkLookup(
 
 proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
-    tmpl        = cfg.params.getOrDefault("domain_template", "")
-    placeholder = cfg.params.getOrDefault("missing_key_placeholder", "x")
-    recordType  = cfg.params.getOrDefault("record_type", "A")
-    dnsServer   = cfg.params.getOrDefault("dns_server", "")
-    timeoutMs   = parseInt(cfg.params.getOrDefault("dns_timeout", "5000"))
-    qtype       = case recordType.toUpperAscii()
-                  of "AAAA": DnsQtype.AAAA
-                  of "ANY":  DnsQtype.ANY
-                  else:      DnsQtype.A
+    tmpl             = cfg.params.getOrDefault("domain_template", "")
+    placeholder      = cfg.params.getOrDefault("missing_key_placeholder", "x")
+    recordType       = cfg.params.getOrDefault("record_type", "A")
+    dnsServer        = cfg.params.getOrDefault("dns_server", "")
+    timeoutMs        = parseInt(cfg.params.getOrDefault("dns_timeout", "5000"))
+    requireChalkMark = cfg.params.getOrDefault("require_chalk_mark", "false") == "true"
+    qtype            = case recordType.toUpperAscii()
+                       of "AAAA": DnsQtype.AAAA
+                       of "ANY":  DnsQtype.ANY
+                       else:      DnsQtype.A
 
   var
     report: ChalkDict
@@ -687,9 +688,10 @@ proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
     dumpExOnDebug()
     onHttpSinkError(cfg, getCurrentException(), hard = true)
 
-  # Emit one DNS lookup per chalk mark; fall back to a single lookup with
-  # report-level keys only when no chalk marks are present.
   if chalks.len == 0:
+    if requireChalkMark:
+      return
+    # Fall back to a single lookup with report-level keys only.
     chalks.add(ChalkDict())
 
   for chalkEntry in chalks:
@@ -724,6 +726,7 @@ proc addDnsSink*() =
       "dns_server":              false,
       "dns_timeout":             false,
       "disable_after_errors":    false,
+      "require_chalk_mark":      false,
     }.toTable()
   record.outputFunction = dnsSinkOut
   record.keys           = keys

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -274,11 +274,11 @@ proc isHardHttpError(e: ref HttpStatusError): bool =
   ## retrying, except 429 (rate limited) which is transient and stays soft.
   e.code in 400..499 and e.code != 429
 
-template onHttpSinkError(cfg: SinkConfig, err: ref Exception, hard: bool) =
-  ## Records an HTTP sink delivery failure and always re-raises `err`.
+template onSinkError(cfg: SinkConfig, err: ref Exception, hard: bool) =
+  ## Records a sink delivery failure and always re-raises `err`.
   ##
-  ## `hard` failures (4xx except 429, malformed presign redirects) disable the
-  ## sink immediately; soft failures disable it once disable_after_errors
+  ## `hard` failures disable the sink immediately; soft failures disable it
+  ## once disable_after_errors
   ## consecutive failures are reached. On every path `err` is re-raised so the
   ## delivery that triggered the failure still propagates to publish()'s onFail,
   ## is accounted as a failure, and is buffered in the report cache rather than
@@ -371,10 +371,10 @@ proc s3SinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
     cfg.iolog(t, "Post to: " & newPath & "; response = " & response.status)
   except HttpStatusError as e:
     dumpExOnDebug()
-    onHttpSinkError(cfg, e, hard = isHardHttpError(e))
+    onSinkError(cfg, e, hard = isHardHttpError(e))
   except:
     dumpExOnDebug()
-    onHttpSinkError(cfg, getCurrentException(), hard = false)
+    onSinkError(cfg, getCurrentException(), hard = false)
 
 proc httpHeaders(cfg: SinkConfig): HttpHeaders =
   var
@@ -456,10 +456,10 @@ proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
     cfg.iolog(t, "Post " & response.status)
   except HttpStatusError as e:
     dumpExOnDebug()
-    onHttpSinkError(cfg, e, hard = isHardHttpError(e))
+    onSinkError(cfg, e, hard = isHardHttpError(e))
   except:
     dumpExOnDebug()
-    onHttpSinkError(cfg, getCurrentException(), hard = false)
+    onSinkError(cfg, getCurrentException(), hard = false)
 
 proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
@@ -483,10 +483,10 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
     )
   except HttpStatusError as e:
     dumpExOnDebug()
-    onHttpSinkError(cfg, e, hard = isHardHttpError(e))
+    onSinkError(cfg, e, hard = isHardHttpError(e))
   except:
     dumpExOnDebug()
-    onHttpSinkError(cfg, getCurrentException(), hard = false)
+    onSinkError(cfg, getCurrentException(), hard = false)
 
   var uri: Uri
   try:
@@ -500,7 +500,7 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
     # A malformed redirect (missing or relative Location) can never yield a
     # working upload URL, so treat it as a hard error and route it through the
     # disable machinery like a 4xx sign response instead of raising past it.
-    onHttpSinkError(cfg, getCurrentException(), hard = true)
+    onSinkError(cfg, getCurrentException(), hard = true)
 
   let uploadHeaders = newHttpHeaders().addForwardedHeaders(signResponse)
   try:
@@ -523,7 +523,7 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
   except:
     dumpExOnDebug()
     # Upload errors are always soft: the presigned URL itself may be transient.
-    onHttpSinkError(cfg, getCurrentException(), hard = false)
+    onSinkError(cfg, getCurrentException(), hard = false)
 
 proc addFileSink*() =
   var
@@ -686,7 +686,7 @@ proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
           )
   except:
     dumpExOnDebug()
-    onHttpSinkError(cfg, getCurrentException(), hard = true)
+    onSinkError(cfg, getCurrentException(), hard = true)
 
   if chalks.len == 0:
     if requireChalkMark:
@@ -711,10 +711,10 @@ proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
       cfg.iolog(t, "DNS: " & domain)
     except ValueError:
       dumpExOnDebug()
-      onHttpSinkError(cfg, getCurrentException(), hard = true)
+      onSinkError(cfg, getCurrentException(), hard = true)
     except:
       dumpExOnDebug()
-      onHttpSinkError(cfg, getCurrentException(), hard = false)
+      onSinkError(cfg, getCurrentException(), hard = false)
 
 proc addDnsSink*() =
   var

--- a/src/utils/sink_impls.nim
+++ b/src/utils/sink_impls.nim
@@ -17,6 +17,7 @@
 ## ever called.
 
 import std/[
+  enumerate,
   json,
   streams,
   tables,
@@ -673,7 +674,7 @@ proc dnsSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
     report = unpack[ChalkDict](nimJsonToBox(reportJson))
     if "_CHALKS" in reportJson:
       let chalksJson = reportJson["_CHALKS"].assertIs(JArray)
-      for i, chalkJson in chalksJson.pairs():
+      for i, chalkJson in enumerate(chalksJson.items()):
         try:
           chalks.add(unpack[ChalkDict](nimJsonToBox(chalkJson.assertIs(JObject))))
         except:

--- a/src/utils/substitutions.nim
+++ b/src/utils/substitutions.nim
@@ -1,0 +1,41 @@
+##
+## Copyright (c) 2023-2026, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+import std/[
+  strutils,
+]
+
+proc applySubstitutions*(s: string, lookup: proc(key: string): string): string =
+  ## Replaces {KEY} placeholders in s by calling lookup(KEY.toUpperAscii()).
+  ## Raises ValueError on malformed braces.
+  var
+    key   = ""
+    inKey = false
+  for c in s:
+    if c == '{':
+      if inKey:
+        raise newException(
+          ValueError,
+          s & ": invalid format string. '{' is repeated without closing previous occurrence",
+        )
+      inKey = true
+      key   = ""
+      continue
+    elif c == '}':
+      if not inKey:
+        raise newException(
+          ValueError,
+          s & ": invalid format string. '}' is occurring without matching '{'",
+        )
+      inKey = false
+      if key != "":
+        result &= lookup(key.toUpperAscii())
+      continue
+    if inKey:
+      key.add(c)
+    else:
+      result.add(c)

--- a/src/utils/substitutions.nim
+++ b/src/utils/substitutions.nim
@@ -32,10 +32,19 @@ proc applySubstitutions*(s: string, lookup: proc(key: string): string): string =
           s & ": invalid format string. '}' is occurring without matching '{'",
         )
       inKey = false
-      if key != "":
-        result &= lookup(key.toUpperAscii())
+      if key == "":
+        raise newException(
+          ValueError,
+          s & ": invalid format string. '{}' is an empty placeholder",
+        )
+      result &= lookup(key.toUpperAscii())
       continue
     if inKey:
       key.add(c)
     else:
       result.add(c)
+  if inKey:
+    raise newException(
+      ValueError,
+      s & ": invalid format string. '{' is not closed",
+    )

--- a/src/utils/times.nim
+++ b/src/utils/times.nim
@@ -17,8 +17,13 @@ export times
 export monotimes
 
 var
-  startTime*     = getTime().utc # gives absolute wall time
-  monoStartTime* = getMonoTime() # used for computing diffs
+  processStartTime* = getTime().utc # set once at startup, never reset
+  processMonoTime*  = getMonoTime() # set once at startup, never reset
+  opTime*           = processStartTime # current operation wall time, reset each heartbeat
+  opMonoTime*       = processMonoTime  # current operation mono time, reset each heartbeat
+
+proc toMs*(t: MonoTime): int64 =
+  t.ticks div 1_000_000
 
 template withDuration*(c: untyped) =
   let start = getMonoTime()
@@ -41,4 +46,4 @@ proc forReport*(t: DateTime): DateTime =
 proc reportTotalTime*() =
   let monoEndTime = getMonoTime()
   if attrGet[bool]("report_total_time"):
-    echo("Total run time: " & $(monoEndTime - monoStartTime))
+    echo("Total run time: " & $(monoEndTime - processMonoTime))

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -83,7 +83,10 @@ class ChalkReport(ContainsDict):
                 for k, v in self.items()
                 if k
                 not in {
+                    "_MONOTIME",
                     "_TIMESTAMP",
+                    "_SINCE_TIMESTAMP",
+                    "_SINCE_MONOTIME",
                     "_DATETIME",
                     "_ACTION_ID",
                     "_ARGV",

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -575,6 +575,7 @@ class Chalk:
         heartbeat: bool = False,
         config: Optional[Path | str] = None,
         params: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
     ) -> ChalkProgram:
         return self.run(
             command="exec",
@@ -584,6 +585,7 @@ class Chalk:
             heartbeat=heartbeat,
             config=config,
             params=params,
+            env=env,
         )
 
     def delete(self, artifact: Path) -> ChalkProgram:

--- a/tests/functional/conf.py
+++ b/tests/functional/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, Crash Override, Inc.
+# Copyright (c) 2023-2026, Crash Override, Inc.
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
@@ -51,6 +51,8 @@ REGISTRY_AUTH = f"{IP}:5048"
 
 SERVER_CHALKDUST = "https://chalkdust.io"
 SERVER_IMDS = "http://169.254.169.254"
+SERVER_DNS = "http://dns.chalk.local:8054"
+DNS_SINK_SERVER = "dns.chalk.local:5354"
 SERVER_STATIC = "http://static:8000"
 SERVER_HTTP = "http://chalk.local:8585"
 SERVER_HTTPS = "https://tls.chalk.local:5858"

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -223,6 +223,13 @@ def server_dns():
     yield SERVER_DNS
 
 
+@pytest.fixture(scope="session", autouse=True)
+def dns_queries_cleanup():
+    yield
+    if is_server_up(f"{SERVER_DNS}/health"):
+        requests.delete(f"{SERVER_DNS}/queries")
+
+
 @pytest.fixture()
 def server_chalkdust():
     return SERVER_CHALKDUST

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, Crash Override, Inc.
+# Copyright (c) 2023-2026, Crash Override, Inc.
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
@@ -22,6 +22,7 @@ from .conf import (
     SERVER_CERT,
     SERVER_CHALKDUST,
     SERVER_DB,
+    SERVER_DNS,
     SERVER_HTTP,
     SERVER_HTTPS,
     SERVER_IMDS,
@@ -213,6 +214,13 @@ def server_static():
     if not is_server_up(f"{SERVER_STATIC}/conftest.py"):
         pytest.skip(f"{SERVER_STATIC} is down. skipping test")
     return SERVER_STATIC
+
+
+@pytest.fixture()
+def server_dns():
+    if not is_server_up(f"{SERVER_DNS}/health"):
+        pytest.skip(f"DNS server ({SERVER_DNS}) is down. skipping test")
+    yield SERVER_DNS
 
 
 @pytest.fixture()

--- a/tests/functional/data/configs/docker_wrap.c4m
+++ b/tests/functional/data/configs/docker_wrap.c4m
@@ -4,6 +4,16 @@ docker.wrap_entrypoint = true
 docker.download_arch_binary_urls = [env("CHALK_SERVER") + "/dummy/chalk-{version}-{os}-{architecture}"]
 docker.arch_binary_locations_path = env("CHALK_TMP")
 
+sink_config dns_build {
+  enabled:         env_exists("DNS_SERVER")
+  sink:            "dns"
+  domain_template: "{_MONOTIME}.{_TIMESTAMP}.{METADATA_ID}.chalk.test"
+  dns_server:      env("DNS_SERVER")
+  dns_timeout:     2000
+}
+
+subscribe("report", "dns_build")
+
 docker {
   docker_registry local {
     enabled: env_exists("CHALK_SERVER")

--- a/tests/functional/data/configs/docker_wrap.c4m
+++ b/tests/functional/data/configs/docker_wrap.c4m
@@ -4,15 +4,16 @@ docker.wrap_entrypoint = true
 docker.download_arch_binary_urls = [env("CHALK_SERVER") + "/dummy/chalk-{version}-{os}-{architecture}"]
 docker.arch_binary_locations_path = env("CHALK_TMP")
 
-sink_config dns_build {
-  enabled:         env_exists("DNS_SERVER")
-  sink:            "dns"
-  domain_template: "{_MONOTIME}.{_TIMESTAMP}.{METADATA_ID}.chalk.test"
-  dns_server:      env("DNS_SERVER")
-  dns_timeout:     2000
+if env_exists("DNS_SERVER") {
+  sink_config dns_build {
+    enabled:         true
+    sink:            "dns"
+    domain_template: "{_MONOTIME}.{_TIMESTAMP}.{METADATA_ID}.chalk.test"
+    dns_server:      env("DNS_SERVER")
+    dns_timeout:     2000
+  }
+  subscribe("report", "dns_build")
 }
-
-subscribe("report", "dns_build")
 
 docker {
   docker_registry local {

--- a/tests/functional/data/configs/heartbeat.c4m
+++ b/tests/functional/data/configs/heartbeat.c4m
@@ -15,6 +15,12 @@ report_template heartbeat_report_template {
     key.HASH.use = true
     key._CURRENT_HASH.use = true
     key._PROCESS_PID.use = true
+
+    key.METADATA_ID.use        = true
+    key._EXEC_ID.use           = true
+    key._HEARTBEAT_COUNT.use   = true
+    key._SINCE_TIMESTAMP.use   = true
+    key._SINCE_MONOTIME.use    = true
 }
 
 
@@ -23,9 +29,17 @@ sink_config test_std_out {
     enabled: true
 }
 
+sink_config test_dns_heartbeat {
+  enabled:         true
+  sink:            "dns"
+  domain_template: "{_HEARTBEAT_COUNT}.{_SINCE_TIMESTAMP}.{_SINCE_MONOTIME}.{_EXEC_ID}.{METADATA_ID}.chalk.test"
+  dns_server:      env("DNS_SERVER")
+  dns_timeout:     2000
+}
+
 custom_report exec_heartbeat_test {
   enabled: true
   report_template: "heartbeat_report_template"
-  sink_configs: ["test_std_out"]
+  sink_configs: ["test_std_out", "test_dns_heartbeat"]
   use_when: ["exec", "heartbeat"]
 }

--- a/tests/functional/data/configs/per_chalk_custom_report.c4m
+++ b/tests/functional/data/configs/per_chalk_custom_report.c4m
@@ -1,0 +1,8 @@
+skip_command_report: true
+
+custom_report per_chalk_test {
+  report_template: "insertion_default"
+  sink_configs:    ["json_console_out"]
+  per_chalk:       true
+  use_when:        ["insert"]
+}

--- a/tests/functional/data/configs/procfs.c4m
+++ b/tests/functional/data/configs/procfs.c4m
@@ -26,4 +26,17 @@ report_template report_default {
   key._PROCESS_DETAIL.use         = true
 
   key._OP_ANCESTOR_ARGVS.use      = true
+
+  key._EXEC_ID.use                = true
+  key._MONOTIME.use               = true
 }
+
+sink_config dns_exec {
+  enabled:         env_exists("DNS_SERVER")
+  sink:            "dns"
+  domain_template: "{_MONOTIME}.{_TIMESTAMP}.{_EXEC_ID}.{METADATA_ID}.chalk.test"
+  dns_server:      env("DNS_SERVER")
+  dns_timeout:     2000
+}
+
+subscribe("report", "dns_exec")

--- a/tests/functional/data/configs/procfs.c4m
+++ b/tests/functional/data/configs/procfs.c4m
@@ -31,12 +31,13 @@ report_template report_default {
   key._MONOTIME.use               = true
 }
 
-sink_config dns_exec {
-  enabled:         env_exists("DNS_SERVER")
-  sink:            "dns"
-  domain_template: "{_MONOTIME}.{_TIMESTAMP}.{_EXEC_ID}.{METADATA_ID}.chalk.test"
-  dns_server:      env("DNS_SERVER")
-  dns_timeout:     2000
+if env_exists("DNS_SERVER") {
+  sink_config dns_exec {
+    enabled:         true
+    sink:            "dns"
+    domain_template: "{_MONOTIME}.{_TIMESTAMP}.{_EXEC_ID}.{METADATA_ID}.chalk.test"
+    dns_server:      env("DNS_SERVER")
+    dns_timeout:     2000
+  }
+  subscribe("report", "dns_exec")
 }
-
-subscribe("report", "dns_exec")

--- a/tests/functional/data/sink_configs/dns_multi.c4m
+++ b/tests/functional/data/sink_configs/dns_multi.c4m
@@ -1,9 +1,10 @@
 sink_config test_dns_id {
-  enabled:         true
-  sink:            "dns"
-  domain_template: "{METADATA_ID}.chalk.test"
-  dns_server:      env("DNS_SERVER")
-  dns_timeout:     2000
+  enabled:            true
+  sink:               "dns"
+  domain_template:    "{METADATA_ID}.chalk.test"
+  dns_server:         env("DNS_SERVER")
+  dns_timeout:        2000
+  require_chalk_mark: true
 }
 
 sink_config test_dns_multi_keys {

--- a/tests/functional/data/sink_configs/dns_multi.c4m
+++ b/tests/functional/data/sink_configs/dns_multi.c4m
@@ -22,6 +22,22 @@ sink_config test_dns_missing_key {
   dns_timeout:     2000
 }
 
+func dns_trunc8(v: string) {
+  return slice(v, 0, 8)
+}
+
+sink_config test_dns_normalize {
+  enabled:         true
+  sink:            "dns"
+  domain_template: "{METADATA_ID}.chalk.test"
+  dns_server:      env("DNS_SERVER")
+  dns_timeout:     2000
+  normalize METADATA_ID {
+    callback: func dns_trunc8
+  }
+}
+
 subscribe("report", "test_dns_id")
 subscribe("report", "test_dns_multi_keys")
 subscribe("report", "test_dns_missing_key")
+subscribe("report", "test_dns_normalize")

--- a/tests/functional/data/sink_configs/dns_multi.c4m
+++ b/tests/functional/data/sink_configs/dns_multi.c4m
@@ -1,0 +1,27 @@
+sink_config test_dns_id {
+  enabled:         true
+  sink:            "dns"
+  domain_template: "{METADATA_ID}.chalk.test"
+  dns_server:      env("DNS_SERVER")
+  dns_timeout:     2000
+}
+
+sink_config test_dns_multi_keys {
+  enabled:         true
+  sink:            "dns"
+  domain_template: "{METADATA_ID}.{_OPERATION}.chalk.test"
+  dns_server:      env("DNS_SERVER")
+  dns_timeout:     2000
+}
+
+sink_config test_dns_missing_key {
+  enabled:         true
+  sink:            "dns"
+  domain_template: "{NONEXISTENT_KEY}.chalk.test"
+  dns_server:      env("DNS_SERVER")
+  dns_timeout:     2000
+}
+
+subscribe("report", "test_dns_id")
+subscribe("report", "test_dns_multi_keys")
+subscribe("report", "test_dns_missing_key")

--- a/tests/functional/server/dns_server.py
+++ b/tests/functional/server/dns_server.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-2026, Crash Override, Inc.
+#
+# This file is part of Chalk
+# (see https://crashoverride.com/docs/chalk)
+"""
+Minimal UDP DNS server for functional tests.
+
+Listens on UDP 5354 for DNS queries, records every queried hostname, and
+returns NOERROR with no answer records (so chalk's DNS sink treats the lookup
+as successful). Exposes an HTTP API on port 8054 so tests can retrieve and
+clear the recorded queries.
+"""
+import asyncio
+import struct
+
+import uvicorn
+from fastapi import FastAPI
+
+app = FastAPI()
+queries: list[str] = []
+
+
+def _parse_qname(data: bytes, offset: int) -> str:
+    labels = []
+    while offset < len(data):
+        length = data[offset]
+        if length == 0:
+            break
+        if (length & 0xC0) == 0xC0:  # compression pointer — not expected in questions
+            break
+        offset += 1
+        labels.append(data[offset : offset + length].decode("ascii", errors="replace"))
+        offset += length
+    return ".".join(labels)
+
+
+class DnsProtocol(asyncio.DatagramProtocol):
+    def connection_made(self, transport: asyncio.DatagramTransport) -> None:
+        self.transport = transport
+
+    def datagram_received(self, data: bytes, addr: tuple) -> None:
+        if len(data) < 13:
+            return
+        name = _parse_qname(data, 12)
+        if name:
+            queries.append(name)
+        # NOERROR with the question echoed back and no answer records
+        response = (
+            data[:2]  # copy query ID
+            + b"\x81\x80"  # QR=1 RD=1 RA=1 RCODE=0
+            + struct.pack(
+                "!HHHH", 1, 0, 0, 0
+            )  # QDCOUNT=1 ANCOUNT=0 NSCOUNT=0 ARCOUNT=0
+            + data[12:]  # echo question section
+        )
+        self.transport.sendto(response, addr)
+
+
+@app.get("/health")
+def health() -> dict:
+    return {}
+
+
+@app.get("/queries")
+def get_queries() -> list[str]:
+    return list(queries)
+
+
+@app.delete("/queries", status_code=204)
+def clear_queries() -> None:
+    queries.clear()
+
+
+async def main() -> None:
+    loop = asyncio.get_running_loop()
+    await loop.create_datagram_endpoint(DnsProtocol, local_addr=("0.0.0.0", 5354))
+    config = uvicorn.Config(app, host="0.0.0.0", port=8054, log_level="warning")
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/functional/test_command.py
+++ b/tests/functional/test_command.py
@@ -85,29 +85,46 @@ def test_insert_extract_directory(
     assert chalk.extract(artifact=tmp_data_dir)
 
 
+@pytest.mark.parametrize(
+    "copy_files", [[LS_PATH, DATE_PATH, HELLO_GO_PATH]], indirect=True
+)
+def test_per_chalk_custom_report(
+    tmp_data_dir: Path, copy_files: list[Path], chalk: Chalk
+):
+    insert = chalk.run(
+        command="insert",
+        target=tmp_data_dir,
+        config=CONFIGS / "per_chalk_custom_report.c4m",
+    )
+    assert len(insert.reports) == len(copy_files)
+    for report in insert.reports:
+        assert report.mark
+
+
 @pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)
 def test_insert_extract_delete(copy_files: list[Path], chalk: Chalk):
+    env = {"PER_CHALK_REPORTS": "1"}
     artifact = copy_files[0]
 
     # insert
-    insert = chalk.insert(artifact=artifact, virtual=False)
+    insert = chalk.insert(artifact=artifact, virtual=False, env=env)
     assert insert.marks_by_path.contains({str(artifact): {}})
     insert_1_hash = insert.report["_CHALKS"][0]["HASH"]
 
     # extract
-    extract = chalk.extract(artifact=artifact)
+    extract = chalk.extract(artifact=artifact, env=env)
 
     # delete
-    delete = chalk.run(command="delete", target=artifact)
+    delete = chalk.run(command="delete", target=artifact, env=env)
 
     for key in ["HASH", "_OP_ARTIFACT_PATH", "_OP_ARTIFACT_TYPE"]:
         assert extract.mark[key] == delete.mark[key]
 
     # extract again and we shouldn't get anything this time
-    assert chalk.extract(artifact=artifact, expecting_chalkmarks=False)
+    assert chalk.extract(artifact=artifact, expecting_chalkmarks=False, env=env)
 
     # insert again and check that hash is the same as first insert
-    insert2 = chalk.insert(artifact=artifact, virtual=False)
+    insert2 = chalk.insert(artifact=artifact, virtual=False, env=env)
     insert_2_hash = insert2.report["_CHALKS"][0]["HASH"]
     assert insert_1_hash == insert_2_hash
 

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -11,6 +11,8 @@ import platform
 import re
 import shutil
 import time
+
+import requests
 from contextlib import ExitStack
 from pathlib import Path
 from typing import Iterator, Optional
@@ -22,6 +24,7 @@ from .chalk.runner import Chalk, ChalkMark, ChalkProgram
 from .conf import (
     AWS_ECR_REPO,
     CONFIGS,
+    DNS_SINK_SERVER,
     DOCKER_HUB_REPO,
     DOCKERFILES,
     DOCKER_SSH_REPO,
@@ -160,6 +163,7 @@ def test_build(
     buildx: bool,
     builder: Optional[str],
     random_hex: str,
+    server_dns: str,
 ):
     """
     Test various variants of docker build command
@@ -173,6 +177,7 @@ def test_build(
         buildx=buildx,
         builder=builder,
         config=CONFIGS / "docker_wrap.c4m",
+        env={"DNS_SERVER": DNS_SINK_SERVER},
     )
     assert digests
     assert build.mark.has(_IMAGE_ENTRYPOINT=["/chalk", "exec", "--"])
@@ -245,6 +250,11 @@ def test_build(
             else MISSING
         ),
     )
+    metadata_id = build.mark["METADATA_ID"]
+    monotime = build.report["_MONOTIME"]
+    timestamp = build.report["_TIMESTAMP"]
+    queries = requests.get(f"{server_dns}/queries").json()
+    assert f"{monotime}.{timestamp}.{metadata_id}.chalk.test" in queries
 
 
 def test_build_platform(

--- a/tests/functional/test_exec.py
+++ b/tests/functional/test_exec.py
@@ -3,13 +3,16 @@
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
 from pathlib import Path
+import operator
 import sys
 
+import requests
 import pytest
 
 from .chalk.runner import Chalk
-from .conf import CONFIGS, SLEEP_PATH, UNAME_PATH
-from .utils.dict import Contains, ContainsDict
+from .conf import CONFIGS, DNS_SINK_SERVER, SLEEP_PATH, UNAME_PATH
+
+from .utils.dict import ANY, Contains, ContainsDict, IntCompare
 from .utils.bin import sha256
 from .utils.log import get_logger
 
@@ -59,6 +62,7 @@ def test_exec_chalked(
     copy_files: list[Path],
     chalk: Chalk,
     tmp_data_dir: Path,
+    server_dns: str,
 ):
     bin_path = copy_files[0]
     bin_hash = sha256(bin_path)
@@ -78,6 +82,7 @@ def test_exec_chalked(
         params=["3"],
         as_parent=as_parent,
         config=CONFIGS / "procfs.c4m",
+        env={"DNS_SERVER": DNS_SINK_SERVER},
     )
 
     assert exec_proc.report["_OPERATION"] == "exec"
@@ -123,7 +128,7 @@ def test_exec_chalked(
                 "pos": 0,
                 "mnt_id": int,
                 "ino": int,
-                "path": "/dev/null",
+                "path": str,
                 "flags": int,
             }
         },
@@ -155,6 +160,12 @@ def test_exec_chalked(
         # but we can check that some of the ancesor argv has python
         _OP_ANCESTOR_ARGVS=Contains([Contains([sys.executable])]),
     )
+    metadata_id = exec_proc.mark["METADATA_ID"]
+    exec_id = exec_proc.report["_EXEC_ID"]
+    monotime = exec_proc.report["_MONOTIME"]
+    timestamp = exec_proc.report["_TIMESTAMP"]
+    queries = requests.get(f"{server_dns}/queries").json()
+    assert f"{monotime}.{timestamp}.{exec_id}.{metadata_id}.chalk.test" in queries
 
 
 # exec wrapping with heartbeat
@@ -162,6 +173,7 @@ def test_exec_chalked(
 def test_exec_heartbeat(
     copy_files: list[Path],
     chalk: Chalk,
+    server_dns: str,
 ):
     bin_path = copy_files[0]
     bin_hash = sha256(bin_path)
@@ -178,17 +190,41 @@ def test_exec_heartbeat(
         heartbeat=True,
         config=CONFIGS / "heartbeat.c4m",
         params=["5"],
+        env={"DNS_SERVER": DNS_SINK_SERVER},
     )
 
     exec_report = result.reports[0]
-    assert exec_report["_OPERATION"] == "exec"
-    assert exec_report.mark["_OP_ARTIFACT_PATH"] == str(bin_path)
-    assert exec_report.mark["_CURRENT_HASH"] == chalk_hash
-    assert exec_report.mark["ARTIFACT_TYPE"] == "ELF"
-    assert exec_report.mark["_PROCESS_PID"] != ""
+    assert exec_report.has(
+        _OPERATION="exec",
+        _EXEC_ID=ANY,
+    )
+    assert exec_report.mark.has(
+        _OP_ARTIFACT_PATH=str(bin_path),
+        _CURRENT_HASH=chalk_hash,
+        ARTIFACT_TYPE="ELF",
+        METADATA_ID=ANY,
+        _PROCESS_PID=ANY,
+    )
 
     # there should be a few heartbeats
     assert len(result.reports) > 1
-    for heartbeat_report in result.reports[1:]:
-        assert heartbeat_report["_OPERATION"] == "heartbeat"
+    metadata_id = exec_report.mark["METADATA_ID"]
+    exec_id = exec_report["_EXEC_ID"]
+    queries = requests.get(f"{server_dns}/queries").json()
+    prev_since_monotime = 0
+    prev_since_timestamp = 0
+    for i, heartbeat_report in enumerate(result.reports[1:], start=1):
+        assert heartbeat_report.has(
+            _OPERATION="heartbeat",
+            _EXEC_ID=exec_id,
+            _HEARTBEAT_COUNT=i,
+            _SINCE_MONOTIME=IntCompare(prev_since_monotime, operator.gt),
+            _SINCE_TIMESTAMP=IntCompare(prev_since_timestamp, operator.gt),
+        )
+        prev_since_monotime = heartbeat_report["_SINCE_MONOTIME"]
+        prev_since_timestamp = heartbeat_report["_SINCE_TIMESTAMP"]
         assert heartbeat_report.mark == exec_report.mark
+        assert (
+            f"{i}.{prev_since_timestamp}.{prev_since_monotime}.{exec_id}.{metadata_id}.chalk.test"
+            in queries
+        )

--- a/tests/functional/test_sink.py
+++ b/tests/functional/test_sink.py
@@ -373,3 +373,4 @@ def test_dns_sink(
     assert f"{metadata_id}.insert.chalk.test" in queries
     assert "x.chalk.test" in queries
     assert "key 'NONEXISTENT_KEY' not found" in result.logs
+    assert f"{metadata_id[:8]}.chalk.test" in queries

--- a/tests/functional/test_sink.py
+++ b/tests/functional/test_sink.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Crash Override, Inc.
+# Copyright (c) 2023-2026, Crash Override, Inc.
 #
 # This file is part of Chalk
 # (see https://crashoverride.com/docs/chalk)
@@ -14,6 +14,7 @@ import requests
 from .chalk.runner import Chalk
 from .conf import (
     CAT_PATH,
+    DNS_SINK_SERVER,
     SERVER_CERT,
     SERVER_HTTP,
     SERVER_HTTPS,
@@ -346,3 +347,29 @@ def _test_server(
     assert fetched_chalk["METADATA_ID"] == metadata_id
 
     return proc
+
+
+# ---------------------------------------------------------------------------
+# DNS sink
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("copy_files", [[CAT_PATH]], indirect=True)
+def test_dns_sink(
+    tmp_data_dir: Path,
+    chalk: Chalk,
+    copy_files: list[Path],
+    server_dns: str,
+):
+    artifact = copy_files[0]
+    result = chalk.insert(
+        artifact,
+        config=SINK_CONFIGS / "dns_multi.c4m",
+        env={"DNS_SERVER": DNS_SINK_SERVER},
+    )
+    metadata_id = result.mark["METADATA_ID"]
+    queries = requests.get(f"{server_dns}/queries").json()
+    assert f"{metadata_id}.chalk.test" in queries
+    assert f"{metadata_id}.insert.chalk.test" in queries
+    assert "x.chalk.test" in queries
+    assert "key 'NONEXISTENT_KEY' not found" in result.logs

--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -50,3 +50,8 @@ tool.syft.syft_container = "ghcr.io/anchore/syft"
 
 # sometimes CI tests need longer TTL to get ICMP error back
 network.partial_traceroute_timeout_ms = 500
+
+if env_exists("PER_CHALK_REPORTS") {
+  outconf.insert.per_chalk_reports  = true
+  outconf.extract.per_chalk_reports = true
+}

--- a/tests/unit/test_dns.nim
+++ b/tests/unit/test_dns.nim
@@ -120,8 +120,9 @@ proc testToAsciiDomain() =
   # Already-encoded xn-- labels are ASCII, pass through unchanged
   check toAsciiDomain("xn--mnchen-3ya.de") == "xn--mnchen-3ya.de"
 
-  # Empty labels (trailing/leading dots) are preserved
-  check toAsciiDomain("foo..bar") == "foo..bar"
+  # Empty labels (adjacent dots) are rejected
+  checkRaises(ValueError):
+    discard toAsciiDomain("foo..bar")
 
   # Label exactly 63 chars is valid
   check toAsciiDomain("a".repeat(63) & ".com") == "a".repeat(63) & ".com"

--- a/tests/unit/test_dns.nim
+++ b/tests/unit/test_dns.nim
@@ -1,0 +1,262 @@
+import std/[
+  strutils,
+]
+import "../../src/utils/dns"
+
+template check(cond: untyped) =
+  doAssert cond, "failed: " & astToStr(cond)
+
+template checkRaises(exc: typedesc, body: untyped) =
+  block:
+    var raised = false
+    try:
+      body
+    except exc:
+      raised = true
+    doAssert raised, "expected " & astToStr(exc) & " to be raised but it was not"
+
+# ---------------------------------------------------------------------------
+# punycodeEncode — RFC 3492 Section 7.1 test vectors
+#
+# The ACE prefix ("xn--") is not shown; these are raw Punycode outputs.
+# Mixed-case annotation (Appendix A) is not implemented; encoding digits are
+# always lowercase. The one RFC case affected is (I) Russian, where the RFC
+# shows an uppercase 'D' from the optional annotation; we expect lowercase 'd'.
+# ---------------------------------------------------------------------------
+
+proc testPunycode() =
+  # manually-verified spot checks
+  check punycodeEncode("münchen") == "mnchen-3ya"
+  check punycodeEncode("bücher")  == "bcher-kva"
+  check punycodeEncode("例")      == "fsq"
+  check punycodeEncode("abc")     == "abc-"   # ASCII only: basic + delimiter
+
+  # (A) Arabic (Egyptian)
+  check punycodeEncode("ليهمابتكلموشعربي؟") == "egbpdaj6bu4bxfgehfvwxn"
+
+  # (B) Chinese (simplified)
+  check punycodeEncode("他们为什么不说中文") == "ihqwcrb4cv8a8dqg056pqjye"
+
+  # (C) Chinese (traditional)
+  check punycodeEncode("他們爲什麽不說中文") == "ihqwctvzc91f659drss3x8bo0yb"
+
+  # (D) Czech — ASCII prefix preserves case, encoding digits are lowercase
+  check punycodeEncode("Pročprostěnemluvíčesky") == "Proprostnemluvesky-uyb24dma41a"
+
+  # (E) Hebrew
+  check punycodeEncode("למההםפשוטלאמדבריםעברית") == "4dbcagdahymbxekheh6e0a7fei0b"
+
+  # (F) Hindi (Devanagari) - "यहलोगहिन्दीक्योंनहींबोलसकतेहैं" (30 RFC codepoints)
+  check punycodeEncode(
+    "यहलोगहिन" &
+    "्दीक्यों" &
+    "नहींबोलस" &
+    "कतेहैं",
+  ) == "i1baa7eci9glrd9b2ae1bj0hfcgg6iyaf8o0a1dig0cd"
+
+  # (G) Japanese (kanji and hiragana)
+  check punycodeEncode("なぜみんな日本語を話してくれないのか") == "n8jok5ay5dzabd5bym9f0cm5685rrjetr6pdxa"
+
+  # (H) Korean (Hangul syllables)
+  check punycodeEncode("세계의모든사람들이한국어를이해한다면얼마나좋을까") ==
+    "989aomsvi5e83db1d2a355cv1e0vak1dwrv93d5xbh15a0dt30a5jpsd879ccm6fea98c"
+
+  # (I) Russian - "почемужеониненговорятпорусски" (28 RFC codepoints)
+  # RFC shows uppercase 'D' (mixed-case annotation); our impl outputs 'd'.
+  check punycodeEncode(
+    "почемуже" &
+    "онинегов" &
+    "орятпору" &
+    "сски",
+  ) == "b1abfaaepdrnnbgefbadotcwatmq2g4l"
+
+  # (J) Spanish — ASCII prefix preserves case
+  check punycodeEncode("PorquénopuedensimplementehablarenEspañol") ==
+    "PorqunopuedensimplementehablarenEspaol-fmd56a"
+
+  # (K) Vietnamese — ASCII prefix preserves case
+  check punycodeEncode("TạisaohọkhôngthểchỉnóitiếngViệt") ==
+    "TisaohkhngthchnitingVit-kjcr8268qyxafd2f1b9g"
+
+  # (L) Japanese: 3年B組金八先生
+  check punycodeEncode("3年B組金八先生") == "3B-ww4c5e180e575a65lsy2b"
+
+  # (M) Japanese: 安室奈美恵-with-SUPER-MONKEYS
+  check punycodeEncode("安室奈美恵-with-SUPER-MONKEYS") ==
+    "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n"
+
+  # (N) Japanese: Hello-Another-Way-それぞれの場所
+  check punycodeEncode("Hello-Another-Way-それぞれの場所") ==
+    "Hello-Another-Way--fc4qua05auwb3674vfr0b"
+
+  # (O) Japanese: ひとつ屋根の下2
+  check punycodeEncode("ひとつ屋根の下2") == "2-u9tlzr9756bt3uc0v"
+
+  # (P) Japanese: MajiでKoiする5秒前
+  check punycodeEncode("MajiでKoiする5秒前") == "MajiKoi5-783gue6qz075azm5e"
+
+  # (Q) Japanese: パフィーdeルンバ
+  check punycodeEncode("パフィーdeルンバ") == "de-jg4avhby1noc0d"
+
+  # (R) Japanese: そのスピードで
+  check punycodeEncode("そのスピードで") == "d9juau41awczczp"
+
+# ---------------------------------------------------------------------------
+# toAsciiDomain
+# ---------------------------------------------------------------------------
+
+proc testToAsciiDomain() =
+  # Pure ASCII passes through unchanged
+  check toAsciiDomain("google.com")         == "google.com"
+  check toAsciiDomain("foo.example.org")    == "foo.example.org"
+
+  # Unicode labels get xn-- encoding
+  check toAsciiDomain("münchen.de")  == "xn--mnchen-3ya.de"
+  check toAsciiDomain("bücher.de")   == "xn--bcher-kva.de"
+
+  # Already-encoded xn-- labels are ASCII, pass through unchanged
+  check toAsciiDomain("xn--mnchen-3ya.de") == "xn--mnchen-3ya.de"
+
+  # Empty labels (trailing/leading dots) are preserved
+  check toAsciiDomain("foo..bar") == "foo..bar"
+
+  # Label exactly 63 chars is valid
+  check toAsciiDomain("a".repeat(63) & ".com") == "a".repeat(63) & ".com"
+
+  # Label of 64 chars raises ValueError
+  checkRaises(ValueError):
+    discard toAsciiDomain("a".repeat(64) & ".com")
+
+  # Hostname of exactly 253 chars is valid (four 62-char labels with dots = 4*62+3 = 251; add one more)
+  # Build a valid 253-char hostname: three 63-char labels plus a 62-char label = 63+1+63+1+63+1+62 = 254 -- too long
+  # Use 63+1+63+1+61 = 189 then add more: 63.63.63.61 = 253 chars? 63+1+63+1+63+1+61 = 253 - yes!
+  let validLong = "a".repeat(63) & "." & "b".repeat(63) & "." &
+                  "c".repeat(63) & "." & "d".repeat(61)
+  check validLong.len == 253
+  check toAsciiDomain(validLong) == validLong
+
+  # Hostname of 254 chars raises ValueError
+  let tooLong = "a".repeat(63) & "." & "b".repeat(63) & "." &
+                "c".repeat(63) & "." & "d".repeat(62)
+  check tooLong.len == 254
+  checkRaises(ValueError):
+    discard toAsciiDomain(tooLong)
+
+# ---------------------------------------------------------------------------
+# parseServerPort
+# ---------------------------------------------------------------------------
+
+proc testParseServerPort() =
+  block:
+    let (h, p) = parseServerPort("8.8.8.8")
+    check h == "8.8.8.8" and int(p) == 53
+
+  block:
+    let (h, p) = parseServerPort("8.8.8.8:5353")
+    check h == "8.8.8.8" and int(p) == 5353
+
+  block:
+    let (h, p) = parseServerPort("[::1]")
+    check h == "::1" and int(p) == 53
+
+  block:
+    let (h, p) = parseServerPort("[::1]:5353")
+    check h == "::1" and int(p) == 5353
+
+  block:
+    let (h, p) = parseServerPort("[2001:db8::1]")
+    check h == "2001:db8::1" and int(p) == 53
+
+  block:
+    let (h, p) = parseServerPort("[2001:db8::1]:5353")
+    check h == "2001:db8::1" and int(p) == 5353
+
+  # Bare IPv6 (no brackets) — falls back via parseUri mismatch detection
+  block:
+    let (h, p) = parseServerPort("::1")
+    check h == "::1" and int(p) == 53
+
+  block:
+    let (h, p) = parseServerPort("2001:db8::1")
+    check h == "2001:db8::1" and int(p) == 53
+
+  # Port boundary values
+  block:
+    let (h, p) = parseServerPort("8.8.8.8:1")
+    check h == "8.8.8.8" and int(p) == 1
+
+  block:
+    let (h, p) = parseServerPort("8.8.8.8:65535")
+    check h == "8.8.8.8" and int(p) == 65535
+
+  # Out-of-range port falls back to default (host must still be extracted correctly)
+  block:
+    let (h, p) = parseServerPort("8.8.8.8:0")
+    check h == "8.8.8.8" and int(p) == 53
+
+  block:
+    let (h, p) = parseServerPort("8.8.8.8:65536")
+    check h == "8.8.8.8" and int(p) == 53
+
+  block:
+    let (h, p) = parseServerPort("8.8.8.8:99999")
+    check h == "8.8.8.8" and int(p) == 53
+
+  # Non-numeric port falls back to default (host still extracted)
+  block:
+    let (h, p) = parseServerPort("8.8.8.8:abc")
+    check h == "8.8.8.8" and int(p) == 53
+
+  # Bracketed IPv6 with out-of-range port
+  block:
+    let (h, p) = parseServerPort("[::1]:0")
+    check h == "::1" and int(p) == 53
+
+  block:
+    let (h, p) = parseServerPort("[::1]:65536")
+    check h == "::1" and int(p) == 53
+
+  # Bracketed IPv6 with non-numeric port
+  block:
+    let (h, p) = parseServerPort("[::1]:abc")
+    check h == "::1" and int(p) == 53
+
+# ---------------------------------------------------------------------------
+# dnsLookup - error paths (no network traffic required)
+# ---------------------------------------------------------------------------
+
+proc testDnsLookupValidation() =
+  # Invalid label length raises ValueError before any socket is opened
+  checkRaises(ValueError):
+    dnsLookup("a".repeat(64) & ".com")
+
+  # Invalid total length raises ValueError
+  checkRaises(ValueError):
+    dnsLookup(
+      "a".repeat(63) & "." & "b".repeat(63) & "." &
+      "c".repeat(63) & "." & "d".repeat(62),
+    )
+
+proc testDnsLookupTimeout() =
+  # 192.0.2.x is TEST-NET (RFC 5737), routable but never responds.
+  # With a 100ms timeout the query must time out rather than hang.
+  var timedOut = false
+  try:
+    dnsLookup(
+      domain    = "example.com",
+      server    = "192.0.2.1",
+      timeoutMs = 100,
+    )
+  except IOError as e:
+    if "timed out" in e.msg:
+      timedOut = true
+  check timedOut
+
+# ---------------------------------------------------------------------------
+
+testPunycode()
+testToAsciiDomain()
+testParseServerPort()
+testDnsLookupValidation()
+testDnsLookupTimeout()
+echo "All DNS tests passed."

--- a/tests/unit/test_dns.nim
+++ b/tests/unit/test_dns.nim
@@ -1,4 +1,7 @@
 import std/[
+  nativesockets,
+  net,
+  posix,
   strutils,
 ]
 import "../../src/utils/dns"
@@ -252,6 +255,72 @@ proc testDnsLookupTimeout() =
       timedOut = true
   check timedOut
 
+var gStubFd   {.global.}: cint = -1
+var gStubDone {.global.}: bool = false
+
+proc runStub(ignored: int) {.thread.} =
+  # Receive one query datagram, then send two replies:
+  # 1) wrong transaction ID (XOR 0xFF on both ID bytes) -- must be discarded
+  # 2) correct transaction ID, RCODE=0                  -- must be accepted
+  var
+    query:   array[512, byte]
+    fromSa:  array[128, byte]
+    fromLen = SockLen(128)
+  let n = posix.recvfrom(
+    SocketHandle(gStubFd),
+    cast[pointer](addr query[0]),
+    512,
+    cint(0),
+    cast[ptr SockAddr](addr fromSa[0]),
+    addr fromLen,
+  )
+  if n < 2:
+    gStubDone = true
+    return
+  var bad:  array[12, byte]
+  var good: array[12, byte]
+  bad[0]  = query[0] xor byte(0xFF)
+  bad[1]  = query[1] xor byte(0xFF)
+  bad[2]  = byte(0x80)
+  good[0] = query[0]
+  good[1] = query[1]
+  good[2] = byte(0x80)
+  discard posix.sendto(
+    SocketHandle(gStubFd), cast[pointer](addr bad[0]), 12, cint(0),
+    cast[ptr SockAddr](addr fromSa[0]), fromLen,
+  )
+  discard posix.sendto(
+    SocketHandle(gStubFd), cast[pointer](addr good[0]), 12, cint(0),
+    cast[ptr SockAddr](addr fromSa[0]), fromLen,
+  )
+  gStubDone = true
+
+proc testDnsTransactionIdValidation() =
+  # Bind a stub UDP server on a random loopback port.  The stub sends a
+  # bad-ID response first, then a good-ID response.  dnsLookup must discard
+  # the first and succeed on the second.
+  let srv = newSocket(
+    domain   = Domain.AF_INET,
+    sockType = SockType.SOCK_DGRAM,
+    protocol = Protocol.IPPROTO_UDP,
+    buffered = false,
+  )
+  defer: srv.close()
+  srv.bindAddr(Port(0), "127.0.0.1")
+  let (_, srvPort) = srv.getLocalAddr()
+  gStubFd   = srv.getFd().cint
+  gStubDone = false
+
+  var t: Thread[int]
+  createThread(t, runStub, 0)
+  dnsLookup(
+    domain    = "example.com",
+    server    = "127.0.0.1:" & $srvPort,
+    timeoutMs = 2000,
+  )
+  joinThread(t)
+  check gStubDone
+
 # ---------------------------------------------------------------------------
 
 testPunycode()
@@ -259,4 +328,5 @@ testToAsciiDomain()
 testParseServerPort()
 testDnsLookupValidation()
 testDnsLookupTimeout()
+testDnsTransactionIdValidation()
 echo "All DNS tests passed."

--- a/tests/unit/test_substitutions.nim
+++ b/tests/unit/test_substitutions.nim
@@ -1,0 +1,68 @@
+import "../../src/utils/substitutions"
+
+template check(cond: untyped) =
+  doAssert cond, "failed: " & astToStr(cond)
+
+template checkRaises(exc: typedesc, body: untyped) =
+  block:
+    var raised = false
+    try:
+      body
+    except exc:
+      raised = true
+    doAssert raised, "expected " & astToStr(exc) & " to be raised but it was not"
+
+proc identity(key: string): string = key
+
+proc testNormalPath() =
+  # No placeholders — passthrough
+  check applySubstitutions("hello.world", identity) == "hello.world"
+
+  # Single placeholder
+  check applySubstitutions("{foo}", identity) == "FOO"
+
+  # Multiple placeholders
+  check applySubstitutions("{a}.{b}.{c}", identity) == "A.B.C"
+
+  # Keys are uppercased before lookup
+  check applySubstitutions("{lower}", identity) == "LOWER"
+  check applySubstitutions("{UPPER}", identity) == "UPPER"
+  check applySubstitutions("{Mixed}", identity) == "MIXED"
+
+  # Literal text mixed with placeholders
+  check applySubstitutions("prefix.{key}.suffix", identity) == "prefix.KEY.suffix"
+
+  # Lookup return value is spliced verbatim
+  check applySubstitutions(
+    "{x}",
+    proc(key: string): string = "replaced",
+  ) == "replaced"
+
+proc testEmptyBraces() =
+  # Empty {} raises ValueError
+  checkRaises(ValueError):
+    discard applySubstitutions("{}.foo", identity)
+  checkRaises(ValueError):
+    discard applySubstitutions("a.{}.b", identity)
+
+proc testMalformedBraces() =
+  # Repeated '{' without closing '}'
+  checkRaises(ValueError):
+    discard applySubstitutions("{a{b}", identity)
+
+  # '}' without preceding '{'
+  checkRaises(ValueError):
+    discard applySubstitutions("a}b", identity)
+
+  # Trailing unclosed '{'
+  checkRaises(ValueError):
+    discard applySubstitutions("{abc", identity)
+
+  # Trailing '{' with no key
+  checkRaises(ValueError):
+    discard applySubstitutions("foo.{", identity)
+
+testNormalPath()
+testEmptyBraces()
+testMalformedBraces()
+echo "All substitution tests passed."


### PR DESCRIPTION
## Summary

- New \`dns\` sink type that encodes chalk key values into a DNS lookup hostname for egress-restricted environments. Supports \`{KEY}\` placeholder substitution, per-key \`normalize\` callbacks (e.g. dot-to-hyphen for version strings, lowercase for node IDs), custom resolver with configurable timeout, \`disable_after_errors\` threshold, and IDNA/Punycode encoding.
- DNS sink iterates \`_CHALKS\` internally to emit one lookup per chalk mark; falls back to a single lookup when no marks are present.
- New \`custom_report\` field \`per_chalk: true\` — emit one report per chalk mark instead of a bundled report.
- Four new runtime host keys: \`_MONOTIME\`, \`_SINCE_TIMESTAMP\`, \`_SINCE_MONOTIME\`, \`_HEARTBEAT_COUNT\`.
- Generic \`{KEY}\` template substitution engine extracted to \`src/utils/substitutions.nim\` (shared between docker push tag rendering and the DNS sink). The engine now raises \`ValueError\` on empty \`{}\` placeholders and unclosed \`{\` — previously these were silently dropped.
- Hardened DNS client: transaction ID validation, QR bit check (RFC 1035 §4.1.1), UDP source filtering, and \`gai_strerror\` included in system-resolver error messages.
- Design doc: \`docs/design-dns-sink.md\`.

## Test plan

```shell
make tests args="test_sink.py::test_dns_sink -x -s"
make tests args="test_sink.py::test_dns_sink_normalize -x -s"
make tests args="test_exec.py -x -s"
make unit-tests args="pattern tests/unit/test_dns.nim"
make unit-tests args="pattern tests/unit/test_substitutions.nim"
```