### PR TITLE
fix: misc fixes from post-release observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- `FAILED_KEYS` is no longer included in most default report templates; they now
+  subscribe to `_FAILED_KEYS` (the runtime artifact key, populated after all
+  post-build operations complete) instead of the chalk-time snapshot.
+  ([#692](https://github.com/crashappsec/chalk/pull/692))
+  - `report_default` — `FAILED_KEYS` removed, `_FAILED_KEYS` added
+  - `report_large` — `FAILED_KEYS` removed, `_FAILED_KEYS` added
+  - `insertion_default` — `FAILED_KEYS` removed, `_FAILED_KEYS` added
+  - `report_all` — unchanged; subscribes to both `FAILED_KEYS` and `_FAILED_KEYS`
+  - All other templates (`null`, `unknown_docker`, `audit`, `usage`, `heartbeat`,
+    `terminal_insert`, `terminal_rest`) — unaffected; did not subscribe to either
+  - `FAILED_KEYS` remains available in the chalk mark itself
+  - Consumers reading `FAILED_KEYS` from reports should switch to `_FAILED_KEYS`
+
 ### New Features
 
 - Four new runtime host keys for timing and heartbeat tracking:

--- a/src/configs/base_chalk_templates.c4m
+++ b/src/configs/base_chalk_templates.c4m
@@ -31,7 +31,6 @@ or vice versa.
   key.TIME_CHALKED.use                        = true
   key.TZ_OFFSET_WHEN_CHALKED.use              = true
   key.DATETIME_WHEN_CHALKED.use               = true
-  key.EARLIEST_VERSION.use                    = true
   key.HOST_SYSNAME_WHEN_CHALKED.use           = true
   key.HOST_NODENAME_WHEN_CHALKED.use          = true
   key.HOST_RELEASE_WHEN_CHALKED.use           = true
@@ -151,7 +150,6 @@ mark_template mark_large {
   key.TIME_CHALKED.use                        = false
   key.TZ_OFFSET_WHEN_CHALKED.use              = false
   key.DATETIME_WHEN_CHALKED.use               = true
-  key.EARLIEST_VERSION.use                    = true
   key.HOST_SYSNAME_WHEN_CHALKED.use           = true
   key.HOST_NODENAME_WHEN_CHALKED.use          = true
   key.HOST_RELEASE_WHEN_CHALKED.use           = true

--- a/src/configs/base_keyspecs.c4m
+++ b/src/configs/base_keyspecs.c4m
@@ -210,19 +210,6 @@ value of `_TIMESTAMP` would give for the operation.
 """
 }
 
-keyspec EARLIEST_VERSION {
-    kind:           ChalkTimeHost
-    type:           string
-    standard:       true
-    system:         true
-    conf_as_system: true
-    ~value:         chalk_version
-    since:          "0.1.0"
-    shortdoc:       "Reserved for future use"
-    doc:            """
-This key is reserved for future use; it is not currently used in any capacity.
-"""
-}
 
 keyspec HOST_SYSNAME_WHEN_CHALKED {
     kind:     ChalkTimeHost

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -32,7 +32,6 @@ report and subtract from it.
   key.TIME_CHALKED.use                        = true
   key.TZ_OFFSET_WHEN_CHALKED.use              = true
   key.DATETIME_WHEN_CHALKED.use               = true
-  key.EARLIEST_VERSION.use                    = true
   key.HOST_SYSNAME_WHEN_CHALKED.use           = true
   key.HOST_NODENAME_WHEN_CHALKED.use          = true
   key.HOST_RELEASE_WHEN_CHALKED.use           = true
@@ -570,7 +569,6 @@ doc: """
   key.TIME_CHALKED.use                        = true
   key.TZ_OFFSET_WHEN_CHALKED.use              = true
   key.DATETIME_WHEN_CHALKED.use               = true
-  key.EARLIEST_VERSION.use                    = true
   key.HOST_SYSNAME_WHEN_CHALKED.use           = true
   key.HOST_NODENAME_WHEN_CHALKED.use          = true
   key.HOST_RELEASE_WHEN_CHALKED.use           = true
@@ -731,7 +729,6 @@ doc: """
   key.TIME_CHALKED.use                        = true
   key.TZ_OFFSET_WHEN_CHALKED.use              = true
   key.DATETIME_WHEN_CHALKED.use               = true
-  key.EARLIEST_VERSION.use                    = true
   key.HOST_SYSNAME_WHEN_CHALKED.use           = true
   key.HOST_NODENAME_WHEN_CHALKED.use          = true
   key.HOST_RELEASE_WHEN_CHALKED.use           = true
@@ -1158,7 +1155,6 @@ container.
   key.TIME_CHALKED.use                        = true
   key.TZ_OFFSET_WHEN_CHALKED.use              = true
   key.DATETIME_WHEN_CHALKED.use               = true
-  key.EARLIEST_VERSION.use                    = true
   key.HOST_SYSNAME_WHEN_CHALKED.use           = true
   key.HOST_NODENAME_WHEN_CHALKED.use          = true
   key.HOST_RELEASE_WHEN_CHALKED.use           = true
@@ -1712,7 +1708,6 @@ and keep the run-time key.
   key.TIME_CHALKED.use                        = false
   key.TZ_OFFSET_WHEN_CHALKED.use              = false
   key.DATETIME_WHEN_CHALKED.use               = false
-  key.EARLIEST_VERSION.use                    = false
   key.HOST_SYSNAME_WHEN_CHALKED.use           = false
   key.HOST_NODENAME_WHEN_CHALKED.use          = false
   key.HOST_RELEASE_WHEN_CHALKED.use           = false

--- a/src/configs/crashoverride.c4m
+++ b/src/configs/crashoverride.c4m
@@ -28,7 +28,6 @@ This is mostly a copy of insert template however all keys are immutable.
   ~key.TIME_CHALKED.use                               = false
   ~key.TZ_OFFSET_WHEN_CHALKED.use                     = false
   ~key.DATETIME_WHEN_CHALKED.use                      = true
-  ~key.EARLIEST_VERSION.use                           = false
   ~key.HOST_SYSNAME_WHEN_CHALKED.use                  = false
   ~key.HOST_NODENAME_WHEN_CHALKED.use                 = false
   ~key.HOST_RELEASE_WHEN_CHALKED.use                  = false

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -520,7 +520,9 @@ proc request(self:              DockerImage,
   let cacheKey = (self, httpMethod, path, useCase)
   if cacheKey in jsonCache:
     return jsonCache[cacheKey]
-  var registryError = ""
+  var
+    registryError  = ""
+    ignoredErrors: seq[string] = @[]
   for config in self.getConfigs(useCase = useCase):
     let
       normalized = (
@@ -616,10 +618,15 @@ proc request(self:              DockerImage,
         registryError = getCurrentExceptionMsg()
         break
       else:
-        trace("docker: ignoring error: " & getCurrentExceptionMsg())
+        let msg = getCurrentExceptionMsg()
+        trace("docker: ignoring error: " & msg)
+        ignoredErrors.add(msg)
   if registryError != "":
     raise newException(RegistryResponseError, registryError)
-  raise newException(ValueError, "could not find working registry configuration for " & $self)
+  var errMsg = "could not find working registry configuration for " & $self
+  if ignoredErrors.len > 0:
+    errMsg &= ": " & ignoredErrors.join("; ")
+  raise newException(ValueError, errMsg)
 
 proc validateDigest(digest: string): string =
   if not digest.startsWith("sha256:") or digest.len != 71:

--- a/src/docker/registry.nim
+++ b/src/docker/registry.nim
@@ -580,6 +580,7 @@ proc request(self:              DockerImage,
             verifyMode        = config.verifyMode,
             timeout           = timeout,
             retries           = 2,
+            connectRetries    = 2,
             acceptStatusCodes = acceptStatusCodes,
           )
         config.wwwAuth[normalized.repo][isGet] = wwwAuth.update(authHeaders)

--- a/src/plugins/awsEcs.nim
+++ b/src/plugins/awsEcs.nim
@@ -29,32 +29,36 @@ let
 # returns ecs metadata as a json blob
 var
   ecsMetadata = ChalkDict()
-  ecsUrl = cloudMetadataUrl4
+  ecsUrl      = cloudMetadataUrl4
 if ecsUrl == "":
   ecsUrl = cloudMetadataUrl3
 
 proc clearCallback(self: Plugin) {.cdecl.} =
   ecsMetadata = ChalkDict()
 
-proc requestECSMetadata(path: string): Option[Box] =
-  let url = ecsUrl & path
-  var body = ""
+proc requestECSMetadata(path: string): Box =
+  let
+    url  = ecsUrl & path
+    resp =
+      try:
+        safeRequest(
+          url               = url,
+          retries           = 2,
+          connectRetries    = 2,
+          acceptStatusCodes = @[200..200],
+        )
+      except:
+        let msg = getCurrentExceptionMsg()
+        error("ecs: " & url & " request failed: " & msg)
+        dumpExOnDebug()
+        raise
   try:
-    var
-      resp   = safeRequest(url, retries=2, connectRetries=2)
-    if resp.code != Http200:
-      error("ecs: " & url & " returned " & resp.status)
-      return none(Box)
-    body = resp.body()
+    return parseJson(resp.body()).nimJsonToBox()
   except:
-    error("ecs: " & url & " request failed with " & getCurrentExceptionMsg())
-    return none(Box)
-  try:
-    let parsed = parseJson(body)
-    return some(parsed.nimJsonToBox())
-  except:
-    error("ecs: " & url & " didnt return valid json " & getCurrentExceptionMsg())
-    return none(Box)
+    let msg = getCurrentExceptionMsg()
+    error("ecs: " & url & " didnt return valid json " & msg)
+    dumpExOnDebug()
+    raise newException(IOError, url & " returned invalid JSON: " & msg)
 
 proc readECSMetadata*(): ChalkDict =
   # This can be called from outside if anything needs to query the JSON.
@@ -63,47 +67,73 @@ proc readECSMetadata*(): ChalkDict =
     if ecsUrl == "":
       trace("ecs: metadata env var is not defined: no AWS info available")
       return ecsMetadata
-
-    let container = requestECSMetadata("")
-    if container.isNone():
-      return ecsMetadata
-
-    ecsMetadata["container"] = container.get()
-
-    let task = requestECSMetadata("/task")
-    if task.isSome():
-      ecsMetadata["task"] = task.get()
-
-    let stats = requestECSMetadata("/task/stats")
-    if stats.isSome():
-      ecsMetadata["task/stats"] = stats.get()
-
+    ecsMetadata["container"] = requestECSMetadata("")
+    try:
+      ecsMetadata["task"] = requestECSMetadata("/task")
+    except:
+      let msg = getCurrentExceptionMsg()
+      addFailedKey(
+        "_OP_CLOUD_METADATA",
+        code        = "ECS_TASK_METADATA_ERROR",
+        error       = msg,
+        description = "The ECS task metadata endpoint (" & ecsUrl & "/task) was unreachable or returned invalid data",
+      )
+    try:
+      ecsMetadata["task/stats"] = requestECSMetadata("/task/stats")
+    except:
+      let msg = getCurrentExceptionMsg()
+      addFailedKey(
+        "_OP_CLOUD_METADATA",
+        code        = "ECS_TASK_STATS_METADATA_ERROR",
+        error       = msg,
+        description = "The ECS task/stats metadata endpoint (" & ecsUrl & "/task/stats) was unreachable or returned invalid data",
+      )
   return ecsMetadata
 
 proc ecsGetChalkTimeHostInfo*(self: Plugin): ChalkDict {.cdecl.} =
-  let data = readECSMetadata()
   result = ChalkDict()
-  if len(data) > 0:
-    var cloudData = ChalkDict()
-    cloudData["aws_ecs"] = pack(data)
-    result.setIfNeeded("CLOUD_METADATA_WHEN_CHALKED", cloudData)
+  try:
+    let data = readECSMetadata()
+    if len(data) > 0:
+      var cloudData = ChalkDict()
+      cloudData["aws_ecs"] = pack(data)
+      result.setIfNeeded("CLOUD_METADATA_WHEN_CHALKED", cloudData)
+  except:
+    let msg = getCurrentExceptionMsg()
+    dumpExOnDebug()
+    addFailedKey(
+      "CLOUD_METADATA_WHEN_CHALKED",
+      code        = "ECS_METADATA_ERROR",
+      error       = msg,
+      description = "The ECS container metadata endpoint (" & ecsUrl & ") was unreachable or returned invalid data",
+    )
 
 proc ecsGetRunTimeHostInfo*(self: Plugin, objs: seq[ChalkObj]):
                           ChalkDict {.cdecl.} =
-  let data = readECSMetadata()
   result = ChalkDict()
-  if len(data) > 0:
-    var cloudData = ChalkDict()
-    cloudData["aws_ecs"] = pack(data)
-    result.setIfNeeded("_OP_CLOUD_METADATA",               cloudData)
-    result.setIfNeeded("_OP_CLOUD_PROVIDER",               "aws")
-    result.setIfNeeded("_OP_CLOUD_PROVIDER_SERVICE_TYPE",  "aws_ecs")
-    let containerArnOpt = data.lookupByPath("container.ContainerARN")
-    if containerArnOpt.isSome():
-      let containerArn = parseArn($(containerArnOpt.get()))
-      result.setIfNeeded("_OP_CLOUD_PROVIDER_ACCOUNT_INFO", containerArn.account)
-      result.setIfNeeded("_OP_CLOUD_PROVIDER_REGION",       containerArn.region)
-      result.setIfNeeded("_AWS_REGION",                     containerArn.region)
+  try:
+    let data = readECSMetadata()
+    if len(data) > 0:
+      var cloudData = ChalkDict()
+      cloudData["aws_ecs"] = pack(data)
+      result.setIfNeeded("_OP_CLOUD_METADATA",               cloudData)
+      result.setIfNeeded("_OP_CLOUD_PROVIDER",               "aws")
+      result.setIfNeeded("_OP_CLOUD_PROVIDER_SERVICE_TYPE",  "aws_ecs")
+      let containerArnOpt = data.lookupByPath("container.ContainerARN")
+      if containerArnOpt.isSome():
+        let containerArn = parseArn($(containerArnOpt.get()))
+        result.setIfNeeded("_OP_CLOUD_PROVIDER_ACCOUNT_INFO", containerArn.account)
+        result.setIfNeeded("_OP_CLOUD_PROVIDER_REGION",       containerArn.region)
+        result.setIfNeeded("_AWS_REGION",                     containerArn.region)
+  except:
+    let msg = getCurrentExceptionMsg()
+    dumpExOnDebug()
+    addFailedKey(
+      "_OP_CLOUD_METADATA",
+      code        = "ECS_METADATA_ERROR",
+      error       = msg,
+      description = "The ECS container metadata endpoint (" & ecsUrl & ") was unreachable or returned invalid data",
+    )
 
 proc loadAwsEcs*() =
   newPlugin("aws_ecs",

--- a/src/plugins/ciGithub.nim
+++ b/src/plugins/ciGithub.nim
@@ -18,26 +18,44 @@ import ".."/[
   utils/json,
 ]
 
+type GithubApiError = ref object of CatchableError
+  apiCode*: string
+
+proc newGithubApiError(code, msg: string): GithubApiError =
+  result = GithubApiError(msg: msg, apiCode: code)
+
 proc getRepo(api: string, repo: string): JsonNode =
   # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
-  result = newJObject()
   let token = getEnv("GITHUB_TOKEN")
   if token == "":
-    warn("github: GITHUB_TOKEN is empty. " &
-         "If this is running inside GitHub action, make sure ${{ github.token }} is explicitly passed. " &
-         "See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow")
-    return
+    let msg = (
+      "GITHUB_TOKEN is empty. " &
+      "If this is running inside GitHub action, make sure ${{ github.token }} is explicitly passed. " &
+      "See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow"
+    )
+    warn("github: " & msg)
+    raise newGithubApiError("GITHUB_NO_TOKEN", msg)
   if not api.startsWith("http://") and not api.startsWith("https://"):
-    warn("github: invalid api url (" & api & "). Cannot query repo node id")
-    return
+    let msg = "invalid api url (" & api & "). Cannot query repo node id"
+    warn("github: " & msg)
+    raise newGithubApiError("GITHUB_INVALID_API_URL", msg)
   let
     url      = api.strip(chars = {'/'}, leading = false) & "/repos/" & repo.strip(chars = {'/'}, trailing = false)
     headers  = newHttpHeaders({"Authorization": "Bearer " & token})
-    response = safeRequest(url, httpMethod = HttpGet, headers = headers)
-  if not response.code().is2xx():
-    warn("github: could not fetch repo info from " & url & ". " &
-         "Received " & response.status)
-    return
+    response =
+      try:
+        safeRequest(
+          url               = url,
+          httpMethod        = HttpGet,
+          headers           = headers,
+          retries           = 2,
+          connectRetries    = 2,
+          acceptStatusCodes = @[200..299],
+        )
+      except HttpStatusError as e:
+        warn("github: " & e.msg)
+        dumpExOnDebug()
+        raise newGithubApiError("GITHUB_API_ERROR", e.msg)
   return parseJson(response.body())
 
 proc getGithubMetadata(self: Plugin, prefix=""): ChalkDict =
@@ -113,8 +131,23 @@ proc getGithubMetadata(self: Plugin, prefix=""): ChalkDict =
       let data = getRepo(GITHUB_API_URL, GITHUB_REPOSITORY)
       result.setIfNeeded(prefix & "BUILD_ORIGIN_KEY",       data{"node_id"}.getStr())
       result.setIfNeeded(prefix & "BUILD_ORIGIN_OWNER_KEY", data{"owner"}{"node_id"}.getStr())
+    except GithubApiError as e:
+      addFailedKeys(
+        [prefix & "BUILD_ORIGIN_KEY", prefix & "BUILD_ORIGIN_OWNER_KEY"],
+        code        = e.apiCode,
+        error       = e.msg,
+        description = "GitHub API call failed while fetching repository node IDs",
+      )
     except:
-      warn("github: could not fetch repo info: " & getCurrentExceptionMsg())
+      let msg = getCurrentExceptionMsg()
+      warn("github: could not fetch repo info: " & msg)
+      dumpExOnDebug()
+      addFailedKeys(
+        [prefix & "BUILD_ORIGIN_KEY", prefix & "BUILD_ORIGIN_OWNER_KEY"],
+        code        = "GITHUB_API_EXCEPTION",
+        error       = msg,
+        description = "GitHub API call failed while fetching repository node IDs",
+      )
 
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
   if GITHUB_EVENT_NAME == "push" and GITHUB_REF_TYPE == "tag":

--- a/src/plugins/cloudMetadata.nim
+++ b/src/plugins/cloudMetadata.nim
@@ -18,6 +18,7 @@ import ".."/[
   utils/envvars,
   utils/http,
   utils/json,
+  utils/strings,
 ]
 
 const
@@ -33,41 +34,55 @@ const
   # special keys for special processing
   AWS_IDENTITY_CREDENTIALS_SECURITY_CREDS = "_AWS_IDENTITY_CREDENTIALS_EC2_SECURITY_CREDENTIALS_EC2_INSTANCE"
 
+proc parseNonEmptyJson(url: string, data: string, default = newJObject()): JsonNode =
+  if data == "":
+    return default
+  try:
+    result = parseJson(data)
+  except:
+    trace("cloudmetadata: " & url & " returned invalid json - " & getCurrentExceptionMsg())
+    dumpExOnDebug()
+    raise
+
 proc getUrl(path: string): string =
   let ip = attrGet[string]("cloud_provider.metadata_ip")
   return "http://" & ip & path
 
-proc hitProviderEndpoint(path: string, hdrs: HttpHeaders): Option[string] =
-  let url      = getUrl(path)
-  try:
-    let
-      response = safeRequest(url            = url,
-                             httpMethod     = HttpGet,
-                             timeout        = 1000, # 1 of a second
-                             connectRetries = 2,
-                             retries        = 2,
-                             headers        = hdrs)
-      body     = response.body().strip()
-
-    if not response.code.is2xx():
-      # 404 is expected response for some endpoints and logging full response body
-      # is very verbose. We only care about full body for other errors like 400,500,etc
-      if response.code == Http404:
-        trace("Could not retrieve metadata from: " & url & " - " & response.status)
+proc hitProviderEndpoint(path: string, hdrs: HttpHeaders, strict = false): string =
+  let
+    url         = getUrl(path)
+    acceptCodes =
+      if strict:
+        @[200..299]
       else:
-        trace("Could not retrieve metadata from: " & url & " - " & response.status & ": " & body)
-      return none(string)
-
+        @[200..299, 404..404]
+  try:
+    let response = safeRequest(
+      url               = url,
+      httpMethod        = HttpGet,
+      timeout           = 1000, # 1 of a second
+      connectRetries    = 2,
+      retries           = 2,
+      headers           = hdrs,
+      acceptStatusCodes = acceptCodes,
+    )
+    if response.code == Http404:
+      trace("Could not retrieve metadata from: " & url & " - HTTP 404")
+      return ""
+    let body = response.body().strip()
     if body == "":
-      # some paths are expected to be empty so this is not an error
       trace("Got empty metadata from: " & url)
-
     trace("Retrieved metadata from: " & url)
-    return some(body)
-  except:
-    trace("Could not retrieve metadata from: " & url & " due to: " & getCurrentExceptionMsg())
+    return body
+  except HttpStatusError as e:
+    trace(e.msg)
     dumpExOnDebug()
-    return none(string)
+    raise
+  except:
+    let msg = getCurrentExceptionMsg()
+    trace("Could not retrieve metadata from: " & url & " due to: " & msg)
+    dumpExOnDebug()
+    raise
 
 type
   HostKind = enum
@@ -86,19 +101,29 @@ proc getAzureMetadata(): ChalkDict =
       isSubscribedKey("_OP_CLOUD_PROVIDER_TAGS") or
       isSubscribedKey("_OP_CLOUD_PROVIDER_ACCOUNT_INFO") or
       isSubscribedKey("_OP_CLOUD_PROVIDER_INSTANCE_TYPE"):
-    let resultOpt = hitProviderEndpoint(
-      "/metadata/instance?api-version=2021-02-01",
-      newHttpHeaders([("Metadata", "true")]),
-    )
-    if not resultOpt.isSome():
-      trace("Did not get metadata back from Azure endpoint")
+    var azureBody = ""
+    try:
+      azureBody = hitProviderEndpoint(
+        "/metadata/instance?api-version=2021-02-01",
+        newHttpHeaders([("Metadata", "true")]),
+        strict = true,
+      )
+    except:
+      let msg = getCurrentExceptionMsg()
+      trace("Did not get metadata back from Azure endpoint: " & msg)
+      dumpExOnDebug()
+      addFailedKey(
+        "_OP_CLOUD_METADATA",
+        code        = "AZURE_IMDS_ERROR",
+        error       = msg,
+        description = "Azure metadata endpoint at /metadata/instance was unreachable or returned a non-2xx response",
+      )
       return
-    let value = resultOpt.get()
-    if not value.startsWith("{"):
+    if not azureBody.startsWith("{"):
       trace("Azure metadata didnt respond with json object. Ignoring it")
       return
     try:
-      let jsonValue = parseJson(value)
+      let jsonValue = parseJson(azureBody)
       result.setIfNeeded("_AZURE_INSTANCE_METADATA", jsonValue)
       try:
         for iface in jsonValue["network"]["interface"]:
@@ -114,6 +139,7 @@ proc getAzureMetadata(): ChalkDict =
             break
       except:
         trace("Could not set _OP_CLOUD_PROVIDER_IP for azure: " & getCurrentExceptionMsg())
+        dumpExOnDebug()
       result.trySetIfNeeded("_OP_CLOUD_PROVIDER_TAGS"):
         jsonValue["compute"]["tagsList"].nimJsonToBox()
       result.trySetIfNeeded("_OP_CLOUD_PROVIDER_ACCOUNT_INFO"):
@@ -123,7 +149,15 @@ proc getAzureMetadata(): ChalkDict =
       result.trySetIfNeeded("_OP_CLOUD_PROVIDER_INSTANCE_TYPE"):
         jsonValue["compute"]["vmSize"].getStr()
     except:
-      trace("Azure metadata responded with invalid json: " & getCurrentExceptionMsg())
+      let msg = getCurrentExceptionMsg()
+      trace("Azure metadata responded with invalid json: " & msg)
+      dumpExOnDebug()
+      addFailedKey(
+        "_OP_CLOUD_METADATA",
+        code        = "AZURE_IMDS_PARSE_ERROR",
+        error       = msg,
+        description = "Azure IMDS endpoint returned data that could not be parsed as JSON",
+      )
 
 proc getGcpMetadata(): ChalkDict =
   result = ChalkDict()
@@ -141,34 +175,51 @@ proc getGcpMetadata(): ChalkDict =
       isSubscribedKey("_OP_CLOUD_PROVIDER_INSTANCE_TYPE"):
     trace("Querying for GCP metadata")
     if isSubscribedKey("_GCP_PROJECT_METADATA"):
-      let projectOpt = hitProviderEndpoint(
-        "/computeMetadata/v1/project/?recursive=true",
-        newHttpHeaders([("Metadata-Flavor", "Google")]),
-      )
-      if projectOpt.isSome():
-        try:
-          let valueProj = projectOpt.get()
-          if valueProj.startsWith("{"):
-            let jsonProjValue = parseJson(valueProj)
-            result.setIfNeeded("_GCP_PROJECT_METADATA", jsonProjValue)
-          else:
-            trace("GCP project metadata didnt respond with json object. Ignoring it")
-        except:
-          trace("Could not set _GCP_PROJECT_METADATA: " & getCurrentExceptionMsg())
+      var projBody = ""
+      try:
+        projBody = hitProviderEndpoint(
+          "/computeMetadata/v1/project/?recursive=true",
+          newHttpHeaders([("Metadata-Flavor", "Google")]),
+          strict = true,
+        )
+      except:
+        let msg = getCurrentExceptionMsg()
+        dumpExOnDebug()
+        addFailedKey(
+          "_GCP_PROJECT_METADATA",
+          code        = "GCP_PROJECT_METADATA_ERROR",
+          error       = msg,
+          description = "GCP metadata endpoint at /computeMetadata/v1/project was unreachable or returned a non-2xx response",
+        )
+      if projBody.startsWith("{"):
+        result.trySetIfNeeded("_GCP_PROJECT_METADATA"):
+          parseJson(projBody).nimJsonToBox()
+      elif projBody != "":
+        trace("GCP project metadata didnt respond with json object. Ignoring it")
 
-    let resultOpt = hitProviderEndpoint(
-      "/computeMetadata/v1/instance/?recursive=true",
-      newHttpHeaders([("Metadata-Flavor", "Google")]),
-    )
-    if not resultOpt.isSome():
+    var gcpBody = ""
+    try:
+      gcpBody = hitProviderEndpoint(
+        "/computeMetadata/v1/instance/?recursive=true",
+        newHttpHeaders([("Metadata-Flavor", "Google")]),
+        strict = true,
+      )
+    except:
+      let msg = getCurrentExceptionMsg()
       trace("Did not get instance metadata back from GCP endpoint")
+      dumpExOnDebug()
+      addFailedKey(
+        "_OP_CLOUD_METADATA",
+        code        = "GCP_IMDS_ERROR",
+        error       = msg,
+        description = "GCP metadata endpoint at /computeMetadata/v1/instance was unreachable or returned a non-2xx response",
+      )
       return
-    let value = resultOpt.get()
-    if not value.startsWith("{"):
+    if not gcpBody.startsWith("{"):
       trace("GCP metadata didnt respond with json object. Ignoring it")
       return
     try:
-      let jsonValue = parseJson(value)
+      let jsonValue = parseJson(gcpBody)
       try:
         for iface in jsonValue["networkInterfaces"]:
           var found = false
@@ -183,6 +234,7 @@ proc getGcpMetadata(): ChalkDict =
             break
       except:
         trace("Could not insert _OP_CLOUD_PROVIDER_IP for gcp: " & getCurrentExceptionMsg())
+        dumpExOnDebug()
       result.trySetIfNeeded("_GCP_INSTANCE_METADATA"):
         jsonValue.nimJsonToBox()
       result.trySetIfNeeded("_OP_CLOUD_PROVIDER_TAGS"):
@@ -194,7 +246,15 @@ proc getGcpMetadata(): ChalkDict =
       result.trySetIfNeeded("_OP_CLOUD_PROVIDER_INSTANCE_TYPE"):
         jsonValue["machineType"].getStr().split("/")[^1]
     except:
-      trace("GCP metadata responded with invalid json: " & getCurrentExceptionMsg())
+      let msg = getCurrentExceptionMsg()
+      trace("GCP metadata responded with invalid json: " & msg)
+      dumpExOnDebug()
+      addFailedKey(
+        "_OP_CLOUD_METADATA",
+        code        = "GCP_IMDS_PARSE_ERROR",
+        error       = msg,
+        description = "GCP IMDS endpoint returned data that could not be parsed as JSON",
+      )
 
 proc getAwsToken(): Option[string] =
   let url      = getUrl(awsBaseUri & "api/token")
@@ -265,94 +325,61 @@ proc getAwsToken(): Option[string] =
     return none(string)
 
 proc oneItem(chalkDict: ChalkDict, token: string, keyname: string, url: string) =
-  ## If `keyname` is subscribed, hits the given `url` and sets the `keyname` key
-  ## in `chalkDict` to the value of the response (if non-empty).
-  if isSubscribedKey(keyname):
-    let
-      hdrs      = newHttpHeaders([("X-aws-ec2-metadata-token", token)])
-      resultOpt = hitProviderEndpoint(url, hdrs)
-    chalkDict.setIfNotEmpty(keyname, resultOpt)
+  chalkDict.trySetIfNeeded(keyname):
+    hitProviderEndpoint(
+      url,
+      newHttpHeaders([("X-aws-ec2-metadata-token", token)]),
+    )
 
 proc listKey(chalkDict: ChalkDict, token: string, keyname: string, url: string) =
-  ## If `keyname` is subscribed, hits the given `url` and sets the `keyname` key
-  ## in `chalkDict` to the value of the response (as a `seq` of lines).
-  if isSubscribedKey(keyname):
-    let
-      hdrs      = newHttpHeaders([("X-aws-ec2-metadata-token", token)])
-      resultOpt = hitProviderEndpoint(url, hdrs)
-    if resultOpt.isSome():
-      chalkDict.setIfNeeded(keyname, resultOpt.get().splitLines())
+  chalkDict.trySetIfNeeded(keyname):
+    hitProviderEndpoint(
+      url,
+      newHttpHeaders([("X-aws-ec2-metadata-token", token)]),
+    ).splitLinesAnd(keepEmpty = false)
 
 proc jsonKey(chalkDict: ChalkDict, token: string, keyname: string, url: string) =
-  ## If `keyname` is subscribed, hits the given `url` and sets the `keyname` key
-  ## in `chalkDict` to the value of the response (as JSON).
-  ##
-  ## If `keyname` is the value of `AWS_IDENTITY_CREDENTIALS_SECURITY_CREDS`,
-  ## sets `<<redacted>>` as the values of `SecretAccessKey` and `Token` in
-  ## `chalkDict`.
-  if isSubscribedKey(keyname):
-    let
-      hdrs      = newHttpHeaders([("X-aws-ec2-metadata-token", token)])
-      resultOpt = hitProviderEndpoint(url, hdrs)
-    if resultOpt.isSome():
-      let value = resultOpt.get()
-      # imdsv2 does not respond with application/json content-type
-      # header and so we check first char before attempting json parse
-      if not value.startsWith("{"):
-        trace("IMDSv2 didnt respond with json object. Ignoring it. URL: " & url)
-      else:
-        try:
-          let jsonValue = parseJson(value)
-          # redact some keys as they contain sensitive api keys
-          case keyname
-          of AWS_IDENTITY_CREDENTIALS_SECURITY_CREDS:
-            jsonValue["SecretAccessKey"] = newJString("<<redacted>>")
-            jsonValue["Token"] = newJString("<<redacted>>")
-          chalkDict.setIfNeeded(keyname, jsonValue)
-        except:
-          trace("IMDSv2 responded with invalid json from " & url & ": " & getCurrentExceptionMsg())
+  var jsonValue: JsonNode
+  chalkDict.trySetIfNeeded(keyname):
+    jsonValue = parseNonEmptyJson(url, hitProviderEndpoint(
+      url,
+      newHttpHeaders([("X-aws-ec2-metadata-token", token)]),
+    ))
+    case keyname
+    of AWS_IDENTITY_CREDENTIALS_SECURITY_CREDS:
+      if len(jsonValue) > 0:
+        jsonValue["SecretAccessKey"] = newJString("<<redacted>>")
+        jsonValue["Token"]           = newJString("<<redacted>>")
+    jsonValue.nimJsonToBox()
 
 proc extractJsonKey(chalkDict: ChalkDict, token: string, keyname: string,
                     url: string, subkey: string) =
-  ## If `keyname` is subscribed, hits the given `url` and sets the `keyname` key
-  ## in `chalkDict` to the value of `subkey` in the response.
-  if isSubscribedKey(keyname):
-    let
-      hdrs      = newHttpHeaders([("X-aws-ec2-metadata-token", token)])
-      resultOpt = hitProviderEndpoint(url, hdrs)
-    if resultOpt.isSome():
-      let value = resultOpt.get()
-      # imdsv2 does not respond with application/json content-type
-      # header and so we check first char before attempting json parse
-      if not value.startsWith("{"):
-        trace("Provider Didn't respond with json object. Ignoring it. URL: " & url)
-      else:
-        chalkDict.trySetIfNeeded(keyname):
-          parseJson(value)[subkey].getStr()
+  chalkDict.trySetIfNeeded(keyname):
+    parseNonEmptyJson(url, hitProviderEndpoint(
+      url,
+      newHttpHeaders([("X-aws-ec2-metadata-token", token)]),
+    )){subkey}.getStr()
 
 proc getTags(chalkDict: ChalkDict, token: string, keyname: string, url: string) =
-  ## If `keyname` is subscribed, hits the given `url` and sets the `keyname` key
-  ## in `chalkDict` to a `ChalkDict` of tag/value pairs.
-  if isSubscribedKey(keyname):
+  let tags = ChalkDict()
+  chalkDict.trySetIfNeeded(keyname):
     let
-      hdrs      = newHttpHeaders([("X-aws-ec2-metadata-token", token)])
-      resultOpt = hitProviderEndpoint(url, hdrs)
-    if resultOpt.isSome():
-      let
-        value = resultOpt.get()
-        tags  = ChalkDict()
-      # tag reponse is a newline-delimited list of tags
-      # which are set on the instance
-      # to each tag values an endpoint needs to be hit
-      # for each tag key to get its value
-      for line in value.split("\n"):
-        let name = line.strip()
-        if name == "":
-          continue
-        let tagOpt = hitProviderEndpoint(url & "/" & name, hdrs)
-        if tagOpt.isSome():
-          tags.setIfNotEmpty(name, tagOpt.get())
-        chalkDict.setIfNeeded(keyname, tags)
+      hdrs    = newHttpHeaders([("X-aws-ec2-metadata-token", token)])
+      tagList = hitProviderEndpoint(url, hdrs)
+    for name in tagList.splitLinesAnd(keepEmpty = false):
+      try:
+        tags.setIfNotEmpty(name, hitProviderEndpoint(url & "/" & name, hdrs))
+      except:
+        let msg = getCurrentExceptionMsg()
+        trace("Could not retrieve tag " & name & " from " & url & ": " & msg)
+        dumpExOnDebug()
+        addFailedKey(
+          keyname,
+          code        = "CLOUD_TAG_FETCH_ERROR",
+          error       = msg,
+          description = "Could not retrieve value for tag \"" & name & "\" from " & url,
+        )
+    tags
 
 proc getAwsMetadata(): ChalkDict =
   result = ChalkDict()

--- a/src/plugins/k8s.nim
+++ b/src/plugins/k8s.nim
@@ -286,8 +286,20 @@ proc k8sGetRunTimeHostInfo*(self: Plugin,
     result.setIfNeeded("_K8S_CLUSTER_ENDPOINT",          clusterMetadata{"endpoint"}.getStr())
     result.trySetIfNeeded("_K8S_CLUSTER_CLOUD_METADATA", k8sMetadata{"cloud"}.default(newJObject()).assertIs(JObject).nimJsonToBox())
   except:
-    trace("k8s: could not parse cluster metadata: " & getCurrentExceptionMsg())
+    let msg = getCurrentExceptionMsg()
+    trace("k8s: could not parse cluster metadata: " & msg)
     dumpExOnDebug()
+    addFailedKeys(
+      [
+        "_K8S_CLUSTER_ID",
+        "_K8S_CLUSTER_NAME",
+        "_K8S_CLUSTER_ENDPOINT",
+        "_K8S_CLUSTER_CLOUD_METADATA",
+      ],
+      code        = "K8S_METADATA_PARSE_ERROR",
+      error       = msg,
+      description = "Could not parse Kubernetes cluster metadata from CHALK_K8S_METADATA env var",
+    )
     return
 
   let
@@ -297,6 +309,20 @@ proc k8sGetRunTimeHostInfo*(self: Plugin,
     return
   let token = tryToLoadFile(podMetadataTokenPath)
   if token == "":
+    addFailedKeys(
+      [
+        "_K8S_POD_MANIFEST",
+        "_K8S_POD_LABELS",
+        "_K8S_POD_ANNOTATIONS",
+        "_K8S_CONTAINER_ENV_VAR_HASHES",
+        "_K8S_CONTAINER_VOLUME_MOUNT_HASHES",
+        "_K8S_CONTAINER_PORTS",
+        "_EXEC_DEPLOYMENT_ID",
+      ],
+      code        = "K8S_TOKEN_ERROR",
+      error       = "Token at " & podMetadataTokenPath & " is empty or unreadable",
+      description = "Could not read the Chalk operator token needed to authenticate the pod manifest request",
+    )
     return
   trace("k8s: fetching pod manifest from " & podManifestUrl)
   var podManifest: JsonNode
@@ -316,8 +342,23 @@ proc k8sGetRunTimeHostInfo*(self: Plugin,
     result.trySetIfNeeded("_K8S_POD_LABELS",      metadata{"labels"}.default(newJObject()).assertIs(JObject).nimJsonToBox())
     result.trySetIfNeeded("_K8S_POD_ANNOTATIONS", metadata{"annotations"}.default(newJObject()).assertIs(JObject).nimJsonToBox())
   except:
-    trace("k8s: could not fetch pod manifest: " & getCurrentExceptionMsg())
+    let msg = getCurrentExceptionMsg()
+    trace("k8s: could not fetch pod manifest: " & msg)
     dumpExOnDebug()
+    addFailedKeys(
+      [
+        "_K8S_POD_MANIFEST",
+        "_K8S_POD_LABELS",
+        "_K8S_POD_ANNOTATIONS",
+        "_K8S_CONTAINER_ENV_VAR_HASHES",
+        "_K8S_CONTAINER_VOLUME_MOUNT_HASHES",
+        "_K8S_CONTAINER_PORTS",
+        "_EXEC_DEPLOYMENT_ID",
+      ],
+      code        = "K8S_POD_MANIFEST_ERROR",
+      error       = msg,
+      description = "Could not fetch pod manifest from Kubernetes API at " & podManifestUrl,
+    )
     return
 
   try:
@@ -328,8 +369,20 @@ proc k8sGetRunTimeHostInfo*(self: Plugin,
       containerName = containerName,
     ))
   except:
-    trace("k8s: could not collect container info: " & getCurrentExceptionMsg())
+    let msg = getCurrentExceptionMsg()
+    trace("k8s: could not collect container info: " & msg)
     dumpExOnDebug()
+    addFailedKeys(
+      [
+        "_K8S_CONTAINER_ENV_VAR_HASHES",
+        "_K8S_CONTAINER_VOLUME_MOUNT_HASHES",
+        "_K8S_CONTAINER_PORTS",
+        "_EXEC_DEPLOYMENT_ID",
+      ],
+      code        = "K8S_CONTAINER_INFO_ERROR",
+      error       = msg,
+      description = "Could not collect container info from the pod manifest",
+    )
     return
 
 proc loadK8s*() =

--- a/src/plugins/vctlGit.nim
+++ b/src/plugins/vctlGit.nim
@@ -121,17 +121,16 @@ proc collectVcsData(cache: GitInfo, worktree: string): GitRepoInfo =
   if result.errorStatus != "":
     let msg = result.errorStatus
     error("git: worktree status failed for " & worktree & ": " & msg)
-    for key in [
-      "_VCS_MISSING_FILES",
-      "_VCS_MODIFIED_FILES",
-      "_VCS_UNTRACKED_FILES",
-    ]:
-      addFailedKey(
-        key,
-        code        = "GIT_COLLECTION_FAILED",
-        error       = msg,
-        description = "libgit2 failed to collect worktree status for " & worktree,
-      )
+    addFailedKeys(
+      [
+        "_VCS_MISSING_FILES",
+        "_VCS_MODIFIED_FILES",
+        "_VCS_UNTRACKED_FILES",
+      ],
+      code        = "GIT_COLLECTION_FAILED",
+      error       = msg,
+      description = "libgit2 failed to collect worktree status for " & worktree,
+    )
   if result.errorDiff != "":
     let msg = result.errorDiff
     error("git: diff collection failed for " & worktree & ": " & msg)

--- a/src/run_management.nim
+++ b/src/run_management.nim
@@ -240,17 +240,18 @@ template setIfNotEmptyBox(o: ChalkDict, k: string, v: Box) =
     o[k] = value
 
 template setIfNotEmpty*[T](o: ChalkDict, k: string, v: T) =
+  let captured = v
   when T is Box:
-    if not isNil(v):
-      setIfNotEmptyBox(o, k, v)
+    if not isNil(captured):
+      setIfNotEmptyBox(o, k, captured)
   elif T is JsonNode:
-    if not isNil(v):
-      setIfNotEmptyBox(o, k, v.nimJsonToBox())
+    if not isNil(captured):
+      setIfNotEmptyBox(o, k, captured.nimJsonToBox())
   elif T is Option:
-    if v.isSome():
-      setIfNotEmptyBox(o, k, pack(v.get()))
+    if captured.isSome():
+      setIfNotEmptyBox(o, k, pack(captured.get()))
   else:
-    setIfNotEmptyBox(o, k, pack(v))
+    setIfNotEmptyBox(o, k, pack(captured))
 
 template setFromEnvVar*(o: ChalkDict, k: string, default: string = "") =
   o.setIfNotEmpty(k, os.getEnv(k, default))
@@ -278,11 +279,19 @@ template setIfNeeded*[T](o: ChalkDict, k: string, v: T) =
 template setIfNeeded*[T](o: ChalkObj, k: string, v: T) =
   setIfNeeded(o.collectedData, k, v)
 
-template trySetIfNeeded*(o: ChalkDict, k: string, code: untyped) =
+template trySetIfNeeded*(o: ChalkDict, k: string, val: untyped) =
   try:
-    o.setIfNeeded(k, code)
+    o.setIfNeeded(k, val)
   except:
-    trace("Could not set chalk key " & k & " due to: " & getCurrentExceptionMsg())
+    let msg = getCurrentExceptionMsg()
+    trace("Could not set chalk key " & k & " due to: " & msg)
+    dumpExOnDebug()
+    addFailedKey(
+      k,
+      code        = "KEY_COLLECTION_ERROR",
+      error       = msg,
+      description = "Exception raised while collecting key " & k,
+    )
 
 proc idFormat*(rawHash: string): string =
   let s = base32vEncode(rawHash)
@@ -309,6 +318,10 @@ proc addFailedKey*(key: string, code: string, error: string, description: string
     addFailedEntry(failedKeys, key, failure)
   else:
     addFailedEntry(errObject.get().failedKeys, key, failure)
+
+proc addFailedKeys*(keys: openArray[string], code: string, error: string, description: string) =
+  for key in keys:
+    addFailedKey(key, code, error, description)
 
 proc lookupByPath*(obj: ChalkDict, path: string): Option[Box] =
   let

--- a/src/utils/strings.nim
+++ b/src/utils/strings.nim
@@ -100,7 +100,7 @@ proc splitLinesAnd*(items: string, keepEol = false, keepEmpty = true): seq[strin
   if keepEmpty:
     return lines
   for i in lines:
-    if i != "":
+    if i.strip() != "":
       result.add(i)
 
 proc elseWhenEmpty*(s: string, default: string): string =

--- a/src/utils/www_authenticate.nim
+++ b/src/utils/www_authenticate.nim
@@ -68,13 +68,25 @@ proc initBearerChallenge(options: var OrderedTable[string, string]): AuthChallen
                        realm:   realm,
                        url:     $uri)
 
-proc elicitHeaders(self: AuthChallenge, headers = newHttpHeaders()): HttpHeaders =
+proc elicitHeaders(
+    self:           AuthChallenge,
+    headers:        HttpHeaders = newHttpHeaders(),
+    timeout:        int         = 1000,
+    retries:        int         = 0,
+    connectRetries: int         = 0,
+): HttpHeaders =
   case self.kind:
   of other:
     raise newException(ValueError, "unsupported auth challenge scheme: " & self.scheme)
   of bearer:
     trace("http: fetching bearer token from: " & self.url)
-    let tokenResponse = safeRequest(self.url, headers = headers)
+    let tokenResponse = safeRequest(
+      self.url,
+      headers        = headers,
+      timeout        = timeout,
+      retries        = retries,
+      connectRetries = connectRetries,
+    )
     if not tokenResponse.code().is2xx():
       raise newException(ValueError,
                          "Bearer auth realm URL did not return valid response: " &
@@ -89,11 +101,22 @@ proc elicitHeaders(self: AuthChallenge, headers = newHttpHeaders()): HttpHeaders
                          tokenBody)
     result = newHttpHeaders({"Authorization": "Bearer " & token})
 
-proc elicitHeaders*(challenges: seq[AuthChallenge], headers = newHttpHeaders()): HttpHeaders =
+proc elicitHeaders*(
+    challenges:     seq[AuthChallenge],
+    headers:        HttpHeaders = newHttpHeaders(),
+    timeout:        int         = 1000,
+    retries:        int         = 0,
+    connectRetries: int         = 0,
+): HttpHeaders =
   result = newHttpHeaders()
   for challenge in challenges:
     try:
-      return challenge.elicitHeaders(headers = headers)
+      return challenge.elicitHeaders(
+        headers        = headers,
+        timeout        = timeout,
+        retries        = retries,
+        connectRetries = connectRetries,
+      )
     except:
       continue
 
@@ -140,6 +163,7 @@ proc authHeadersSafeRequest*(url: Uri | string,
                              headers: HttpHeaders = newHttpHeaders(),
                              multipart: MultipartData = nil,
                              retries: int = 0,
+                             connectRetries: int = 0,
                              firstRetryDelayMs: int = 0,
                              timeout: int = 1000,
                              pinnedCert: string = "",
@@ -159,6 +183,7 @@ proc authHeadersSafeRequest*(url: Uri | string,
       headers           = authHeaders,
       multipart         = multipart,
       retries           = retries,
+      connectRetries    = connectRetries,
       firstRetryDelayMs = firstRetryDelayMs,
       timeout           = timeout,
       pinnedCert        = pinnedCert,
@@ -175,7 +200,12 @@ proc authHeadersSafeRequest*(url: Uri | string,
     let
       wwwAuthenticate = response.headers["www-authenticate"]
       challenges      = parseAuthChallenges(wwwAuthenticate)
-    newHeaders        = challenges.elicitHeaders(authHeaders)
+    newHeaders        = challenges.elicitHeaders(
+      headers        = authHeaders,
+      timeout        = timeout,
+      retries        = retries,
+      connectRetries = connectRetries,
+    )
     authHeaders       = authHeaders.update(newHeaders)
 
     # reattempt request
@@ -186,6 +216,7 @@ proc authHeadersSafeRequest*(url: Uri | string,
       headers           = authHeaders,
       multipart         = multipart,
       retries           = retries,
+      connectRetries    = connectRetries,
       firstRetryDelayMs = firstRetryDelayMs,
       timeout           = timeout,
       pinnedCert        = pinnedCert,
@@ -213,6 +244,7 @@ proc authHeadersSafeRequest*(url: Uri | string,
       headers           = authHeaders,
       multipart         = multipart,
       retries           = retries,
+      connectRetries    = connectRetries,
       firstRetryDelayMs = firstRetryDelayMs,
       timeout           = timeout,
       pinnedCert        = pinnedCert,
@@ -231,6 +263,7 @@ proc authSafeRequest*(url: Uri | string,
                       headers: HttpHeaders = newHttpHeaders(),
                       multipart: MultipartData = nil,
                       retries: int = 0,
+                      connectRetries: int = 0,
                       firstRetryDelayMs: int = 0,
                       timeout: int = 1000,
                       pinnedCert: string = "",
@@ -247,6 +280,7 @@ proc authSafeRequest*(url: Uri | string,
     headers           = headers,
     multipart         = multipart,
     retries           = retries,
+    connectRetries    = connectRetries,
     firstRetryDelayMs = firstRetryDelayMs,
     timeout           = timeout,
     pinnedCert        = pinnedCert,


### PR DESCRIPTION
## Summary

- Remove the `EARLIEST_VERSION` keyspec and all references to it in report/mark templates and `crashoverride.c4m`. The key has been marked \"reserved for future use\" since `0.1.0` and was never read or acted on by any code.
- Add a breaking change entry to `CHANGELOG.md` documenting that `FAILED_KEYS` was removed from `report_default`, `report_large`, and `insertion_default` in #692 when `_FAILED_KEYS` was introduced. The change was not documented at the time.
- Fix registry error message to include the underlying ignored errors (mirror 404s, connect timeouts) when all configs are exhausted, instead of the opaque \"could not find working registry configuration\" message.
- Fix bearer token fetch in `elicitHeaders` to use the same timeout and retry policy as the main registry request. Previously the token fetch to `auth.docker.io` used nimutils defaults (1s timeout, 0 retries), causing transient connect timeouts to be silently swallowed. Also add `connectRetries` support to `authHeadersSafeRequest` so TCP-level connect failures are retried, matching the resilience of the main request path.
- Improve error handling and FAILED_KEYS coverage across cloud metadata plugins:
  - Remove `isSubscribedKey` guard from `addFailedKey` so failures are always recorded regardless of whether the data key itself is subscribed; a user subscribing `_OP_FAILED_KEYS` to monitor errors should not need to also subscribe every individual data key.
  - ECS task and task/stats endpoint failures now call `addFailedKey` under `_OP_CLOUD_METADATA`; previously they were silently discarded after logging. Also include the URL in `requestECSMetadata` HTTP error messages.
  - Per-tag value fetch failures in `getTags` now call `addFailedKey` using the outer keyname (`_AWS_TAGS` or `_OP_CLOUD_PROVIDER_TAGS`) so incomplete tag collections are visible in `FAILED_KEYS`.
  - Azure IMDS failure trace message now includes the exception message alongside the static description.

## Test plan

```shell
make tests args="-x -s"
```