### PR TITLE
fix: exit heartbeat loop when all reporting sinks are disabled

### DIFF
--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -19,6 +19,7 @@ import ".."/[
   plugin_api,
   reporting,
   run_management,
+  sinks,
   subscan,
   types,
   utils/exec,
@@ -186,9 +187,25 @@ proc doHeartbeatReport(chalkOpt: Option[ChalkObj]) =
         chalk.collectedData[k] = v
 
     chalk.collectRunTimeArtifactInfo()
-  doReporting(clearState = true)
+  doReporting(
+    clearState = true,
+    writeCache = false,
+  )
 
-proc doHeartbeat(chalkOpt: Option[ChalkObj], pid: Pid, fn: (pid: Pid) -> bool) =
+proc hasNoActiveHeartbeatSinks(): bool =
+  if topicHasActiveSubscribers("report"):
+    return false
+  for topic in activeCustomReportTopics():
+    if topicHasActiveSubscribers(topic):
+      return false
+  return true
+
+proc doHeartbeat(
+    chalkOpt:     Option[ChalkObj],
+    pid:          Pid,
+    hasExited:    (pid: Pid) -> bool,
+    exitOnNoSinks: bool,
+) =
   let
     inMicroSec    = int(attrGet[Con4mDuration]("exec.heartbeat.rate"))
     sleepInterval = int(inMicroSec / 1000)
@@ -203,12 +220,17 @@ proc doHeartbeat(chalkOpt: Option[ChalkObj], pid: Pid, fn: (pid: Pid) -> bool) =
 
   while true:
     sleep(sleepInterval)
+    if hasExited(pid):
+      break
     # reset stats which includes the opTime
     # so that each heartbeat has accurate timestamp
     clearReportingState()
     incHeartbeatCount()
     chalkOpt.doHeartbeatReport()
-    if fn(pid):
+    if hasExited(pid):
+      break
+    if exitOnNoSinks and hasNoActiveHeartbeatSinks():
+      info("All reporting sinks are disabled; stopping heartbeat process.")
       break
 
 type
@@ -470,7 +492,11 @@ proc runCmdExec*(args: seq[string]) =
       postExecState.doPostExec(detach = false)
 
       if attrGet[bool]("exec.heartbeat.run"):
-        chalkOpt.doHeartbeat(pid, getChildExitStatus)
+        chalkOpt.doHeartbeat(
+          pid           = pid,
+          hasExited     = getChildExitStatus,
+          exitOnNoSinks = false,
+        )
       else:
         trace("Waiting for spawned process to exit.")
         var stat_loc: cint
@@ -507,4 +533,8 @@ proc runCmdExec*(args: seq[string]) =
       postExecState.doPostExec(detach = true)
 
       if attrGet[bool]("exec.heartbeat.run"):
-        chalkOpt.doHeartbeat(ppid, getParentExitStatus)
+        chalkOpt.doHeartbeat(
+          pid           = ppid,
+          hasExited     = getParentExitStatus,
+          exitOnNoSinks = true,
+        )

--- a/src/reportcache.nim
+++ b/src/reportcache.nim
@@ -487,3 +487,8 @@ proc writeReportCache*() =
         getCurrentExceptionMsg())
       error("Please remove it manually to avoid unnecessary double reporting")
       dumpExOnDebug()
+
+proc clearReportCache*() =
+  reportCache.clear()
+  sinkErrors = @[]
+  dirtyCache  = false

--- a/src/reporting.nim
+++ b/src/reporting.nim
@@ -132,31 +132,37 @@ proc doEmbeddedReport(): Box =
   else:
     pack[seq[Box]](@[])
 
-proc doCustomReporting() =
+proc activeCustomReportTopics*(): seq[string] =
+  let commandName = getBaseCommandName()
   for topic in getChalkSubsections("custom_report"):
-    trace(topic & ": checking custom report")
     let spec = "custom_report." & topic
     let enabledOpt = attrGetOpt[bool](spec & ".enabled")
-    if enabledOpt.isNone() or not enabledOpt.get(): continue
-    var
-      sinkConfs = attrGet[seq[string]](spec & ".sink_configs")
-
-    discard registerTopic(topic)
-
-    let
-      commandName = getBaseCommandName()
-      useWhen     = attrGet[seq[string]](spec & ".use_when")
+    if enabledOpt.isNone() or not enabledOpt.get():
+      continue
+    let useWhen = attrGet[seq[string]](spec & ".use_when")
     if commandName notin useWhen and "*" notin useWhen:
