### PR TITLE
feat: add GitLab CI collapsible log section sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
 
 ### New Features
 
+- New GitLab CI collapsible log section sink. When chalk runs inside a GitLab
+  CI job (`GITLAB_CI` is set), the chalk report is automatically wrapped in
+  GitLab's `section_start`/`section_end` markers with `collapsed=true`, making
+  it collapsible in the GitLab job log UI — mirroring the existing GitHub
+  Actions `::group::` support.
+  ([#696](https://github.com/crashappsec/chalk/pull/696))
+
 - Four new runtime host keys for timing and heartbeat tracking:
   - `_MONOTIME` — monotonic clock value at the start of the current operation,
     in milliseconds (kernel monotonic time, suitable for elapsed-time math).

--- a/src/configs/base_report_templates.c4m
+++ b/src/configs/base_report_templates.c4m
@@ -2304,6 +2304,7 @@ The summary report that outputs to your terminal by default, when
 running insert commands.
 """
   key._OPERATION.use                          = true
+  key._ACTION_ID.use                          = true
   key._DATETIME.use                           = true
   key._TIMESTAMP.use                          = true
   key._MONOTIME.use                           = true

--- a/src/configs/base_sinkconfs.c4m
+++ b/src/configs/base_sinkconfs.c4m
@@ -34,6 +34,12 @@ sink_config github_json_group {
   filters: ["pretty_json", "github_log_group", "fix_new_line"]
 }
 
+# https://docs.gitlab.com/ee/ci/jobs/index.html#custom-collapsible-sections
+sink_config gitlab_json_group {
+  sink: "stdout"
+  filters: ["pretty_json", "gitlab_log_section", "fix_new_line"]
+}
+
 # This is the default sink for virtual chalking.
 sink_config virtual_chalk_log {
   enabled:  true

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -28,7 +28,7 @@ key_types            := ["Chalk-time Host", "Chalk-time Artifact",
                          "Run-time Artifact", "Run-time Host"]
 known_sink_filters   := ["log_level", "log_prefix", "pretty_json",
                          "fix_new_line", "add_topic", "wrap",
-                         "github_log_group"]
+                         "github_log_group", "gitlab_log_section"]
 
 # This is the enum for key types.   See 'key' object documentation below
 # for more details.

--- a/src/configs/ioconfig.c4m
+++ b/src/configs/ioconfig.c4m
@@ -29,6 +29,13 @@ custom_report github_group_chalk_time {
   use_when:        ["insert", "extract", "build", "push", "pull"]
 }
 
+custom_report gitlab_group_chalk_time {
+  enabled:         false
+  report_template: "terminal_insert"
+  sink_configs:    ["gitlab_json_group"]
+  use_when:        ["insert", "extract", "build", "push", "pull"]
+}
+
 if not using_tty() {
   color: false
   custom_report.terminal_chalk_time.enabled: false
@@ -52,6 +59,10 @@ if skip_summary_report {
 
 if env_exists("CI") and env_exists("GITHUB_SHA") {
   custom_report.github_group_chalk_time.enabled: true
+}
+
+if env_exists("CI") and env_exists("GITLAB_CI") {
+  custom_report.gitlab_group_chalk_time.enabled: true
 }
 
 cmd := command_name()

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -63,14 +63,28 @@ proc githubLogGroup(msg: string, extra: StringTable): (string, bool) =
   message.stripLineEnd() # in-place strip
   return (@[header, message, footer].join("\n"), true)
 
+proc gitlabLogSection(msg: string, extra: StringTable): (string, bool) =
+  # https://docs.gitlab.com/ee/ci/jobs/index.html#custom-collapsible-sections
+  # Timestamp must be an integer (Unix seconds); GitLab rejects floats.
+  let
+    ts      = $int(getTime().toUnixFloat())
+    esc     = "\e[0K"
+    header  = esc & "section_start:" & ts & ":chalk_report[collapsed=true]\r" & esc & "Chalk Report"
+    footer  = esc & "section_end:"   & ts & ":chalk_report\r" & esc
+  var
+    message = msg
+  message.stripLineEnd()
+  return (@[header, message, footer].join("\n"), true)
+
 const
-  availableFilters = { "log_level"       : MsgFilter(logLevelFilter),
-                       "log_prefix"      : MsgFilter(logPrefixFilter),
-                       "pretty_json"     : MsgFilter(prettyJson),
-                       "fix_new_line"    : MsgFilter(fixNewline),
-                       "show_topic"      : MsgFilter(showTopic),
-                       "wrap"            : MsgFilter(chalkLogWrap),
-                       "github_log_group": MsgFilter(githubLogGroup),
+  availableFilters = { "log_level"         : MsgFilter(logLevelFilter),
+                       "log_prefix"        : MsgFilter(logPrefixFilter),
+                       "pretty_json"       : MsgFilter(prettyJson),
+                       "fix_new_line"      : MsgFilter(fixNewline),
+                       "show_topic"        : MsgFilter(showTopic),
+                       "wrap"              : MsgFilter(chalkLogWrap),
+                       "github_log_group"  : MsgFilter(githubLogGroup),
+                       "gitlab_log_section": MsgFilter(gitlabLogSection),
                      }.toTable()
 
 proc chalkErrSink*(msg: string, cfg: SinkConfig, t: Topic, arg: StringTable) =

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -295,6 +295,13 @@ class ChalkProgram(Program):
         return self.report.marks
 
     @property
+    def all_marks(self):
+        marks = []
+        for r in self.reports:
+            marks += r.marks
+        return marks
+
+    @property
     def artifact(self):
         return self.report.artifact
 
@@ -514,7 +521,7 @@ class Chalk:
         )
         if expecting_report:
             if expecting_chalkmarks:
-                for chalk in result.marks:
+                for chalk in result.all_marks:
                     assert chalk.has(_VIRTUAL=IfExists(virtual))
                 if virtual:
                     assert result.virtual_path.exists()

--- a/tests/functional/test_plugins.py
+++ b/tests/functional/test_plugins.py
@@ -221,9 +221,13 @@ def test_github(
         "GITHUB_EVENT_NAME": "push",
         "GITHUB_REF_TYPE": "tag",
         "RUNNER_TEMP": str(tmp_data_dir),
+        # enable github report as its default by default in testing.c4m
+        "SHOW_GITHUB_GROUP": "true",
     }
     insert = chalk.insert(bin_path, env=env)
-    assert insert.report.contains(
+
+    # first report is normal one and second is the github one
+    assert insert.reports[0].contains(
         {
             "BUILD_ID": "51064362862",
             "BUILD_UNIQUE_ID": str,
@@ -245,10 +249,13 @@ def test_github(
         }
     )
     insert2 = chalk.insert(bin_path, env=env)
-    assert insert2.report.has(BUILD_UNIQUE_ID=insert.report["BUILD_UNIQUE_ID"])
+    assert insert2.reports[0].has(BUILD_UNIQUE_ID=insert.reports[0]["BUILD_UNIQUE_ID"])
+
+    assert "::group::Chalk Report" in insert.text
+    assert "::endgroup::" in insert.text
 
     env = chalk.run(command="env", env=env)
-    assert env.report.contains(
+    assert env.reports[0].contains(
         {
             "_BUILD_ID": "51064362862",
             "_BUILD_UNIQUE_ID": str,
@@ -291,9 +298,12 @@ def test_gitlab(copy_files: list[Path], chalk: Chalk):
             "CI_PROJECT_NAMESPACE_ID": "456",
             "CI_CONFIG_PATH": "ci/.gitlab-ci.yml",
             "CI_PIPELINE_NAME": "build",
+            # enable gitlab group report as it is disabled by default in testing.c4m
+            "SHOW_GITLAB_GROUP": "true",
         },
     )
-    assert insert.report.contains(
+    # first report is normal one and second is the gitlab one
+    assert insert.reports[0].contains(
         {
             "BUILD_ID": "4999820578",
             "BUILD_COMMIT_ID": "ffac537e6cbbf934b08745a378932722df287a53",
@@ -309,6 +319,9 @@ def test_gitlab(copy_files: list[Path], chalk: Chalk):
             "BUILD_WORKFLOW_PATH": "ci/.gitlab-ci.yml",
         }
     )
+
+    assert "section_start:" in insert.text
+    assert "section_end:" in insert.text
 
 
 @pytest.mark.parametrize("copy_files", [[LS_PATH]], indirect=True)

--- a/tests/functional/testing.c4m
+++ b/tests/functional/testing.c4m
@@ -8,7 +8,8 @@ log_format = "plain"
 
 subscribe("report", "json_console_out")
 subscribe("fail",   "json_console_out")
-custom_report.github_group_chalk_time.enabled: false
+custom_report.github_group_chalk_time.enabled: env_exists("SHOW_GITHUB_GROUP")
+custom_report.gitlab_group_chalk_time.enabled: env_exists("SHOW_GITLAB_GROUP")
 custom_report.terminal_chalk_time.enabled: false
 custom_report.terminal_other_op.enabled: false
 custom_report.terminal_other_op.use_when: ["extract", "delete", "exec", "env", "heartbeat", "postexec"]


### PR DESCRIPTION
## Summary

- Adds a `gitlab_log_section` sink filter that wraps chalk report output in GitLab's `section_start`/`section_end` ANSI markers with `collapsed=true`, so the report renders as a collapsed section in the GitLab CI job log UI
- Mirrors the existing GitHub Actions `::group::` sink — enabled automatically when `CI` and `GITLAB_CI` env vars are set
- Updates `testing.c4m` to gate both group sinks behind opt-in env vars (`SHOW_GITHUB_GROUP` / `SHOW_GITLAB_GROUP`), and adds group marker assertions to `test_github` and `test_gitlab`

## Test plan

```shell
make tests args="test_plugins.py::test_gitlab test_plugins.py::test_github -x -s"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)