### PR TITLE
feat: add sink fallback chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+CLAUDE.md
 .TODO
 /bin
 /chalk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,38 @@
 
   ([#689](https://github.com/crashappsec/chalk/pull/689))
 
+- Sink configs now support a `fallback_sink_config` field naming another
+  `sink_config` to use when the primary is unavailable. When the primary fails
+  or is disabled by errors, chalk walks the fallback chain until one succeeds.
+  Key behaviors:
+  - The fallback is attempted on every delivery failure, regardless of whether
+    the `disable_after_errors` threshold has been reached.
+  - Each sink in the chain has its own independent `disable_after_errors`
+    threshold.
+  - If the fallback delivers successfully, no report cache entry is created for
+    that delivery.
+  - Circular chains are rejected at configuration load time.
+  - The field is accepted on all sink types.
+
+  ```con4m
+  sink_config primary_api {
+    sink:                 "post"
+    uri:                  "https://api.us-east-1.example.com/report"
+    disable_after_errors: 3
+    fallback_sink_config: "backup_api"
+  }
+
+  sink_config backup_api {
+    sink:                 "post"
+    uri:                  "https://api.eu-west-1.example.com/report"
+    disable_after_errors: 3
+  }
+
+  subscribe("report", "primary_api")
+  ```
+
+  ([#698](https://github.com/crashappsec/chalk/pull/698))
+
 ## 1.1.3
 
 **July 6, 2026**

--- a/docs/design-sink-fallback.md
+++ b/docs/design-sink-fallback.md
@@ -140,9 +140,10 @@ sink type declaration so the con4m validator accepts the field.
 
 **`src/configs/chalk.c42spec`** — add an `elif conffield == "fallback_sink_config"`
 branch in `sink_config_check` to validate that the referenced name exists as a
-`sink_config` section. Circular-chain detection is handled in Nim, not here,
-because the full graph may not be loaded when the validator runs for any
-individual section.
+`sink_config` section. `sections("sink_config")` returns all declared sections
+regardless of order, so forward references are safe. Circular-chain detection
+is handled in Nim rather than here because the graph traversal is simpler to
+express in Nim.
 
 ### Nim changes
 
@@ -180,8 +181,13 @@ the result.
 
 - Skips disabled sinks (enabled = false) and continues to the next link.
 - If the candidate is already a live (non-runtime-disabled) subscriber of the
-  same topic, it already received the message via the normal publish path —
-  returns `true` immediately to avoid double delivery.
+  same topic and is **not** in `sinkErrors` (it succeeded during normal
+  publish), returns `true` immediately — the message was already delivered,
+  no action needed.
+- If the candidate is a live subscriber but **is** in `sinkErrors` (it also
+  failed during normal publish), skips it to avoid double-delivery and
+  continues to the next link. The primary's error is cached independently of
+  the candidate's own failure tracking.
 - Otherwise, creates a `$fallback$<topic>$<currentName>` temp topic, subscribes
   the candidate, and publishes the pre-wrapped message. `sinkErrors` is
   saved and restored around the publish so fallback failures do not contaminate

--- a/docs/design-sink-fallback.md
+++ b/docs/design-sink-fallback.md
@@ -1,0 +1,217 @@
+# Design: Sink Fallback Chain
+
+This document describes the design and intent behind the `fallback_sink_config`
+field, which allows a `sink_config` to name another `sink_config` to use when
+the primary is unavailable.
+
+## Motivation
+
+Chalk's `disable_after_errors` mechanism stops hammering a sink that has
+started consistently failing, but it leaves the problem of what to do with
+reports that can no longer be delivered. Today they go to the report cache and
+are retried on the next chalk invocation — but if the underlying endpoint is
+persistently unavailable, those cached reports accumulate indefinitely.
+
+For operations where metadata delivery is critical — `insert`, `build`, `exec`,
+and heartbeats — this gap can be significant. A corporate proxy blocking TLS to
+a presign endpoint, a regional API outage, or a misconfigured network policy
+can silently drop chalk reports for as long as the condition persists.
+
+The fallback chain gives operators a concrete alternative delivery path. Common
+scenarios:
+
+- Primary is a `presign` sink pointing to an internal API; fallback is an `s3`
+  sink with write-only credentials, reached via a different egress path.
+- Primary is a `post` sink in `us-east-1`; fallback is an identical `post` sink
+  in `eu-west-1`.
+- Primary is a high-fidelity `post` sink; fallback is a lightweight `dns` sink
+  that at minimum confirms the operation occurred.
+
+## Configuration
+
+Add `fallback_sink_config` to any `sink_config` section to name the sink that
+should receive the report when the primary cannot:
+
+```con4m
+sink_config primary_api {
+  sink:                  "presign"
+  uri:                   "https://api.corp.example.com/sign"
+  disable_after_errors:  3
+  fallback_sink_config:  "backup_s3"
+}
+
+sink_config backup_s3 {
+  sink:                  "s3"
+  uri:                   "s3://chalk-reports-backup/reports"
+  uid:                   env("CHALK_S3_KEY_ID")
+  secret:                env("CHALK_S3_SECRET")
+  region:                "us-east-1"
+  disable_after_errors:  5
+  fallback_sink_config:  "last_resort_dns"
+}
+
+sink_config last_resort_dns {
+  sink:            "dns"
+  domain_template: "{METADATA_ID}.chalk.fallback.example.com"
+  disable_after_errors: 10
+}
+
+subscribe("report", "primary_api")
+```
+
+Chains of arbitrary length are supported. Each sink in the chain has its own
+`disable_after_errors` threshold — a fallback that itself starts failing will
+eventually be disabled and the next link tried.
+
+Circular chains (`A → B → A`) are rejected at configuration load time with an
+error message.
+
+**New field:**
+
+| Field                  | Type     | Required | Default | Description                                                               |
+| ---------------------- | -------- | -------- | ------- | ------------------------------------------------------------------------- |
+| `fallback_sink_config` | `string` | false    | `""`    | Name of another `sink_config` to use when this sink fails or is disabled. |
+
+The field is accepted on all sink types.
+
+## Behavior
+
+### On every delivery failure
+
+When a primary sink fails to deliver a report (any error, regardless of whether
+the `disable_after_errors` threshold has been reached), chalk walks the fallback
+chain from that sink until it finds one that succeeds. The first success ends
+the walk; the report is not sent to any further links in the chain.
+
+The primary sink's consecutive-failure counter is incremented as normal. The
+fallback acts as a safety net for the report but does not suppress the primary's
+error accounting.
+
+### After the primary is disabled
+
+Once a sink's consecutive-failure counter reaches `disable_after_errors`,
+`cfg.enabled` is set to `false` and nimutils stops calling it during publish.
+Subsequent publish calls skip the primary silently — `ioErrorHandler` is never
+fired for it again.
+
+To handle this, chalk's publish path checks all subscribers that have been
+runtime-disabled and have a fallback configured, and delivers to their fallback
+chain directly. This happens in the same pass that handles active failures, so
+the behavior is uniform regardless of when the sink was disabled.
+
+### Runtime-disabled vs. user-disabled
+
+`fallback_sink_config` only activates for sinks that were disabled due to an
+error — not for sinks that were intentionally disabled by the operator. The
+distinction is tracked in a runtime set (`runtimeDisabledSinks`) that is
+populated only when chalk itself sets `enabled = false` due to an error:
+
+| Cause                                 | `runtimeDisabledSinks` | Fallback triggers? |
+| ------------------------------------- | ---------------------- | ------------------ |
+| `enabled: false` in config            | no                     | no                 |
+| `disable_after_errors` threshold      | yes                    | yes                |
+| Hard HTTP 4xx error                   | yes                    | yes                |
+| File sink write failure               | yes                    | yes                |
+| File path unresolvable at config load | yes                    | yes                |
+| Destination path not writable at load | yes                    | yes                |
+
+### Fallback's own error counting
+
+Each sink in the chain maintains its own independent consecutive-failure counter
+and `disable_after_errors` threshold. If the fallback itself starts failing, it
+accumulates toward its own threshold and is eventually disabled. At that point,
+the next link in the chain is tried. A sink that has been deliberately tuned
+with a higher threshold (or no threshold) can act as a persistent last resort.
+
+### Interaction with the report cache
+
+The report cache is unaffected. If every sink in the chain fails for a given
+report, the original primary sink is added to `sinkErrors` and the report is
+cached under its name as before. On the next chalk run, the primary starts
+enabled again (the runtime-disabled state is in-memory only), so the cached
+report is replayed through the full chain.
+
+## Implementation
+
+### Schema changes
+
+**`src/configs/base_sinks.c4m`** — add `~fallback_sink_config: false` to each
+sink type declaration so the con4m validator accepts the field.
+
+**`src/configs/chalk.c42spec`** — add an `elif conffield == "fallback_sink_config"`
+branch in `sink_config_check` to validate that the referenced name exists as a
+`sink_config` section. Circular-chain detection is handled in Nim, not here,
+because the full graph may not be loaded when the validator runs for any
+individual section.
+
+### Nim changes
+
+**`src/sinks.nim`**
+
+- `var sinkFallbacks: Table[string, string]` — maps `sink_config` name to its
+  configured fallback name.
+- `var runtimeDisabledSinks: HashSet[string]` — names of sinks disabled by
+  chalk due to errors (not by user config).
+- `proc getFallbackName*(name: string): string` — returns the fallback name, or
+  `""` if none.
+- `proc isRuntimeDisabled*(name: string): bool` — returns whether the sink was
+  disabled by an error.
+- `proc hasFallbackCycle(startName, proposed: string): bool` — walks
+  `sinkFallbacks` to detect a cycle before registering a new entry.
+- In `getSinkConfigByName`, new `of "fallback_sink_config"` case: reads the
+  value, runs `hasFallbackCycle`, stores in `sinkFallbacks` if clean, and
+  crucially does **not** add the field to `opts` (it is not a parameter for the
+  underlying sink implementation).
+- In `getSinkConfigByName`, at the two points where `enabled = false` is set
+  for file-path errors: add `runtimeDisabledSinks.incl(name)`.
+- In `ioErrorHandler`: add `runtimeDisabledSinks.incl(cfg.name)` when
+  `not cfg.enabled` (covers hard errors, threshold disables, and file write
+  failures). No fallback logic here.
+
+**`src/utils/sink_impls.nim`** — no changes. `onSinkError` continues to set
+`cfg.enabled = false` and re-raise; `ioErrorHandler` in `sinks.nim` observes
+the result.
+
+**`src/reportcache.nim`**
+
+`tryFallbackChain(primary: SinkConfig, topicName: string, wrappedMsg: string): bool`
+(in `sinks.nim`, called from `reportcache.nim`): walks the fallback chain from
+`primary`. For each candidate link:
+
+- Skips disabled sinks (enabled = false) and continues to the next link.
+- If the candidate is already a live (non-runtime-disabled) subscriber of the
+  same topic, it already received the message via the normal publish path —
+  returns `true` immediately to avoid double delivery.
+- Otherwise, creates a `$fallback$<topic>$<currentName>` temp topic, subscribes
+  the candidate, and publishes the pre-wrapped message. `sinkErrors` is
+  saved and restored around the publish so fallback failures do not contaminate
+  the caller's error state. The temp subscription is cleaned up in a
+  `try..finally` block. Returns `true` on first success.
+
+`handleFallbacks(topic: string, msg: string)` (in `reportcache.nim`, called
+from `safePublish`):
+
+```
+1. Collect candidates (deduplicated by name):
+   a. Every sink in sinkErrors that has a fallback configured
+      (active failure this publish cycle)
+   b. Every subscriber of the topic that isRuntimeDisabled and has a fallback
+      (was skipped silently by nimutils publish)
+2. Wrap msg as "[ <msg> ]\n" and call tryFallbackChain for each candidate.
+3. Remove successfully rescued sinks from sinkErrors.
+4. For candidates whose chain was fully exhausted, add them to sinkErrors
+   so the report is cached for the next run.
+```
+
+`safePublish` call order:
+
+```
+tracePublish(topic, msg, successfulPublishes)
+handleFallbacks(topic, msg)
+if sinkErrors.len != 0 and not cacheReadOnly:
+  addSinkErrorsToCache(topic, msg)
+```
+
+All fallback logic is confined to `handleFallbacks` and `tryFallbackChain`.
+`ioErrorHandler` and `getSinkConfigByName` only record the disable event;
+`safePublish` is the single point that acts on it.

--- a/src/configs/base_sinks.c4m
+++ b/src/configs/base_sinks.c4m
@@ -14,10 +14,11 @@
 ## callback outhook()
 
 sink file {
-  ~filename:        true
-  ~log_search_path: false
-  ~use_search_path: false
-  ~on_write_msg:    false
+  ~filename:             true
+  ~log_search_path:      false
+  ~use_search_path:      false
+  ~on_write_msg:         false
+  ~fallback_sink_config: false
   shortdoc:  "Log appending to a local file"
   doc:       """
 
@@ -49,11 +50,12 @@ then the sink configuration will error when used.
 }
 
 sink rotating_log {
-  ~filename:          true
-  ~max:               true
-  ~log_search_path:   false
-  ~truncation_amount: false
-  ~on_write_msg:      false
+  ~filename:             true
+  ~max:                  true
+  ~log_search_path:      false
+  ~truncation_amount:    false
+  ~on_write_msg:         false
+  ~fallback_sink_config: false
   shortdoc:       "A self-truncating log file"
   doc: """
 
@@ -93,6 +95,7 @@ sink s3 {
   ~endpoint:             false
   ~on_write_msg:         false
   ~disable_after_errors: false
+  ~fallback_sink_config: false
   shortdoc:              "S3 object storage"
   doc:                   """
 
@@ -174,6 +177,7 @@ sink post {
   ~on_write_msg:         false
   ~auth:                 false
   ~disable_after_errors: false
+  ~fallback_sink_config: false
   shortdoc:              "HTTP/HTTPS POST"
   doc:       """
 
@@ -250,6 +254,7 @@ sink presign {
   ~on_write_msg:         false
   ~auth:                 false
   ~disable_after_errors: false
+  ~fallback_sink_config: false
   shortdoc:              "HTTP/HTTPS Presign PUT"
   doc:                   """
 Sink which allows to upload reports to a pre-signed URL.
@@ -294,6 +299,7 @@ sink dns {
   ~dns_timeout:             false
   ~disable_after_errors:    false
   ~require_chalk_mark:      false
+  ~fallback_sink_config:    false
   shortdoc: "DNS lookup with a templated hostname"
   doc:      """
 
@@ -334,6 +340,7 @@ See `docs/design-dns-sink.md` for full design rationale.
 }
 
 sink stdout {
+  ~fallback_sink_config: false
   shortdoc:  "Write to stdout"
   doc:             """
 
@@ -342,6 +349,7 @@ When configuring, this sink take no configuration parameters.
 }
 
 sink stderr {
+  ~fallback_sink_config: false
   shortdoc:  "Write to stderr"
   doc:             """
 

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -4259,7 +4259,9 @@ A few important notes:
 
 3. If, for any reason, writing to the report cache fails, there will be a forced write to stderr, whether you've subscribed to it or not, in an attempt to prevent data loss.
 
-4. There is currently not a way to specify a 'fallback' sink.
+4. To specify a fallback sink, set `fallback_sink_config` on a `sink_config` to
+   the name of another `sink_config`. When the primary sink fails or is
+   runtime-disabled, chalk will walk the chain until one succeeds.
 
 5. If this is off, there is no check for previously cached data.
 
@@ -5038,6 +5040,16 @@ func sink_config_check(path) {
       t := attr_type(path + "." + conffield)
       if not typecmp(t, list[string]) {
           return conffield + ": Field must be a list[string]"
+      }
+    }
+    elif conffield == "fallback_sink_config" {
+      t := attr_type(path + "." + conffield)
+      if not typecmp(t, string) {
+        return conffield + ": Field must be a string (name of another sink_config)"
+      }
+      fbname := attr_get(path + "." + conffield, string)
+      if fbname != "" and not sections("sink_config").contains(fbname) {
+        return ("fallback_sink_config: no sink_config named '" + fbname + "' exists")
       }
     }
     elif conffield == "record_type" {

--- a/src/reportcache.nim
+++ b/src/reportcache.nim
@@ -22,7 +22,11 @@
 ## 'current' sinks need to catch up.  If so, we UNSUBSCRIBE them from
 ## the current topic, and re-subscribe them to a topic just for them.
 
-import std/posix
+import std/[
+  posix,
+  sequtils,
+  sets,
+]
 import "."/[
   sinks,
   types,
@@ -335,6 +339,38 @@ proc panicPublish(contents, tmpfilename, targetname, err: string) =
 
   doPanicWrite(s)
 
+proc handleFallbacks(topic, msg: string) =
+  if topic notin allTopics:
+    return
+
+  var
+    candidateNames: HashSet[string]
+    candidates:     seq[SinkConfig]
+
+  for s in sinkErrors:
+    if getFallbackName(s.name) != "":
+      candidateNames.incl(s.name)
+      candidates.add(s)
+
+  for subscriber in allTopics[topic].getSubscribers():
+    if isRuntimeDisabled(subscriber.name) and
+       getFallbackName(subscriber.name) != "" and
+       subscriber.name notin candidateNames:
+      candidateNames.incl(subscriber.name)
+      candidates.add(subscriber)
+
+  if candidates.len == 0:
+    return
+
+  let wrappedMsg = "[ " & msg.strip() & " ]\n"
+
+  for primary in candidates:
+    if tryFallbackChain(primary, topic, wrappedMsg):
+      sinkErrors = sinkErrors.filterIt(it != primary)
+    else:
+      if primary notin sinkErrors:
+        sinkErrors.add(primary)
+
 proc safePublish*(topic, msg: string) =
   if not attrGet[bool]("use_report_cache"):
     tracePublish(topic, msg)
@@ -357,6 +393,8 @@ proc safePublish*(topic, msg: string) =
 
   # This publish is just for sinks that didn't get unsubscribed...
   tracePublish(topic, msg, successfulPublishes)
+
+  handleFallbacks(topic, msg)
 
   # If sinks were unsubscribed because they had some catch-up to do, but
   # the sink is still broken, then the sink config will still live in

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -9,6 +9,9 @@
 
 import std/[
   os,
+  sequtils,
+  sets,
+  tables,
   uri,
   posix,
 ]
@@ -154,8 +157,28 @@ when not defined(release):
   availableSinkConfigs["debug_hook"] = defaultDebugHook
 
 # These are used by reportcache.nim
-var   sinkErrors*: seq[SinkConfig] = @[]
+var   sinkErrors*:          seq[SinkConfig]  = @[]
+var   runtimeDisabledSinks: HashSet[string]
+var   sinkFallbacks:        Table[string, string]
 const quietTopics* = ["chalk_usage_stats"]
+
+proc getFallbackName*(name: string): string =
+  sinkFallbacks.getOrDefault(name, "")
+
+proc isRuntimeDisabled*(name: string): bool =
+  name in runtimeDisabledSinks
+
+proc hasFallbackCycle(startName, proposed: string): bool =
+  var
+    current = proposed
+    visited: HashSet[string]
+  visited.incl(startName)
+  while current != "":
+    if current in visited:
+      return true
+    visited.incl(current)
+    current = sinkFallbacks.getOrDefault(current, "")
+  return false
 
 template formatIo(cfg: SinkConfig, t: Topic, err: string, msg: string): string =
   var line = ""
@@ -239,11 +262,15 @@ proc isSinkDestWritable(sinkPath: string): bool =
 proc ioErrorHandler(cfg: SinkConfig, t: Topic, msg, err, tb: string) =
   if cfg.mySink.name in ["file", "rotating_log"]:
     cfg.enabled = false
+    runtimeDisabledSinks.incl(cfg.name)
     warn(
       "sink '" & cfg.name & "' disabled after write failure " &
       "(filesystem may be read-only or inaccessible): " & err
     )
     return
+
+  if not cfg.enabled:
+    runtimeDisabledSinks.incl(cfg.name)
 
   let quiet = t.name in quietTopics
   if not quiet:
@@ -335,6 +362,16 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
       discard setOverride(getChalkScope(), section & ".pinned_cert_file", some(pack(path)))
       # Can't delete from a dict while we're iterating over it.
       deleteList.add(k)
+    of "fallback_sink_config":
+      let fbName = attrGetOpt[string](section & "." & k).getOrElse("")
+      if fbName != "":
+        if hasFallbackCycle(name, fbName):
+          error(
+            "sink_config '" & name & "': fallback_sink_config '" & fbName &
+            "' would create a circular chain - ignoring"
+          )
+        else:
+          sinkFallbacks[name] = fbName
     of "on_write_msg", "normalize":
       discard
     of "log_search_path":
@@ -390,12 +427,14 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
       except:
         warn(opts[k] & ": could not resolve sink filename. disabling sink")
         enabled = false
+        runtimeDisabledSinks.incl(name)
       if enabled and not isSinkDestWritable(opts[k]):
         warn(
           "sink '" & name & "': destination '" & opts[k] &
           "' is not writable (filesystem may be read-only), disabling sink"
         )
         enabled = false
+        runtimeDisabledSinks.incl(name)
     else:
       opts[k] = attrGetOpt[string](section & "." & k).getOrElse("")
 
@@ -476,6 +515,40 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
     return none(SinkConfig)
 
 proc getSinkConfigs*(): Table[string, SinkConfig] = return availableSinkConfigs
+
+proc tryFallbackChain*(primary: SinkConfig, topicName: string, wrappedMsg: string): bool =
+  var current = primary
+  while true:
+    let nextName = getFallbackName(current.name)
+    if nextName == "":
+      return false
+    let nextOpt = getSinkConfigByName(nextName)
+    if nextOpt.isNone():
+      return false
+    let next = nextOpt.get()
+    if not next.enabled:
+      current = next
+      continue
+    if topicName in allTopics:
+      let alreadySubscribed = allTopics[topicName].getSubscribers().anyIt(it == next)
+      if alreadySubscribed and not isRuntimeDisabled(next.name):
+        return true
+    let
+      tmpName  = "$fallback$" & topicName & "$" & current.name
+      tmpTopic = registerTopic(tmpName)
+    subscribe(tmpTopic, next)
+    var succeeded = false
+    let prevErrors = sinkErrors
+    sinkErrors     = @[]
+    try:
+      let n  = publish(tmpTopic, wrappedMsg)
+      succeeded = n >= 1 and sinkErrors.len == 0
+    finally:
+      sinkErrors = prevErrors
+      discard unsubscribe(tmpTopic, next)
+    if succeeded:
+      return true
+    current = next
 
 proc setupDefaultLogConfigs*() =
   let

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -269,6 +269,11 @@ proc ioErrorHandler(cfg: SinkConfig, t: Topic, msg, err, tb: string) =
     )
     return
 
+  # cfg.enabled is false when disable_after_errors was just reached inside
+  # onSinkError. Record it as runtime-disabled so handleFallbacks can activate
+  # the fallback chain on future publishes that skip this sink silently.
+  # Intentionally no return: we still add to sinkErrors below so the report
+  # is cached for this delivery.
   if not cfg.enabled:
     runtimeDisabledSinks.incl(cfg.name)
 
@@ -532,7 +537,16 @@ proc tryFallbackChain*(primary: SinkConfig, topicName: string, wrappedMsg: strin
     if topicName in allTopics:
       let alreadySubscribed = allTopics[topicName].getSubscribers().anyIt(it == next)
       if alreadySubscribed and not isRuntimeDisabled(next.name):
-        return true
+        # next is also a direct subscriber of this topic, so it already ran
+        # during the normal publish pass. If it succeeded (not in sinkErrors),
+        # the message was already delivered -- return true so the primary is
+        # cleared from sinkErrors. If it failed (in sinkErrors), skip it to
+        # avoid double-delivery but continue walking the chain so the primary's
+        # error is cached independently of next's own failure.
+        if not sinkErrors.anyIt(it == next):
+          return true
+        current = next
+        continue
     let
       tmpName  = "$fallback$" & topicName & "$" & current.name
       tmpTopic = registerTopic(tmpName)

--- a/tests/functional/data/sink_configs/post_http_fallback.c4m
+++ b/tests/functional/data/sink_configs/post_http_fallback.c4m
@@ -1,0 +1,18 @@
+log_level = "trace"
+
+sink_config my_primary_config {
+  enabled:              true
+  sink:                 "post"
+  uri:                  env("CHALK_PRIMARY_URL")
+  disable_after_errors: 1
+  fallback_sink_config: "my_fallback_config"
+}
+
+sink_config my_fallback_config {
+  enabled: true
+  sink:    "post"
+  uri:     env("CHALK_FALLBACK_URL")
+}
+
+subscribe("report", "my_primary_config")
+subscribe("report", "json_console_out")

--- a/tests/functional/data/sink_configs/post_http_fallback.c4m
+++ b/tests/functional/data/sink_configs/post_http_fallback.c4m
@@ -1,18 +1,43 @@
 log_level = "trace"
 
+# Chain 1: primary and hop1 fail, final delivers - exercises multi-hop walk
 sink_config my_primary_config {
   enabled:              true
   sink:                 "post"
   uri:                  env("CHALK_PRIMARY_URL")
   disable_after_errors: 1
-  fallback_sink_config: "my_fallback_config"
+  fallback_sink_config: "my_hop1_config"
 }
 
-sink_config my_fallback_config {
+sink_config my_hop1_config {
+  enabled:              true
+  sink:                 "post"
+  uri:                  env("CHALK_HOP1_URL")
+  disable_after_errors: 1
+  fallback_sink_config: "my_final_config"
+}
+
+sink_config my_final_config {
   enabled: true
   sink:    "post"
-  uri:     env("CHALK_FALLBACK_URL")
+  uri:     env("CHALK_FINAL_URL")
+}
+
+# Chain 2: all sinks fail - exercises report caching when no link delivers
+sink_config my_fail_primary_config {
+  enabled:              true
+  sink:                 "post"
+  uri:                  env("CHALK_FAIL_URL")
+  disable_after_errors: 1
+  fallback_sink_config: "my_fail_hop_config"
+}
+
+sink_config my_fail_hop_config {
+  enabled: true
+  sink:    "post"
+  uri:     env("CHALK_FAIL_URL")
 }
 
 subscribe("report", "my_primary_config")
+subscribe("report", "my_fail_primary_config")
 subscribe("report", "json_console_out")

--- a/tests/functional/test_sink.py
+++ b/tests/functional/test_sink.py
@@ -284,34 +284,41 @@ def test_post_http_fallback(
     server_http: str,
 ):
     """
-    Primary sink points to a failing endpoint; fallback delivers the report.
-    The report must arrive at the server via the fallback, and no report cache
-    entry must be created (the fallback delivery clears the primary from sinkErrors).
+    Two fallback chains run in a single chalk insert.
+
+    Chain 1 (my_primary_config -> my_hop1_config -> my_final_config): primary
+    and hop1 fail, final delivers. Verifies the chain walks past failing
+    intermediate sinks.
+
+    Chain 2 (my_fail_primary_config -> my_fail_hop_config): all sinks fail.
+    Verifies the report is cached for retry on the next chalk invocation.
     """
     result = chalk.insert(
         copy_files[0],
         config=SINK_CONFIGS / "post_http_fallback.c4m",
         use_embedded=False,
         env={
-            "CHALK_PRIMARY_URL": f"{SERVER_HTTP}/500",
-            "CHALK_FALLBACK_URL": f"{SERVER_HTTP}/report",
+            "CHALK_PRIMARY_URL": f"{server_http}/500",
+            "CHALK_HOP1_URL": f"{server_http}/500",
+            "CHALK_FINAL_URL": f"{server_http}/report",
+            "CHALK_FAIL_URL": f"{server_http}/500",
         },
         ignore_errors=True,
     )
     metadata_id = result.mark["METADATA_ID"]
     assert metadata_id
 
-    # primary must have logged a failure
+    # chain 1: primary and hop1 logged failures, final delivered the report
     assert "my_primary_config" in result.logs
-
-    # report must have been delivered via the fallback
+    assert "my_hop1_config" in result.logs
     db_id = server_sql(f"SELECT chalk_id FROM chalks WHERE metadata_id='{metadata_id}'")
-    assert db_id is not None, "report was not delivered to the server via fallback"
+    assert db_id is not None, "report was not delivered via the fallback chain"
 
-    # fallback rescued the delivery - no report cache entry should be written
+    # chain 2: all sinks failed, report must be cached for retry
+    assert "my_fail_primary_config" in result.logs
     assert (
-        not result.logged_reports_path.exists()
-    ), "report was cached despite fallback success"
+        result.logged_reports_path.exists()
+    ), "report was not cached when all sinks failed"
 
 
 @pytest.mark.parametrize("copy_files", [[CAT_PATH]], indirect=True)

--- a/tests/functional/test_sink.py
+++ b/tests/functional/test_sink.py
@@ -277,6 +277,44 @@ def test_400_disables_sink(
 
 
 @pytest.mark.parametrize("copy_files", [[CAT_PATH]], indirect=True)
+def test_post_http_fallback(
+    copy_files: list[Path],
+    chalk: Chalk,
+    server_sql: Callable[[str], str | None],
+    server_http: str,
+):
+    """
+    Primary sink points to a failing endpoint; fallback delivers the report.
+    The report must arrive at the server via the fallback, and no report cache
+    entry must be created (the fallback delivery clears the primary from sinkErrors).
+    """
+    result = chalk.insert(
+        copy_files[0],
+        config=SINK_CONFIGS / "post_http_fallback.c4m",
+        use_embedded=False,
+        env={
+            "CHALK_PRIMARY_URL": f"{SERVER_HTTP}/500",
+            "CHALK_FALLBACK_URL": f"{SERVER_HTTP}/report",
+        },
+        ignore_errors=True,
+    )
+    metadata_id = result.mark["METADATA_ID"]
+    assert metadata_id
+
+    # primary must have logged a failure
+    assert "my_primary_config" in result.logs
+
+    # report must have been delivered via the fallback
+    db_id = server_sql(f"SELECT chalk_id FROM chalks WHERE metadata_id='{metadata_id}'")
+    assert db_id is not None, "report was not delivered to the server via fallback"
+
+    # fallback rescued the delivery - no report cache entry should be written
+    assert (
+        not result.logged_reports_path.exists()
+    ), "report was cached despite fallback success"
+
+
+@pytest.mark.parametrize("copy_files", [[CAT_PATH]], indirect=True)
 def test_presign_http_fastapi(
     copy_files: list[Path],
     chalk: Chalk,


### PR DESCRIPTION
## Summary

- Adds \`fallback_sink_config\` field to all sink types, naming another \`sink_config\` to use when the primary fails or is runtime-disabled
- Fallback is walked as a chain; each link has its own independent \`disable_after_errors\` threshold; circular chains are rejected at config load time
- If any link in the chain delivers successfully, the primary is cleared from \`sinkErrors\` so no report cache entry is created for that delivery
- If a fallback candidate is also a direct subscriber of the same topic but also failed (present in \`sinkErrors\`), it is skipped to avoid double-delivery and the chain walk continues; the primary's error is cached independently of the candidate's own failure tracking
- A sink explicitly set to \`enabled: false\` in config does not trigger fallback — only error-caused disables do

## Test plan

```shell
make tests args="test_sink.py::test_post_http_fallback -x -s"
```

The test runs a single chalk insert with two chains active simultaneously: a 3-hop chain where primary and hop1 fail but the final link delivers (multi-hop walk), and a parallel all-fail chain that verifies the report is cached when no link delivers.