### PR TITLE
fix: digest divergence on dual-push buildx builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Chalk Release Notes
 
+## 1.2.1
+
+**September 2nd, 2026**
+
+### Bug Fixes
+
+- Fixed `--metadata-file` and `--iidfile` describing chalk's copy of the image
+  instead of the image the build actually pushed, when the build pushes via
+  `docker buildx build --output type=image,...` without any `-t` tag (for
+  example a `push-by-digest=true` build) and chalk is configured to also push
+  the image to a registry of its own. buildkit merges the exporter response of
+  every exporter into a single flat object where the last exporter wins keys
+  such as `image.name` and `containerimage.digest`, and chalk appended its own
+  exporter last. Chalk's exporter is now inserted before the exporters the
+  build asked for, so `--metadata-file` keeps describing the build's own image.
+  Downstream steps reading the digest out of `--metadata-file` were previously
+  handed a digest belonging to chalk's registry, and any `docker tag`,
+  `docker pull` or `aws ecr put-image` built from it failed with a not-found
+  error.
+- Chalk's own image exporter now mirrors the `compression`,
+  `compression-level`, `force-compression` and `oci-mediatypes` params of the
+  build's image exporter. buildkit derives the manifest digest from the
+  exported layer blobs, so without this the two copies of the same build got
+  different digests and neither digest described both images.
+- Fixed chalk reporting an invented `:latest` tag for `push-by-digest=true`
+  builds. buildkit publishes the manifest by digest only and never creates a
+  tag for it, so the tag-less image name is now reported without a tag.
+
 ## 1.2.0
 
 **August 11, 2026**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@
 - Fixed chalk reporting an invented `:latest` tag for `push-by-digest=true`
   builds. buildkit publishes the manifest by digest only and never creates a
   tag for it, so the tag-less image name is now reported without a tag.
+- Fixed `_REPO_TAGS` dropping a tag, and `_REPO_LIST_DIGESTS` omitting a
+  registry, when the same image is published under more than one OCI index.
+  A build with two image exporters produces exactly that: buildkit attaches a
+  provenance attestation per exporter and the attestation records the image
+  name, so each copy of the image gets its own index digest over an identical
+  image manifest. Chalk matched tags only against index digests it already
+  knew, so the second copy's tag was discarded with a
+  `could not match docker image tag` warning. Tags are now also matched on the
+  platform image manifest, and the newly discovered index digest is recorded.
 
 ## 1.2.0
 

--- a/src/docker/build.nim
+++ b/src/docker/build.nim
@@ -383,9 +383,53 @@ proc readMetadataFile(ctx: DockerInvocation) =
     data = "{}"
   ctx.metadataFile = data.tryParseMetadataFile()
 
+# buildkit derives the manifest digest from the exported layer blobs, so the
+# same build exported twice with different compression or media-type settings
+# gets two different digests. These are the --output params which change the
+# digest of the exported image.
+const DIGEST_OUTPUT_PARAMS = [
+  "compression",
+  "compression-level",
+  "force-compression",
+  "oci-mediatypes",
+]
+
+proc getDigestOutputParams(ctx: DockerInvocation): string =
+  ## Render the digest-affecting params of the image exporter the user asked
+  ## for, so that chalk's own exporter can mirror them. Without mirroring,
+  ## chalk's copy of the image and the user's copy get different digests and
+  ## neither digest describes both images.
+  result = ""
+  for output in ctx.foundOutputs:
+    if output.getOrDefault("type") notin ["image", "registry"]:
+      continue
+    for param in DIGEST_OUTPUT_PARAMS:
+      if param in output:
+        result &= param & "=" & output[param] & ","
+    break
+
+proc addOutput(ctx: DockerInvocation, output: string) =
+  ## Add an image exporter to the build.
+  ##
+  ## buildkit merges the --metadata-file response of every exporter into a
+  ## single flat json object in which the last exporter wins the duplicated
+  ## keys - image.name, containerimage.digest, containerimage.descriptor:
+  ## https://github.com/moby/buildkit/blob/master/solver/llbsolver/export.go
+  ## Exporter order follows --output order on the command line, so chalk's
+  ## exporter is inserted *before* any exporter the user asked for. That way
+  ## --metadata-file keeps describing the image the user is pushing, both for
+  ## the user's own build steps and for chalk's own post-build collection.
+  let args = @["--output", output]
+  for i, arg in ctx.newCmdLine:
+    if arg in ["-o", "--output"] or arg.startsWith("-o=") or arg.startsWith("--output="):
+      ctx.newCmdLine = ctx.newCmdLine[0 ..< i] & args & ctx.newCmdLine[i .. ^1]
+      return
+  ctx.newCmdLine &= args
+
 proc setPushTags(ctx: DockerInvocation, chalk: ChalkObj): seq[string] =
   if not ctx.foundPush:
     return