-      trace(spec & ": skipping as " & commandName & " not in " & $useWhen)
       continue
     if topic == "audit" and not attrGet[bool]("publish_audit"):
       continue
+    result.add(topic)
+
+proc doCustomReporting() =
+  for topic in activeCustomReportTopics():
+    trace(topic & ": checking custom report")
+    let spec = "custom_report." & topic
+    var sinkConfs = attrGet[seq[string]](spec & ".sink_configs")
+
+    discard registerTopic(topic)
+
     if len(sinkConfs) == 0 and topic notin ["audit", "chalk_usage_stats"]:
       warn("Report '" & topic & "' has no configured sinks.  Skipping.")
 
     let templateToUse  = getReportTemplate(spec)
 
     for sinkConfName in sinkConfs:
+      if isRuntimeDisabled(sinkConfName):
+        trace(sinkConfName & ": skipping runtime-disabled sink for topic " & topic)
+        continue
       let res = topicSubscribe((@[pack(topic), pack(sinkConfName)])).get()
       if not unpack[bool](res):
         warn("Report '" & topic & "' sink config is invalid. Skipping.")
@@ -173,7 +179,11 @@ proc doCustomReporting() =
       if report != "":
         safePublish(topic, report)
 
-proc doReporting*(topic="report", clearState = false) {.exportc, cdecl.} =
+proc doReporting*(
+    topic      = "report",
+    clearState = false,
+    writeCache = true,
+) {.exportc, cdecl.} =
   if inSubscan():
     let ctx = getCurrentCollectionCtx()
     ctx.report = doEmbeddedReport()
@@ -190,6 +200,9 @@ proc doReporting*(topic="report", clearState = false) {.exportc, cdecl.} =
       doCommandReport(topic)
     if not skipCustom:
       doCustomReporting()
-    writeReportCache()
+    if writeCache:
+      writeReportCache()
+    else:
+      clearReportCache()
   if clearState:
     clearReportingState()

--- a/src/sinks.nim
+++ b/src/sinks.nim
@@ -521,6 +521,9 @@ proc getSinkConfigByName*(name: string): Option[SinkConfig] =
 
 proc getSinkConfigs*(): Table[string, SinkConfig] = return availableSinkConfigs
 
+proc topicHasActiveSubscribers*(topic: string): bool =
+  topic in allTopics and allTopics[topic].getNumSubscribers() > 0
+
 proc tryFallbackChain*(primary: SinkConfig, topicName: string, wrappedMsg: string): bool =
   var current = primary
   while true:


### PR DESCRIPTION
## Summary

- When all configured reporting sinks get disabled due to repeated failures in exec-as-parent mode, the heartbeat loop now exits rather than running indefinitely
- Heartbeat reports that fail to deliver are discarded rather than cached for retry on the next chalk invocation (preventing spurious "will cache unreported messages" warnings and stale data appearing in future runs)
- Subscribe attempts for sinks disabled by runtime errors are skipped silently at trace level; the existing warn for user-configured `enabled: false` sinks is preserved

## Details

- `topicHasActiveSubscribers()` in `sinks.nim` — checks nimutils subscriber count for a topic; drops to 0 when a sink is removed by the publish machinery after failures
- `activeCustomReportTopics()` in `reporting.nim` — extracted shared filter (enabled, use_when, publish_audit guard) used by both `doCustomReporting` and the new sink-check
- `hasNoActiveHeartbeatSinks()` in `cmd_exec.nim` — returns true when neither the `report` topic nor any active custom report topic has subscribers
- `doHeartbeat` gains `exitOnNoSinks: bool` param — `false` in chalk-as-parent mode (chalk must stay alive to manage the child process), `true` in exec-as-parent mode
- Exit check moved to before `doHeartbeatReport()` to avoid a spurious extra heartbeat on process exit; a second check after the report catches exits during slow delivery
- `doReporting` gains `writeCache: bool = true` — heartbeat passes `false`, calling `clearReportCache()` instead of `writeReportCache()`
- `clearReportCache()` added to `reportcache.nim` — discards in-memory failures without touching disk

## Test plan

```shell
# manual: points dead_http at 127.0.0.1:19999 with disable_after_errors=2
# expect: "sink disabled" error after 2 failures, then "stopping heartbeat process" info, then exit
./chalk exec -f tests/functional/data/configs/heartbeat_sink_failure.c4m --log-level=info -- sleep 300
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)