### PR TITLE
fix: external tools hang for full timeout duration on Alpine Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,14 @@
   range `0`-`19`.
   ([#757](https://github.com/crashappsec/chalk/pull/757))
 
+### Bug Fixes
+
+- Fixed external tools (SBOM, SAST, secret scanners) run directly (not via
+  Docker) always taking the full timeout duration on Alpine Linux, even when
+  the tool completes successfully. First detected via syft.
+  ([#759](https://github.com/crashappsec/chalk/pull/759),
+  [con4m#136](https://github.com/crashappsec/con4m/pull/136))
+
 ## 1.1.3
 
 **July 6, 2026**

--- a/chalk.nimble
+++ b/chalk.nimble
@@ -20,7 +20,7 @@ requires "nim >= 2.0.8"
 # are the pinned versions used in CI; `make nimble.paths` clones and checks
 # out these commits when the repos are absent.  In interactive shells the
 # Makefile defaults to the `dev` branch instead.
-# con4m:    f2364ee578f22aa0a4ad94e68173c24fe0d5038e
+# con4m:    44dafed4a96f1ce40a6c9bee55e676f9de9837fc
 # nimutils: b34b2d79274cd69d10be19f42e2c68d6f6c96203
 requires "unicodedb == 0.12.0"
 requires "https://github.com/viega/zippy == 0.10.7" # MIT


### PR DESCRIPTION
## Summary

- Bump con4m to [44dafed](https://github.com/crashappsec/con4m/commit/44dafed4a96f1ce40a6c9bee55e676f9de9837fc) which fixes a hang in con4m's `run()` and `system()` builtins

## Problem

On Alpine Linux, external tools run directly (not via Docker) — SBOM scanners, SAST tools, secret scanners — always took the full configured timeout duration, even when the tool completed successfully in 1-2 seconds. Exit code and output were correct; the delay was entirely artificial. First reported by Toyota Motor North America via syft SBOM collection hanging for the full 300-second default timeout on every chalk invocation.

## Root cause

Three components interact to produce the hang:

**1. con4m's `system()` uses `execCmdEx` with `clone(CLONE_VM|CLONE_VFORK)`**

con4m's `run()` and `system()` builtins called Nim's `execCmdEx`, which spawns `sh` using `clone(CLONE_VM|CLONE_VFORK|SIGCHLD)`. This makes chalk the kernel parent of the entire subprocess chain (`sh` → `timeout` → `syft`).

**2. BusyBox timeout's "replace + watchdog" architecture**

Alpine uses BusyBox for `/usr/bin/timeout`. Unlike GNU coreutils `timeout` (which forks a child and waits), BusyBox timeout:
1. `vfork()`s an intermediate process
2. That process `fork()`s a **watchdog** (which inherits the pipe write end)
3. The intermediate exits
4. BusyBox timeout **execs itself into the target command** — there is no separate timeout parent process; timeout *is* syft at this point

The watchdog's job is to send `SIGKILL` to the target PID when the alarm fires. It detects liveness by polling `kill(pid, 0)`.

**3. Zombie processes respond positively to `kill(pid, 0)`**

When syft finishes and exits, chalk is its kernel parent (via the `CLONE_VM` chain). chalk is blocked in `readLine` waiting for the pipe to close and cannot call `waitpid`. Syft therefore becomes a **zombie** — still in the process table, PPID = chalk.

`kill(pid, 0)` returns 0 for zombie processes. The watchdog cannot distinguish a zombie from a live process. It keeps running — holding the pipe write end open — until the full timeout elapses, at which point it sends `SIGKILL` to the zombie (a no-op), exits, and the pipe finally closes.

**Timeline (syft_timeout = 300, syft completes in ~2s)**

```
t=0s    chalk spawns sh; sh execs into timeout; timeout execs into syft
t=2s    syft exits → becomes zombie under chalk (chalk blocked in readLine)
        watchdog: kill(syft_pid, 0) = 0  ← zombie still in table
t=300s  watchdog alarm fires; SIGKILL sent to zombie (no-op); watchdog exits
        pipe write end closes; chalk's readLine returns
        chalk processes the valid output that arrived at t=2s
```

**Why this only affects Alpine**

GNU coreutils `timeout` (used on Debian, Ubuntu, RHEL, etc.) forks a child to run the command and uses `waitpid`. When the child exits it is reaped immediately by GNU timeout, which then exits and closes the pipe. No watchdog, no `kill(pid, 0)` polling.

**Why Docker-based tool execution is not affected**

When an external tool runs inside a Docker container, `docker run` is the intermediate process. Docker's subprocess management does not exhibit the same watchdog/zombie interaction.

**strace evidence**

```
t+0s   PID 14 (chalk)    fork()                         → PID 15
t+0s   PID 15            execve("/bin/sh", ["-c", ...])
t+0s   PID 15 (sh)       execve("/usr/bin/timeout", ...)  ← sh optimises to exec
t+0s   PID 15 (timeout)  vfork()                        → PID 16 (intermediate)
t+0s   PID 16            fork()                         → PID 17 (watchdog)
t+0s   PID 16            exit_group()
t+0s   PID 15 (timeout)  wait4(-1) = 16
t+0s   PID 15 (timeout)  execve("/usr/bin/syft", ...)   ← timeout IS now syft

t+2s   PID 15 (syft)     exit_group()                   ← zombie, PPID = chalk
t+2s   PID 17 (watchdog) kill(15, 0) = 0                ← zombie responds
...
t+300s PID 17 (watchdog) kill(15, SIGKILL)               ← kills zombie (no-op)
t+300s PID 17            exit_group()                   ← pipe closes
t+300s PID 14 (chalk)    readLine returns
```

## Fix

con4m's `run()` and `system()` builtins now use nimutils' `runCmdGetEverything("/bin/sh", ["-c", cmd])` instead of `execCmdEx`. nimutils spawns the shell with a regular `fork()` and runs a C select-loop that calls `wait4(WNOHANG)` every ~1 second. When syft exits, nimutils reaps the zombie within 1 second. The watchdog then gets `ESRCH` from `kill(pid, 0)` and exits immediately, closing the pipe.

**Fixed strace (same scenario)**

```
t+2s   PID 14 (chalk)    wait4(15, WNOHANG) = 15        ← zombie reaped
t+3s   PID 17 (watchdog) kill(15, 0) = ESRCH            ← process gone
t+3s   PID 17            exit_group()                   ← pipe closes
t+3s   PID 14 (chalk)    readLine returns
```

**Timing comparison (Alpine 3.21, syft_timeout = 30)**

| | Wall time |
|---|---|
| Before fix | 39.7s (30s hang + ~10s chalk overhead) |
| After fix | 13.2s (~10s chalk overhead, syft completes in ~3s) |

## References

- con4m fix: [crashappsec/con4m#136](https://github.com/crashappsec/con4m/pull/136)

## Test plan

```shell
# on Alpine with syft installed natively (not via Docker), syft_timeout set to 30:
# should complete in ~10s, not ~40s
make tests args="test_docker.py -k sbom -x"
```