+  let digestParams = ctx.getDigestOutputParams()
   for image in chalk.iterPushTags():
     trace("docker: adding tag to the build - " & image)
     if len(ctx.foundTags) > 0 or not ctx.foundBuildx:
@@ -394,7 +438,7 @@ proc setPushTags(ctx: DockerInvocation, chalk: ChalkObj): seq[string] =
     else:
       # --output directly pushes to the registry. no need to add to result
       # as those images are pruned later on
-      ctx.newCmdLine &= @["--output", "type=image,push=true,name=" & image]
+      ctx.addOutput("type=image,push=true," & digestParams & "name=" & image)
     ctx.allTags.add(parseImage(image))
 
 proc launchDockerSubchalk(ctx:     DockerInvocation,
@@ -476,10 +520,21 @@ proc collectBeforeBuild*(chalk: ChalkObj, ctx: DockerInvocation) =
   dict.setIfNeeded("DOCKER_CHALK_ADDED_LABELS",        ctx.addedLabels)
   dict.setIfNeeded("DOCKER_FILE_CHALKED",              ctx.getUpdatedDockerFile())
 
+proc isPushByDigest(ctx: DockerInvocation): bool =
+  for output in ctx.foundOutputs:
+    if output.getOrDefault("push-by-digest") == "true":
+      return true
+  return false
+
 proc collectAfterBuild(ctx: DockerInvocation, chalksByPlatform: TableRef[DockerPlatform, ChalkObj]) =
   let
     iidFile               = ctx.iidFile
-    metadataNames         = parseImages(ctx.metadataFile{"image.name"}.getStr().split(","))
+    # for push-by-digest builds buildkit never creates a tag, so the tag-less
+    # names it reports back genuinely have no tag and we must not invent one
+    metadataNames         = parseImages(
+      ctx.metadataFile{"image.name"}.getStr().split(","),
+      defaultTag = if ctx.isPushByDigest(): "" else: "latest",
+    )
     metadataImage         = ctx.metadataFile{"containerimage.digest"}.getStr().extractDockerHash()
     metadataConfig        = ctx.metadataFile{"containerimage.config.digest"}.getStr().extractDockerHash()
     descriptor            = ctx.metadataFile{"containerimage.descriptor"}

--- a/src/docker/cmdline.nim
+++ b/src/docker/cmdline.nim
@@ -180,11 +180,18 @@ proc extractOutputs(ctx: DockerInvocation) =
             trace("docker: found --push equivalent with --output=" & i)
             ctx.foundPush = true
           of "image":
-            if kv.getOrDefault("push") == "true" or kv.getOrDefault("push-by-digest") == "true":
+            let pushByDigest = kv.getOrDefault("push-by-digest") == "true"
+            if kv.getOrDefault("push") == "true" or pushByDigest:
               trace("docker: found --push equivalent with --output=" & i)
               ctx.foundPush = true
             if kv.getOrDefault("name") != "":
-              ctx.allTags.add(parseImage(kv.getOrDefault("name")))
+              # push-by-digest publishes the manifest by digest only and
+              # buildkit never creates a tag for it, so a tag-less name
+              # genuinely has no tag and we must not invent :latest for it
+              ctx.allTags.add(parseImage(
+                kv.getOrDefault("name"),
+                defaultTag = if pushByDigest: "" else: "latest",
+              ))
           of "docker":
             trace("docker: found --load equivalent with --output=" & i)
             ctx.foundLoad = true

--- a/src/docker/collect.nim
+++ b/src/docker/collect.nim
@@ -315,12 +315,29 @@ proc collectImageFrom(chalk:    ChalkObj,
       for i in repo.tagImages:
         try:
           let
-            manifest = fetchListOrImageManifest(i, platforms = @[platform])
-            digest   = manifest.digest.extractDockerHash()
+            image       = fetchImageManifest(i, platform)
+            list        = image.list
+            imageDigest = image.digest.extractDockerHash()
+            digest      = (
+              if list != nil: list.digest.extractDockerHash()
+              else:           imageDigest
+            )
           if digest notin allDigests:
-            warn("docker: could not match docker image tag " & $i & " digest " & digest &
-                 " to a known list or image digest " & $allDigests)
-            continue
+            # The same image manifest can be wrapped in more than one index.
+            # A build with two image exporters is exactly that: buildkit
+            # attaches a provenance attestation per exporter and the
+            # attestation records the image name, so each copy of the image
+            # gets its own index digest over an identical image manifest.
+            # Match on the platform image manifest in that case, and record
+            # the index digest we just learned about.
+            if imageDigest notin allDigests:
+              warn("docker: could not match docker image tag " & $i & " digest " & digest &
+                   " to a known list or image digest " & $allDigests)
+              continue
+            discard repoListDigests.hasKeyOrPut(registry, newOrderedTable[string, seq[string]]())
+            discard repoListDigests[registry].hasKeyOrPut(i.name, @[])
+            if digest notin repoListDigests[registry][i.name]:
+              repoListDigests[registry][i.name].add(digest)
           discard repoTags.hasKeyOrPut(registry, newOrderedTable[string, OrderedTableRef[string, string]]())
           discard repoTags[registry].hasKeyOrPut(i.name, newOrderedTable[string, string]())
           repoTags[registry][i.name][i.tag] = digest

--- a/tests/functional/chalk/runner.py
+++ b/tests/functional/chalk/runner.py
@@ -707,6 +707,8 @@ class Chalk:
         labels: Optional[dict[str, str]] = None,
         annotations: Optional[dict[str, str]] = None,
         named_contexts: Optional[dict[str, Path | str]] = None,
+        outputs: Optional[list[str]] = None,
+        metadata_file: Optional[Path | str] = None,
         ignore_errors: bool = False,
     ) -> tuple[DockerDigests, ChalkProgram]:
         cwd = cwd or Path(os.getcwd())
@@ -735,6 +737,8 @@ class Chalk:
                 labels=labels,
                 annotations=annotations,
                 named_contexts=named_contexts,
+                outputs=outputs,
+                metadata_file=metadata_file,
             )
 
         with Docker.build_cmd(
@@ -756,6 +760,8 @@ class Chalk:
             labels=labels,
             annotations=annotations,
             named_contexts=named_contexts,
+            outputs=outputs,
+            metadata_file=metadata_file,
         ) as (params, stdin):
             digests, result = Docker.with_digests(
                 self.run(

--- a/tests/functional/data/configs/docker_push_by_digest.c4m
+++ b/tests/functional/data/configs/docker_push_by_digest.c4m
@@ -1,0 +1,14 @@
+# Configures a second push destination so that a tag-less push-by-digest
+# --output build ends up with two image exporters in one buildx invocation.
+# Both destinations live in the same insecure registry so that the test can
+# look either copy up by digest without authenticating.
+docker {
+  docker_registry local {
+    enabled: true
+    uri: env("IP") + ":5044"
+    docker_push scan {
+      repository: env("CHALK_MIRROR_REPO")
+      tags: ["scan"]
+    }
+  }
+}

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -436,6 +436,72 @@ def test_push_by_digest_metadata_file(
     assert "DOCKER_TAGS" not in build.mark
 
 
+@pytest.mark.parametrize("dockerfile", [DOCKERFILES / "valid" / "sample_1"])
+def test_push_by_digest_provenance_indexes(
+    chalk: Chalk,
+    dockerfile: Path,
+    random_hex: str,
+    tmp_data_dir: Path,
+):
+    """
+    Same two-exporter build, but with provenance attestations left on. buildkit
+    attaches a provenance manifest per exporter and the attestation records the
+    image name, so each copy of the image ends up under its own index digest
+    over an identical image manifest. chalk must still resolve its own copy
+    rather than dropping it for having an unrecognised index digest.
+    """
+    repo = f"{random_hex}/app"
+    mirror_repo = f"{random_hex}/mirror"
+    metadata_file = tmp_data_dir / "metadata.json"
+    _, build = chalk.docker_build(
+        dockerfile=dockerfile / "Dockerfile",
+        buildx=True,
+        load=False,
+        run_docker=False,
+        provenance=True,
+        outputs=[
+            ",".join(
+                [
+                    "type=image",
+                    f"name={REGISTRY}/{repo}",
+                    "push-by-digest=true",
+                    "name-canonical=true",
+                    "push=true",
+                ]
+            )
+        ],
+        metadata_file=metadata_file,
+        config=CONFIGS / "docker_push_by_digest.c4m",
+        env={"CHALK_MIRROR_REPO": mirror_repo},
+    )
+
+    metadata = json.loads(metadata_file.read_text())
+    assert metadata["image.name"] == f"{REGISTRY}/{repo}"
+
+    # the index digest in the metadata file belongs to the build's copy only;
+    # chalk's copy is wrapped in its own index
+    index = metadata["containerimage.digest"]
+    assert Docker.manifest_exists(f"{REGISTRY}/{repo}@{index}")
+    assert not Docker.manifest_exists(f"{REGISTRY}/{mirror_repo}@{index}")
+
+    # both copies must still be reported, each against its own index digest,
+    # and chalk's tag must survive rather than being dropped for not matching
+    # the build's index
+    assert build.mark.lifted.has(
+        _REPO_LIST_DIGESTS={
+            REGISTRY: {
+                repo: ANY,
+                mirror_repo: ANY,
+            },
+        },
+        _REPO_TAGS={
+            REGISTRY: {
+                mirror_repo: ANY,
+            },
+        },
+    )
+
+
 @pytest.mark.parametrize("buildkit", [True, False])
 @pytest.mark.parametrize(
     "base, test",

--- a/tests/functional/test_docker.py
+++ b/tests/functional/test_docker.py
@@ -373,6 +373,69 @@ def test_multiple_tags(
     assert cosign.verify(tags[0])
 
 
+@pytest.mark.parametrize("dockerfile", [DOCKERFILES / "valid" / "sample_1"])
+def test_push_by_digest_metadata_file(
+    chalk: Chalk,
+    dockerfile: Path,
+    random_hex: str,
+    tmp_data_dir: Path,
+):
+    """
+    A tag-less push-by-digest --output, combined with a chalk-configured
+    registry push, puts two image exporters in a single buildx invocation.
+    buildkit merges the response of every exporter into the one
+    --metadata-file, with the last exporter winning duplicated keys, so
+    chalk's exporter must not displace the one the build asked for.
+    """
+    repo = f"{random_hex}/app"
+    mirror_repo = f"{random_hex}/mirror"
+    metadata_file = tmp_data_dir / "metadata.json"
+    _, build = chalk.docker_build(
+        dockerfile=dockerfile / "Dockerfile",
+        buildx=True,
+        # the --output below is what pushes; chalk has to discover the push
+        # from there rather than from --push or -t
+        load=False,
+        run_docker=False,
+        outputs=[
+            ",".join(
+                [
+                    "type=image",
+                    f"name={REGISTRY}/{repo}",
+                    "push-by-digest=true",
+                    "name-canonical=true",
+                    "push=true",
+                    "compression=zstd",
+                    "force-compression=true",
+                    "oci-mediatypes=true",
+                ]
+            )
+        ],
+        metadata_file=metadata_file,
+        config=CONFIGS / "docker_push_by_digest.c4m",
+        env={"CHALK_MIRROR_REPO": mirror_repo},
+    )
+
+    metadata = json.loads(metadata_file.read_text())
+
+    # the metadata file must describe the image the build pushed, not chalk's
+    # copy of it, otherwise every downstream step which reads the digest out
+    # of the file targets an image that was never pushed to the build's repo
+    assert metadata["image.name"] == f"{REGISTRY}/{repo}"
+    assert mirror_repo not in metadata["image.name"]
+
+    digest = metadata["containerimage.digest"]
+    assert Docker.manifest_exists(f"{REGISTRY}/{repo}@{digest}")
+
+    # chalk mirrors the compression and media-type params of the build's
+    # exporter onto its own, so a single digest describes both copies
+    assert Docker.manifest_exists(f"{REGISTRY}/{mirror_repo}@{digest}")
+
+    # buildkit publishes the manifest by digest only and never creates a tag
+    # for it, so chalk must not report one
+    assert "DOCKER_TAGS" not in build.mark
+
+
 @pytest.mark.parametrize("buildkit", [True, False])
 @pytest.mark.parametrize(
     "base, test",

--- a/tests/functional/utils/docker.py
+++ b/tests/functional/utils/docker.py
@@ -114,6 +114,8 @@ class Docker:
         labels: Optional[dict[str, str]] = None,
         annotations: Optional[dict[str, str]] = None,
         named_contexts: Optional[dict[str, Path | str]] = None,
+        outputs: Optional[list[str]] = None,
+        metadata_file: Optional[Path | str] = None,
     ):
         stdin = b""
         tags = tags or []
@@ -125,6 +127,8 @@ class Docker:
             buildx = True
         cmd += ["build"]
         if buildx and not platforms and not provenance and not sbom and load:
+            if outputs:
+                raise ValueError("--output is incompatible with --load")
             cmd += ["--load"]
         for t in tags:
             cmd += ["-t", t]
@@ -163,6 +167,15 @@ class Docker:
                 raise ValueError("--build-context only works with buildx")
             for name, path in named_contexts.items():
                 cmd += [f"--build-context={name}={path}"]
+        if outputs:
+            if not buildx:
+                raise ValueError("--output only works with buildx")
+            for output in outputs:
+                cmd += [f"--output={output}"]
+        if metadata_file:
+            if not buildx:
+                raise ValueError("--metadata-file only works with buildx")
+            cmd += [f"--metadata-file={metadata_file}"]
         cmd += [str(context or ".")]
         yield cmd, stdin
 
@@ -190,6 +203,8 @@ class Docker:
         labels: Optional[dict[str, str]] = None,
         annotations: Optional[dict[str, str]] = None,
         named_contexts: Optional[dict[str, Path | str]] = None,
+        outputs: Optional[list[str]] = None,
+        metadata_file: Optional[Path | str] = None,
     ) -> tuple[DockerDigests, Program]:
         """
         run docker build with parameters
@@ -213,6 +228,8 @@ class Docker:
             labels=labels,
             annotations=annotations,
             named_contexts=named_contexts,
+            outputs=outputs,
+            metadata_file=metadata_file,
         ) as (params, stdin):
             return Docker.with_digests(
                 run(
@@ -575,6 +592,13 @@ class Docker:
         """Return True if a blob with the given digest exists in the registry."""
         ref = f"{registry}/{repo}@sha256:{digest}"
         return bool(run(["crane", "blob", "--insecure", ref], check=False, binary=True))
+
+    @staticmethod
+    def manifest_exists(ref: str) -> bool:
+        """Return True if the registry serves a manifest for the given ref."""
+        return bool(
+            run(["crane", "manifest", "--insecure", ref], check=False, binary=True)
+        )
 
     @staticmethod
     def is_overlayfs() -> bool:


### PR DESCRIPTION
Fix divergent container digests when running dual-push (chalkular mode) via buildx

<details>
<summary>claude summary of changes</summary>
## Description

When a build pushes via `docker buildx build --output type=image,...` with no `-t` tag, and chalk is also configured to push the image to a registry of its own, the invocation ends up with **two image exporters**. That single fact causes four separate defects, fixed here.

buildkit merges the response of every exporter into the single `--metadata-file`, with the last exporter winning duplicated keys ([`solver/llbsolver/export.go`](https://github.com/moby/buildkit/blob/master/solver/llbsolver/export.go), which still carries a `// TODO: separate these out`). chalk appended its exporter last, so `image.name`, `containerimage.digest`, `containerimage.config.digest` and `containerimage.descriptor` all came back describing chalk's copy rather than the image the build pushed. `--iidfile` is written from the same merged map (`getImageID(resp.ExporterResponse)` in buildx), so it was wrong too.

The user-visible effect: every downstream step that reads the digest out of `--metadata-file` targeted an image that was never pushed to its own repository. `docker tag`, `docker pull`, `aws ecr put-image` and any Helm/Argo reference built from that value fail with a not-found error, even though the build exits 0 and pushes correctly. chalk hit the same 404 itself while trying to record the image, which is why affected images showed up with no digest.

The fixes:

1. **`src/docker/build.nim` — new `addOutput`.** chalk's `--output` is now inserted *before* any exporter the build already had, instead of appended, so the build's own exporter wins the metadata merge. Exporter order follows `--output` order on the command line, so this is sufficient. Falls back to appending when the build has no `--output` of its own.
2. **`src/docker/build.nim` — new `DIGEST_OUTPUT_PARAMS` / `getDigestOutputParams`.** chalk's exporter now mirrors `compression`, `compression-level`, `force-compression` and `oci-mediatypes` from the build's image exporter. buildkit derives the manifest digest from the exported layer blobs, so without this the two copies got different digests and neither digest described both images.
3. **`src/docker/cmdline.nim` + `collectAfterBuild`** — stop inventing a `:latest` tag for `push-by-digest=true` builds. buildkit publishes the manifest by digest only and never creates a tag, so the tag-less name is now reported without one. This was being fabricated in two places: `extractOutputs`, and again from `image.name` in `collectAfterBuild`.
4. **`src/docker/collect.nim` — tolerate one image under several OCI indexes.** Even with fix 2, the two copies do not end up under the same *index*: buildkit attaches a provenance attestation per exporter and the attestation records the image name, so each copy gets its own index digest over an identical image manifest. `collectImageFrom` resolved a repository's tags with `fetchListOrImageManifest`, which returns the *index* when the image is under one, and then required that digest to be already known. chalk's own index digest never was, so the guard discarded the tag with a `could not match docker image tag` warning — dropping chalk's tag from `_REPO_TAGS` and its registry from `_REPO_LIST_DIGESTS`. Tags are now also matched on the platform image manifest, and the newly discovered index digest is recorded.

   This branch fires only when the index digest is *otherwise unknown*, so single-exporter builds keep the original code path. That is deliberate: `test_base_images` asserts `_REPO_LIST_DIGESTS` strictly, including `MISSING` expectations, and unconditionally recording resolved index digests would break it.

Note that giving chalk a separate metadata file for its own bookkeeping is not implementable — `buildx build` accepts exactly one `--metadata-file` and buildkit writes one merged response per invocation. Exporter ordering is what delivers the same outcome.

`_REPO_DIGESTS` was **not** affected by the index divergence, for what it is worth: `collectImageManifest` re-stamps every repository with the platform image manifest digest rather than the index digest, and fix 2 makes that manifest identical across both copies, so it already resolved in both.

## Testing

Two new functional tests in `tests/functional/test_docker.py`:

```
make tests args="-k push_by_digest"
```

- `test_push_by_digest_metadata_file` — covers fixes 1–3. Kept at `provenance=False`; with attestations on, its "one digest describes both copies" assertion is false by construction.
- `test_push_by_digest_provenance_indexes` — covers fix 4, with `provenance=True` so the two copies genuinely land under different indexes.

Supporting harness changes:

- `tests/functional/utils/docker.py` — `build_cmd`/`build` gain `outputs` and `metadata_file`; new `manifest_exists()` helper (uses `crane manifest`, since a manifest digest is not a blob digest and the existing `blob_exists` would 404 on it). `--output` now raises if combined with `--load`.
- `tests/functional/chalk/runner.py` — `docker_build` forwards both params.
- `tests/functional/data/configs/docker_push_by_digest.c4m` — new. Adds the second push destination. Deliberately not `docker_wrap.c4m`, whose mirror registry (`:5048`) requires auth and so cannot be queried by digest without credentials; both copies go to the same insecure registry instead.

All new parameters default to `None`, so existing callers are unaffected.

### Fixes 1–3

Asserted against the build's own repository and chalk's mirror:

| assertion | before | after |
| --- | --- | --- |
| `image.name` is the build's repo | fails — reports chalk's registry | passes |
| reported digest resolves in the build's repo | fails — HTTP 404 | passes — HTTP 200 |
| same digest resolves in chalk's repo | passes | passes |
| no `DOCKER_TAGS` recorded | fails — `[".../together-web:latest"]` | passes |

Three of the four fail on the unfixed binary. The third only has value in combination with the second: both can hold simultaneously only if the reported digest belongs to the build *and* is byte-identical to chalk's copy, which is what fix 2 buys.

### Fix 4

Measured on **both** storage drivers, since `collectAfterBuild` branches on `isDockerOverlayFS()` and CI defaults to the containerd snapshotter:

| | `_REPO_DIGESTS` | `_REPO_LIST_DIGESTS` | `_REPO_TAGS` |
| --- | --- | --- | --- |
| before (overlay2 / overlayfs) | both repos | build's repo only | **empty** |
| after (overlay2 / overlayfs) | both repos | **both repos** | **chalk's tag present** |

Every reported digest was checked against the registries: the shared image manifest returns 200 in both repositories; each index returns 200 only in its own repository and 404 in the other; the reported tag resolves to chalk's index. No `could not match docker image tag` warnings remain. A single-exporter `-t` build was re-run on both drivers as a regression check and is unchanged.

### Manual verification

Also verified outside the suite against two local registries, with binaries built from identical trees except the fix, using the reporter's exact command line (`push-by-digest=true,name-canonical=true,push=true,compression=zstd,force-compression=true,oci-mediatypes=true`):

- **before:** `image.name` = chalk's registry; its digest 404s in the build's repository. Layers in chalk's copy were `tar+gzip` (buildx default, ignoring the requested `compression=zstd`).
- **after:** `image.name` = the build's repository, digest resolves there, and both registries share one identical image manifest with `tar+zstd` layers.

Worth knowing when reproducing: `push-by-digest` is rejected on the default `docker` driver (*"push-by-digest is currently not implemented for docker driver"*), so this code path only runs under a `docker-container` or remote builder. The suite's `insecure_builder` is one.

</details>