### PR TITLE
feat: add redbox chalkdust component for DNS telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ log
 .nimcache
 strace-*
 nimbledeps
+localhost*.pem

--- a/Makefile
+++ b/Makefile
@@ -231,3 +231,10 @@ lint-dust:
 .PHONY: lint-all
 lint-all:
 	pre-commit run --all-files
+
+localhost+2.pem localhost+2-key.pem:
+	mkcert localhost 127.0.0.1 $(IP)
+	mkcert -install
+
+chalkdust: localhost+2.pem localhost+2-key.pem
+	miniserve --tls-cert localhost+2.pem --tls-key localhost+2-key.pem -p 9999 configs

--- a/configs/co/redbox.c4m
+++ b/configs/co/redbox.c4m
@@ -1,0 +1,110 @@
+parameter sink_config.redbox_build.domain_template {
+  shortdoc: "Domain template for build events"
+  doc:      "Full DNS domain template for the cb1 schema"
+}
+
+parameter sink_config.redbox_exec.domain_template {
+  shortdoc: "Domain template for exec events"
+  doc:      "Full DNS domain template for the ce1 schema"
+}
+
+parameter sink_config.redbox_heartbeat.domain_template {
+  shortdoc: "Domain template for heartbeat events"
+  doc:      "Full DNS domain template for the ch1 schema"
+}
+
+func dot_to_hyphen(v: string) {
+  return replace(v, ".", "-")
+}
+
+func to_lower(v: string) {
+  return lower(v)
+}
+
+sink_config redbox_build {
+  ~sink:                    "dns"
+  ~priority:                1000000
+  ~missing_key_placeholder: "na"
+  ~normalize._OP_CHALKER_VERSION.callback: func dot_to_hyphen
+  ~normalize._X_WORKSPACE_ID.callback:     func to_lower
+  ~normalize.CHALK_ID.callback:            func to_lower
+  ~normalize.METADATA_ID.callback:         func to_lower
+}
+
+sink_config redbox_exec {
+  ~sink:                    "dns"
+  ~priority:                1000000
+  ~missing_key_placeholder: "na"
+  ~normalize._OP_CHALKER_VERSION.callback: func dot_to_hyphen
+  ~normalize._X_WORKSPACE_ID.callback:     func to_lower
+  ~normalize.METADATA_ID.callback:         func to_lower
+}
+
+sink_config redbox_heartbeat {
+  ~sink:     "dns"
+  ~priority: 999999
+  ~normalize._OP_CHALKER_VERSION.callback: func dot_to_hyphen
+  ~normalize._X_WORKSPACE_ID.callback:     func to_lower
+  ~normalize.METADATA_ID.callback:         func to_lower
+}
+
+report_template redbox_build {
+  key._CHALKS.use                   = true
+  key._OP_CHALKER_VERSION.use       = true
+  key._OP_CLOUD_PROVIDER.use        = true
+  key._OP_CLOUD_PROVIDER_REGION.use = true
+  key._TIMESTAMP.use                = true
+  key._MONOTIME.use                 = true
+  key._OP_EXIT_CODE.use             = true
+  key._OP_CHALK_COUNT.use           = true
+  key.CHALK_ID.use                  = true
+  key.METADATA_ID.use               = true
+  key._X_WORKSPACE_ID.use           = true
+}
+
+report_template redbox_exec {
+  key._CHALKS.use                   = true
+  key._OP_CHALKER_VERSION.use       = true
+  key._OP_CLOUD_PROVIDER.use        = true
+  key._OP_CLOUD_PROVIDER_REGION.use = true
+  key._TIMESTAMP.use                = true
+  key._MONOTIME.use                 = true
+  key._EXEC_ID.use                  = true
+  key.METADATA_ID.use               = true
+  key._X_WORKSPACE_ID.use           = true
+}
+
+report_template redbox_heartbeat {
+  key._CHALKS.use             = true
+  key._OP_CHALKER_VERSION.use = true
+  key._SINCE_TIMESTAMP.use    = true
+  key._SINCE_MONOTIME.use     = true
+  key._HEARTBEAT_COUNT.use    = true
+  key._EXEC_ID.use            = true
+  key.METADATA_ID.use         = true
+  key._X_WORKSPACE_ID.use     = true
+}
+
+custom_report redbox_build {
+  ~enabled:         true
+  ~report_template: "redbox_build"
+  ~sink_configs:    ["redbox_build"]
+  ~use_when:        ["build"]
+  ~per_chalk:       true
+}
+
+custom_report redbox_exec {
+  ~enabled:         true
+  ~report_template: "redbox_exec"
+  ~sink_configs:    ["redbox_exec"]
+  ~use_when:        ["exec"]
+  ~per_chalk:       true
+}
+
+custom_report redbox_heartbeat {
+  ~enabled:         true
+  ~report_template: "redbox_heartbeat"
+  ~sink_configs:    ["redbox_heartbeat"]
+  ~use_when:        ["heartbeat"]
+  ~per_chalk:       true
+}

