### PR TITLE
feat: add exec.nice config for initial reporting process priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,12 @@
 
   ([#698](https://github.com/crashappsec/chalk/pull/698))
 
+- New `exec.nice` field sets the nice level for the chalk reporting
+  process after the fork. Reverted before postexec and heartbeat so
+  each phase uses its own independent value. Defaults to `5`,
+  range `0`-`19`.
+  ([#757](https://github.com/crashappsec/chalk/pull/757))
+
 ## 1.1.3
 
 **July 6, 2026**

--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -46,8 +46,9 @@ else:
   iterator inotify_events(evs: pointer, n: int): ptr InotifyEvent =
     discard
 
-const
-  PATH_MAX = 4096 # PROC_PIDPATHINFO_MAXSIZE on mac
+proc getpriority(which: cint, who: cint): cint {.importc, header: "<sys/resource.h>".}
+var PRIO_PROCESS {.importc, header: "<sys/resource.h>".}: cint
+const PATH_MAX = 4096 # PROC_PIDPATHINFO_MAXSIZE on mac
 
 proc doExecCollection(allOpts: seq[string], pid: Pid): Option[ChalkObj] =
   # First, check the chalk file location, and if there's one there, then create
@@ -303,7 +304,7 @@ else:
   proc initPostExecWatch(): Option[PostExecState] =
     return none(PostExecState)
 
-proc doPostExec(state: Option[PostExecState], detach: bool) =
+proc doPostExec(state: Option[PostExecState], detach: bool, baseNice: cint) =
   if state.isNone():
     return
 
@@ -320,13 +321,13 @@ proc doPostExec(state: Option[PostExecState], detach: bool) =
         return
 
     let
-      ws            = state.get()
-      niceValue     = attrGet[int]("exec.postexec.nice")
+      ws          = state.get()
+      niceValue   = attrGet[int]("exec.postexec.nice")
+      appliedNice = nice(cint(niceValue))
     var
       accessedPaths = initHashSet[string]()
 
     trace("postexec: using nice " & $niceValue)
-    discard nice(cint(niceValue))
 
     try:
       setFullCommandName("postexec")
@@ -400,7 +401,7 @@ proc doPostExec(state: Option[PostExecState], detach: bool) =
     # else restore previous nice as chalk can be doing things after postexec
     else:
       trace("postexec: reverting nice " & $niceValue)
-      discard nice(cint(niceValue * -1))
+      discard nice(cint(baseNice - appliedNice))
 
 proc runCmdExec*(args: seq[string]) =
   when not defined(posix):
@@ -460,6 +461,7 @@ proc runCmdExec*(args: seq[string]) =
 
   let
     postExecState = initPostExecWatch()
+    baseNice      = getpriority(PRIO_PROCESS, 0)
     pid           = fork()
 
   if attrGet[bool]("exec.chalk_as_parent"):
@@ -470,9 +472,10 @@ proc runCmdExec*(args: seq[string]) =
       setExitCode(1)
     else:
       trace("Chalk is parent process: " & $(ppid) & ". Child pid: " & $(pid))
-      let execNice = attrGet[int]("exec.nice")
+      let
+        execNice    = attrGet[int]("exec.nice")
+        appliedNice = nice(cint(execNice))
       trace("exec: using nice " & $execNice)
-      discard nice(cint(execNice))
       # add some sleep so that the child process has a chance to exec before
       # we try to collect data from it otherwise the process data collected
       # might be about the chalk binary instead of the target binary, which
@@ -492,9 +495,12 @@ proc runCmdExec*(args: seq[string]) =
         chalkOpt.get().collectRunTimeArtifactInfo()
       doReporting(clearState = true)
       trace("exec: reverting nice " & $execNice)
-      discard nice(cint(execNice * -1))
+      discard nice(cint(baseNice - appliedNice))
 
-      postExecState.doPostExec(detach = false)
+      postExecState.doPostExec(
+        detach   = false,
+        baseNice = baseNice,
+      )
 
       if attrGet[bool]("exec.heartbeat.run"):
         chalkOpt.doHeartbeat(
@@ -519,9 +525,10 @@ proc runCmdExec*(args: seq[string]) =
     else:
       let cpid = getpid() # get pid after fork of child process
       trace("Chalk is child process: " & $(cpid))
-      let execNice = attrGet[int]("exec.nice")
+      let
+        execNice    = attrGet[int]("exec.nice")
+        appliedNice = nice(cint(execNice))
       trace("exec: using nice " & $execNice)
-      discard nice(cint(execNice))
       let
         inMicroSec   = int(attrGet[Con4mDuration]("exec.initial_sleep_time"))
         initialSleep = int(inMicroSec / 1000)
@@ -537,9 +544,12 @@ proc runCmdExec*(args: seq[string]) =
         chalkOpt.get().collectRunTimeArtifactInfo()
       doReporting(clearState = true)
       trace("exec: reverting nice " & $execNice)
-      discard nice(cint(execNice * -1))
+      discard nice(cint(baseNice - appliedNice))
 
-      postExecState.doPostExec(detach = true)
+      postExecState.doPostExec(
+        detach   = true,
+        baseNice = baseNice,
+      )
 
       if attrGet[bool]("exec.heartbeat.run"):
         chalkOpt.doHeartbeat(

--- a/src/commands/cmd_exec.nim
+++ b/src/commands/cmd_exec.nim
@@ -470,6 +470,9 @@ proc runCmdExec*(args: seq[string]) =
       setExitCode(1)
     else:
       trace("Chalk is parent process: " & $(ppid) & ". Child pid: " & $(pid))
+      let execNice = attrGet[int]("exec.nice")
+      trace("exec: using nice " & $execNice)
+      discard nice(cint(execNice))
       # add some sleep so that the child process has a chance to exec before
       # we try to collect data from it otherwise the process data collected
       # might be about the chalk binary instead of the target binary, which
@@ -488,6 +491,8 @@ proc runCmdExec*(args: seq[string]) =
       if chalkOpt.isSome():
         chalkOpt.get().collectRunTimeArtifactInfo()
       doReporting(clearState = true)
+      trace("exec: reverting nice " & $execNice)
+      discard nice(cint(execNice * -1))
 
       postExecState.doPostExec(detach = false)
 
@@ -514,7 +519,9 @@ proc runCmdExec*(args: seq[string]) =
     else:
       let cpid = getpid() # get pid after fork of child process
       trace("Chalk is child process: " & $(cpid))
-
+      let execNice = attrGet[int]("exec.nice")
+      trace("exec: using nice " & $execNice)
+      discard nice(cint(execNice))
       let
         inMicroSec   = int(attrGet[Con4mDuration]("exec.initial_sleep_time"))
         initialSleep = int(inMicroSec / 1000)
@@ -529,6 +536,8 @@ proc runCmdExec*(args: seq[string]) =
       if chalkOpt.isSome():
         chalkOpt.get().collectRunTimeArtifactInfo()
       doReporting(clearState = true)
+      trace("exec: reverting nice " & $execNice)
+      discard nice(cint(execNice * -1))
 
       postExecState.doPostExec(detach = true)
 

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2889,6 +2889,19 @@ If it is NOT true, set exec.searchpath to provide any locations Chalk should che
 """
   }
 
+  field nice {
+    type:    int
+    default: 5
+    range:   (0, 19)
+    doc: """
+Nice level for the chalk exec reporting process to reduce overall system impact.
+Applied after the fork so the exec'd entrypoint is unaffected, and reverted
+before postexec and heartbeat run so each phase applies its own absolute value
+from the same inherited base.
+See https://www.man7.org/linux/man-pages/man2/nice.2.html
+"""
+  }
+
 }
 
 singleton exec_deployment {


### PR DESCRIPTION
## Summary

- Adds `exec.nice` field (default `5`, range `0`-`19`) to set the OS nice level for the chalk reporting process after the fork, so the exec'd entrypoint is unaffected
- The nice is reverted after initial collection+reporting so postexec and heartbeat each apply their own configured value independently from the same inherited base

## Test plan

```shell
# verify trace logs show "exec: using nice 5" and "exec: reverting nice 5"
# followed by "heartbeat: using nice 5" at the heartbeat-configured level
./chalk exec -f tests/functional/data/configs/heartbeat_sink_failure.c4m --log-level=trace -- sleep 30
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)