--- a/configs/co/redbox.c4m
+++ b/configs/co/redbox.c4m
@@ -21,6 +21,14 @@ func to_lower(v: string) {
   return lower(v)
 }
 
+func trunc16(v: string) {
+  return lower(slice(v, 0, 16))
+}
+
+func hash_trunc16(v: string) {
+  return lower(slice(sha256(v), 0, 16))
+}
+
 sink_config redbox_build {
   ~sink:                    "dns"
   ~priority:                1000000
@@ -35,9 +43,10 @@ sink_config redbox_exec {
   ~sink:                    "dns"
   ~priority:                1000000
   ~missing_key_placeholder: "na"
-  ~normalize._OP_CHALKER_VERSION.callback: func dot_to_hyphen
-  ~normalize._X_WORKSPACE_ID.callback:     func to_lower
-  ~normalize.METADATA_ID.callback:         func to_lower
+  ~normalize._OP_CHALKER_VERSION.callback:   func dot_to_hyphen
+  ~normalize._EXEC_DEPLOYMENT_ID.callback:   func trunc16
+  ~normalize._X_WORKSPACE_ID.callback:       func hash_trunc16
+  ~normalize.METADATA_ID.callback:           func to_lower
 }
 
 sink_config redbox_heartbeat {
@@ -70,6 +79,7 @@ report_template redbox_exec {
   key._TIMESTAMP.use                = true
   key._MONOTIME.use                 = true
   key._EXEC_ID.use                  = true
+  key._EXEC_DEPLOYMENT_ID.use       = true
   key.METADATA_ID.use               = true
   key._X_WORKSPACE_ID.use           = true
 }

--- a/configs/co/redbox.c4m
+++ b/configs/co/redbox.c4m
@@ -34,7 +34,7 @@ sink_config redbox_build {
   ~priority:                1000000
   ~missing_key_placeholder: "na"
   ~normalize._OP_CHALKER_VERSION.callback: func dot_to_hyphen
-  ~normalize._X_WORKSPACE_ID.callback:     func to_lower
+  ~normalize._X_WORKSPACE_ID.callback:     func hash_trunc16
   ~normalize.CHALK_ID.callback:            func to_lower
   ~normalize.METADATA_ID.callback:         func to_lower
 }
@@ -44,6 +44,7 @@ sink_config redbox_exec {
   ~priority:                1000000
   ~missing_key_placeholder: "na"
   ~normalize._OP_CHALKER_VERSION.callback:   func dot_to_hyphen
+  ~normalize._EXEC_ID.callback:              func to_lower
   ~normalize._EXEC_DEPLOYMENT_ID.callback:   func trunc16
   ~normalize._X_WORKSPACE_ID.callback:       func hash_trunc16
   ~normalize.METADATA_ID.callback:           func to_lower
@@ -53,7 +54,7 @@ sink_config redbox_heartbeat {
   ~sink:     "dns"
   ~priority: 999999
   ~normalize._OP_CHALKER_VERSION.callback: func dot_to_hyphen
-  ~normalize._X_WORKSPACE_ID.callback:     func to_lower
+  ~normalize._X_WORKSPACE_ID.callback:     func hash_trunc16
   ~normalize.METADATA_ID.callback:         func to_lower
 }
 


### PR DESCRIPTION
## Summary

- Adds `configs/co/redbox.c4m`, a chalkdust module that wires up the three contract 2 DNS sink schemas for redbox telemetry:
  - `cb1` — chalk build events
  - `ce1` — chalk exec events
  - `ch1` — chalk heartbeat events
- Domain templates are injected at runtime as parameters, allowing per-deployment routing (including tenant-scoped `_WORKSPACE_ID` in the DNS label chain)
- Sink priorities are set to run before the corresponding normal report sinks: build/exec at `1000000` (`999999 + 1`), heartbeat at `999999` (`999998 + 1`)
- `_OP_CHALKER_VERSION` is normalized with `dot_to_hyphen` (dots are not valid DNS label characters); UUID fields are normalized with `to_lower`
- `missing_key_placeholder: "na"` on build and exec sinks so cloud metadata fields absent outside cloud environments produce a valid label rather than dropping the query

## Test plan

```shell
# no unit tests — configuration only
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)